### PR TITLE
Gradle: remove superfluous "ext" definitions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,11 +57,8 @@ sourceSets.test.resources.srcDirs = ['dungeon/assets/', 'game/test_resources', '
 sourceSets.test.java.srcDirs = ['game/test/', 'dungeon/test']
 sourceSets.main.antlr.srcDirs = ['dungeon/src/dsl/antlr']
 
-project.ext.mainClassName = 'starter.BasicStarter'
-project.ext.assetsDir = new File('game/assets')
-
 application {
-    mainClass = project.mainClassName
+    mainClass = 'starter.BasicStarter'
 }
 
 tasks.register('runRandom', JavaExec) {
@@ -105,35 +102,25 @@ generateGrammarSource {
 }
 
 jar {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
     manifest {
-        attributes 'Main-Class': project.mainClassName
+        attributes 'Main-Class': 'starter.BasicStarter'
     }
-
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
-
-    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*module-info.class'
 }
 
 tasks.register('starterJar', Jar) {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
     manifest {
         attributes 'Main-Class': 'starter/Starter'
     }
-
     archiveFileName = 'Starter.jar'
-
     from sourceSets.main.output
+}
 
+tasks.withType(Jar).configureEach {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*module-info.class'
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
-
-    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*module-info.class'
 }
 
 // MANUAL TESTS:

--- a/build.gradle
+++ b/build.gradle
@@ -57,11 +57,8 @@ sourceSets.test.resources.srcDirs = ['dungeon/assets/', 'game/test_resources', '
 sourceSets.test.java.srcDirs = ['game/test/', 'dungeon/test']
 sourceSets.main.antlr.srcDirs = ['dungeon/src/dsl/antlr']
 
-project.ext.mainClassName = 'starter.BasicStarter'
-project.ext.assetsDir = new File('game/assets')
-
 application {
-    mainClass = project.mainClassName
+    mainClass = 'starter.BasicStarter'
 }
 
 tasks.register('runRandom', JavaExec) {
@@ -81,7 +78,7 @@ tasks.register('blockly', JavaExec) {
 
 tasks.register('debug', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
-    mainClass = project.mainClassName
+    mainClass = 'starter.BasicStarter'
     debug = true
 }
 
@@ -108,7 +105,7 @@ jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
     manifest {
-        attributes 'Main-Class': project.mainClassName
+        attributes 'Main-Class': 'starter.BasicStarter'
     }
 
     from {

--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,11 @@ sourceSets.test.resources.srcDirs = ['dungeon/assets/', 'game/test_resources', '
 sourceSets.test.java.srcDirs = ['game/test/', 'dungeon/test']
 sourceSets.main.antlr.srcDirs = ['dungeon/src/dsl/antlr']
 
+project.ext.mainClassName = 'starter.BasicStarter'
+project.ext.assetsDir = new File('game/assets')
+
 application {
-    mainClass = 'starter.BasicStarter'
+    mainClass = project.mainClassName
 }
 
 tasks.register('runRandom', JavaExec) {
@@ -102,25 +105,35 @@ generateGrammarSource {
 }
 
 jar {
-    manifest {
-        attributes 'Main-Class': 'starter.BasicStarter'
-    }
-}
-
-tasks.register('starterJar', Jar) {
-    manifest {
-        attributes 'Main-Class': 'starter/Starter'
-    }
-    archiveFileName = 'Starter.jar'
-    from sourceSets.main.output
-}
-
-tasks.withType(Jar).configureEach {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*module-info.class'
+
+    manifest {
+        attributes 'Main-Class': project.mainClassName
+    }
+
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
+
+    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*module-info.class'
+}
+
+tasks.register('starterJar', Jar) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+    manifest {
+        attributes 'Main-Class': 'starter/Starter'
+    }
+
+    archiveFileName = 'Starter.jar'
+
+    from sourceSets.main.output
+
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+
+    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*module-info.class'
 }
 
 // MANUAL TESTS:


### PR DESCRIPTION
Remove ext vars

fixes #1330 

Tested on Windows with:

`run`, `start`, `debug`, `jar`, `starterJar`

without any special incidents