### PR TITLE
Dungeon Starter: Fix example.dng - use "blue_knight" from dungeon/assets instead of "knight" from game/assets

### DIFF
--- a/dungeon/assets/scripts/example.dng
+++ b/dungeon/assets/scripts/example.dng
@@ -296,7 +296,7 @@ entity_type chest_type {
 
 entity_type knight_type {
     draw_component {
-        path: "character/knight"
+        path: "character/blue_knight"
     },
     hitbox_component {},
     position_component{},

--- a/dungeon/assets/scripts/template.dng
+++ b/dungeon/assets/scripts/template.dng
@@ -42,7 +42,7 @@ entity_type chest_type {
 
 entity_type knight_type {
     draw_component {
-        path: "character/knight"
+        path: "character/blue_knight"
     },
     hitbox_component {},
     position_component{},

--- a/dungeon/doc/dsl/examplescripts/example_scenario.dng
+++ b/dungeon/doc/dsl/examplescripts/example_scenario.dng
@@ -40,7 +40,7 @@ entity_type chest_type {
 
 entity_type knight_type {
     draw_component {
-        path: "character/knight"
+        path: "character/blue_knight"
     },
     hitbox_component {},
     position_component{},

--- a/dungeon/doc/dsl/scenario_builder.md
+++ b/dungeon/doc/dsl/scenario_builder.md
@@ -155,7 +155,7 @@ Das folgende Snippet zeigt die Definition eines Entitätstyps, aus dem eine "Rit
 // Definition eines Entitätstyp
 entity_type ritter_typ {
     draw_component {
-        path: "character/knight"
+        path: "character/blue_knight"
     },
     position_component {},
     interaction_component{
@@ -379,7 +379,7 @@ entity_type knight_type {
         on_interacton: interact
     },
     draw_component {
-        path: "character/knight"
+        path: "character/blue_knight"
     },
     position_component{}
 }

--- a/dungeon/doc/how_to_play.md
+++ b/dungeon/doc/how_to_play.md
@@ -17,7 +17,7 @@ An Zauberkesseln ![Zauberkessel](../../game/assets/objects/cauldron/idle/cauldro
 
 ## Deine Quest
 
-Im Level sind verschiedene NPCs (Non-Playable Characters) ![Knight](../../game/assets/character/knight/idle_down/idle_down_knight_1.png) ![Blue Knight](../../dungeon/assets/character/blue_knight/idle_left/knight_m_idle_anim_mirrored_f0.png) verteilt. Wenn du dich ihnen näherst, kannst du mit der Taste "E" mit ihnen reden. Jeder von ihnen wird dir eine Aufgabe stellen, welche du beantworten musst.
+Im Level sind verschiedene NPCs (Non-Playable Characters), z.B. ![Blue Knight](../assets/character/blue_knight/idle_left/knight_m_idle_anim_mirrored_f0.png), verteilt. Wenn du dich ihnen näherst, kannst du mit der Taste "E" mit ihnen reden. Jeder von ihnen wird dir eine Aufgabe stellen, welche du beantworten musst.
 
 Manchmal musst du Items in eine Kiste legen, um deine Antworten abzugeben. Dafür kannst du dir in deinem Inventar die Itembeschreibung anschauen, lege dafür deinen Mauszeiger auf das Item im Inventar. Dort steht, welche Antwort das Item ist und zu welcher Aufgabe das Item gehört.
 Die Kisten, in die du die Items legen sollst, sind ebenfalls im HUD beschrieben. Gehe dafür einfach zu einer Kiste hin und drücke "E". Wenn es sich um eine Questkiste handelt, wird die Aufgabe im Namen der Kiste angezeigt.

--- a/dungeon/doc/how_to_play.md
+++ b/dungeon/doc/how_to_play.md
@@ -17,7 +17,7 @@ An Zauberkesseln ![Zauberkessel](../../game/assets/objects/cauldron/idle/cauldro
 
 ## Deine Quest
 
-Im Level sind verschiedene NPCs (Non-Playable Characters) ![Knight](../../game/assets/character/knight/idle_down/idle_down_knight_1.png) ![Blue Knight](../../game/assets/character/blue_knight/idle_left/knight_m_idle_anim_mirrored_f0.png) verteilt. Wenn du dich ihnen näherst, kannst du mit der Taste "E" mit ihnen reden. Jeder von ihnen wird dir eine Aufgabe stellen, welche du beantworten musst.
+Im Level sind verschiedene NPCs (Non-Playable Characters) ![Knight](../../game/assets/character/knight/idle_down/idle_down_knight_1.png) ![Blue Knight](../../dungeon/assets/character/blue_knight/idle_left/knight_m_idle_anim_mirrored_f0.png) verteilt. Wenn du dich ihnen näherst, kannst du mit der Taste "E" mit ihnen reden. Jeder von ihnen wird dir eine Aufgabe stellen, welche du beantworten musst.
 
 Manchmal musst du Items in eine Kiste legen, um deine Antworten abzugeben. Dafür kannst du dir in deinem Inventar die Itembeschreibung anschauen, lege dafür deinen Mauszeiger auf das Item im Inventar. Dort steht, welche Antwort das Item ist und zu welcher Aufgabe das Item gehört.
 Die Kisten, in die du die Items legen sollst, sind ebenfalls im HUD beschrieben. Gehe dafür einfach zu einer Kiste hin und drücke "E". Wenn es sich um eine Questkiste handelt, wird die Aufgabe im Namen der Kiste angezeigt.

--- a/dungeon/test_resources/task_test.dng
+++ b/dungeon/test_resources/task_test.dng
@@ -56,7 +56,7 @@ entity_type wizard_type {
 
 entity_type knight_type {
     draw_component {
-        path: "character/knight"
+        path: "character/blue_knight"
     },
     hitbox_component {},
     position_component{}


### PR DESCRIPTION
Use "blue_knight" (present in `Dungeon` subproject) instead of "knight" (only present in `Game` subproject for the time being):

`grep -Irl "character/knight" dungeon/ | xargs sed -i 's/character\/knight/character\/blue_knight/g'` and manual adjustments...
