### PR TITLE
DSL: fix hard coded references to assets from Game subproject

### DIFF
--- a/dungeon/build.gradle
+++ b/dungeon/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
 
 sourceSets.main.java.srcDirs = ['src/', "$projectDir/build/generated-src/antlr/main/"]
-sourceSets.main.resources.srcDirs = ['assets/', {project(':game').sourceSets.main.resources.srcDirs}]
+sourceSets.main.resources.srcDirs = ['assets/']
 
 sourceSets.test.java.srcDirs = ['test/']
 sourceSets.test.resources.srcDirs = ['test_resources/']

--- a/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
+++ b/dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java
@@ -36,7 +36,7 @@ public class NativeScenarioBuilder {
     Entity questowner = new Entity("Questgeber");
     questowner.add(new PositionComponent());
     try {
-      questowner.add(new DrawComponent(new SimpleIPath("character/knight")));
+      questowner.add(new DrawComponent(new SimpleIPath("character/blue_knight")));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -69,7 +69,7 @@ public class NativeScenarioBuilder {
     Entity questowner = new Entity("Questgeber");
     questowner.add(new PositionComponent());
     try {
-      questowner.add(new DrawComponent(new SimpleIPath("character/knight")));
+      questowner.add(new DrawComponent(new SimpleIPath("character/blue_knight")));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
In `dungeon/src/dslinterop/nativescenariobuilder/NativeScenarioBuilder.java` hard-coded references to assets from the game subproject were present. 

This PR changes that: Instead of `character/knight` from the Game subproject use `character/blue_knight`, which is actually defined in the Dungeon subproject.

This also makes the reference `{project(':game').sourceSets.main.resources.srcDirs}` to the Game subproject assets in `build.gradle` of Dungeon superfluous and resolves IntelliJ's warning about duplicate content roots.



closes #1418