### PR TITLE
Dungeon: do not start with empty task list

### DIFF
--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.text.DecimalFormat;
+import java.text.ParseException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -133,8 +134,11 @@ public class Starter {
       // no configuration, so let's abort here
       System.err.println("No .dng file selected. Exiting ...");
     } catch (IOException e) {
-      // could not read configuration, so let's abort here
-      System.err.println("Couldn't read specified .dng. Exiting ...");
+      // could not open configuration, so let's abort here
+      System.err.println("Couldn't open specified .dng. Exiting ...");
+    } catch (ParseException e) {
+      // could not find entry points in configuration, so let's abort here
+      System.err.println("Couldn't find tasks in .dng. Exiting ...");
     }
   }
 
@@ -209,11 +213,13 @@ public class Starter {
         });
   }
 
-  private static Set<DSLEntryPoint> processCLIArguments(String[] args) throws IOException {
+  private static Set<DSLEntryPoint> processCLIArguments(String[] args)
+      throws IOException, ParseException {
     Set<DSLEntryPoint> entryPoints = new HashSet<>();
     DSLEntryPointFinder finder = new DSLEntryPointFinder();
     DSLFileLoader.processArguments(args)
         .forEach(path -> finder.getEntryPoints(path).ifPresent(entryPoints::addAll));
+    if (entryPoints.isEmpty()) throw new ParseException("no entry points found", 0);
     return entryPoints;
   }
 


### PR DESCRIPTION
Aktuell kann der Starter mit und ohne Argumente gestartet werden. 

- Wenn ohne Argumente gestartet, versucht er dynamisch per JFileChooser eine Konfiguration zu erfragen und beendet das Spiel, wenn der User keine Datei auswählt.
- Wenn mit Argumenten gestartet, werden die Strings als Pfade aufgelöst und es wird versucht, diese Dateien zu laden.
  - Wenn es keine ".dng"-Dateien sind, werden sie stillschweigend ignoriert.
  - Wenn aus einer .dng-Datei keine Entrypoints geladen werden können, wird das stillschweigend ignoriert.

Das Problem ist aber, dass die Liste der Entrypoints u.U. leer ist und das Spiel damit startet und man sich fragt, was grad kaputt ist (siehe #1420). Es wäre besser, wenn das Spiel dann abgebrochen würde.

Dieser PR bricht das Spiel ab, wenn keinerlei Entrypoints geladen werden konnten.

Beispiel: `./gradlew clean :dungeon:runStarter --args=foo` führt zum Abbruch "Couldn't find tasks in .dng. Exiting ...". 


closes #1420 


---

Es gibt mehrere Stellen, wo hier eingegriffen werden könnte:
 - In `Starter#processCLIArguments` ist die Prüfung relativ frühzeitig, allerdings evtl. semantisch etwas merkwürdig: wir konnten ja die Datei ggf. öffnen, nur es kam halt zu einem leeren Ergebnis. Die `ParseException` passt da aber ganz gut - wir konnten die Argumente nicht parsen, es gibt keine EntryPoints.
 - Die Methode `Starter#taskSelectorOnSetup` wäre ebenfalls ein Kandidat, bei einem leeren Parameter `Set<DSLEntryPoint> entryPoints` eine Exception zu werfen. Das wäre ggf. sogar "natürlicher", weil die Methode quasi einen falsch gesetzten Parameter bekommen hat. Hier bräuchte man dann aber eine andere Exception, weil das Parsen der DNG-Datei ja bereits stattgefunden hat.
 - Die Methode `TaskSelector#selectTaskQuestion` wäre auch ein geeigneter Kandidat, da hier das GUI aufgebaut wird und bei leerem Parameter `Set<DSLEntryPoint> entryPoints` eigentlich abgebrochen werden sollte (und nicht stillschweigend ein leeres Menü aufgebaut und angezeigt werden sollte). Aber das ist "tief" in der DSL, wer weiss, welche (versteckten) Nebenwirkungen hier eine Änderung nach sich zieht.
