### PR TITLE
DSL-Loader: allow relative path to .dng file

### DIFF
--- a/dungeon/src/entrypoint/DSLFileLoader.java
+++ b/dungeon/src/entrypoint/DSLFileLoader.java
@@ -52,7 +52,7 @@ public class DSLFileLoader {
           Set<Path> jarPaths = findDSLFilesInJar(arg);
           foundPaths.addAll(jarPaths);
         } else if (fileName.endsWith(DSL_FILE_ENDING)) {
-          foundPaths.add(path);
+          foundPaths.add(path.toAbsolutePath());
         }
       }
     }


### PR DESCRIPTION
This should allow to start the dungeon using relative and/or absolute paths to a .dng file:

```
./gradlew :dungeon:runStarter --args=doc/dsl/examplescripts/example_scenario.dng  
./gradlew :dungeon:runStarter --args=/Users/foo/bar/pm-dungeon/dungeon/doc/dsl/examplescripts/example_scenario.dng
```

Note: Since `./gradlew :dungeon:runStarter` starts **inside** the `dungeon` subproject, we can't use `--args=dungeon/doc/dsl/examplescripts/example_scenario.dng`, but have to use a relative path inside the `dungeon` subproject like `--args=doc/dsl/examplescripts/example_scenario.dng`.
