### PR TITLE
Dungeon: fix handling of accessing resources

### DIFF
--- a/dungeon/src/contrib/crafting/Crafting.java
+++ b/dungeon/src/contrib/crafting/Crafting.java
@@ -3,17 +3,17 @@ package contrib.crafting;
 import com.badlogic.gdx.utils.JsonReader;
 import com.badlogic.gdx.utils.JsonValue;
 import contrib.item.Item;
-import core.Game;
 import core.utils.ResourceUtil;
 import core.utils.logging.CustomLogLevel;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -116,51 +116,6 @@ public final class Crafting {
    */
   private static Recipe parseRecipe(final InputStream stream) {
     return parseRecipe(stream, "");
-  }
-
-  /** Load recipes if the program was started from a jar file. */
-  private static void loadFromJar() {
-    try {
-      String path =
-          new File(Objects.requireNonNull(Game.class.getResource("")).getPath())
-              .getParent()
-              // for windows
-              .replaceAll("(!|file:\\\\)", "")
-              // for unix/macos
-              .replaceAll("(!|file:)", "");
-      JarFile jar = new JarFile(path);
-      Enumeration<JarEntry> entries = jar.entries();
-      while (entries.hasMoreElements()) {
-        JarEntry entry = entries.nextElement();
-        if (entry.getName().startsWith("recipes") && entry.getName().endsWith(".recipe")) {
-          LOGGER.info("Load recipe: " + entry.getName());
-          Recipe r =
-              parseRecipe(Game.class.getResourceAsStream("/" + entry.getName()), entry.getName());
-          if (r != null) Crafting.RECIPES.add(r);
-        }
-      }
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  /** Load recipes if the program was started from a folder. */
-  private static void loadFromFile() {
-    File folder =
-        new File(Objects.requireNonNull(Crafting.class.getResource("/recipes")).getPath());
-    File[] files = folder.listFiles();
-    if (files == null) {
-      return;
-    }
-    for (File file : files) {
-      if (file.getName().endsWith(".recipe")) {
-        LOGGER.info("Load recipe: " + file.getName());
-        Recipe r =
-            parseRecipe(
-                Crafting.class.getResourceAsStream("/recipes/" + file.getName()), file.getName());
-        if (r != null) Crafting.RECIPES.add(r);
-      }
-    }
   }
 
   /**

--- a/dungeon/src/contrib/crafting/Crafting.java
+++ b/dungeon/src/contrib/crafting/Crafting.java
@@ -4,14 +4,18 @@ import com.badlogic.gdx.utils.JsonReader;
 import com.badlogic.gdx.utils.JsonValue;
 import contrib.item.Item;
 import core.Game;
+import core.utils.ResourceUtil;
 import core.utils.logging.CustomLogLevel;
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * Handles the crafting system.
@@ -80,13 +84,38 @@ public final class Crafting {
    * <p>If the program is compiled to a jar file, recipes will be loaded from within the jar file.
    */
   public static void loadRecipes() {
-    if (Objects.requireNonNull(Crafting.class.getResource("/recipes"))
-        .toString()
-        .startsWith("jar:")) {
-      loadFromJar();
-    } else {
-      loadFromFile();
+    try {
+      // get Path for resource folder
+      Path recipesFolder = ResourceUtil.pathOf("recipes");
+
+      // traverse this directory and parse all recipes
+      if (Files.isDirectory(recipesFolder)) {
+        Set<Recipe> recipes =
+            Files.walk(recipesFolder)
+                .filter(Files::isRegularFile)
+                .filter(p -> p.toString().endsWith(".recipe"))
+                .map(ResourceUtil::newInputStream)
+                .flatMap(Optional::stream)
+                .map(Crafting::parseRecipe)
+                .collect(Collectors.toSet());
+        Crafting.RECIPES.addAll(recipes);
+      }
+    } catch (Exception e) {
+      LOGGER.log(CustomLogLevel.ERROR, "Error parsing recipes in 'recipes'");
     }
+  }
+
+  /**
+   * Parse a recipe from a file.
+   *
+   * <p>Temporary method to call original method with empty string (only needed for error message).
+   * Needs to be fixed.
+   *
+   * @param stream The stream to read from.
+   * @return The parsed recipe.
+   */
+  private static Recipe parseRecipe(final InputStream stream) {
+    return parseRecipe(stream, "");
   }
 
   /** Load recipes if the program was started from a jar file. */

--- a/game/src/core/utils/ResourceUtil.java
+++ b/game/src/core/utils/ResourceUtil.java
@@ -1,0 +1,93 @@
+package core.utils;
+
+import core.utils.logging.CustomLogLevel;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.*;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+public final class ResourceUtil {
+  private static final Logger LOGGER = Logger.getLogger(ResourceUtil.class.getSimpleName());
+
+  /**
+   * Open the resource given as parameter as Path.
+   *
+   * <p>Use a new FileSystem if inside JAR, or just a Path otherwise.
+   *
+   * <p>Throws an exception if no path could be found for the requested resource. Not intended for
+   * use in streams.
+   *
+   * @param resource in assets folder, can be a specific file or a folder
+   * @return The actual Path object for the resource.
+   * @throws URISyntaxException if URI for resource is malformed
+   * @throws IOException if the attempt to open a file system for the JAR is not successful
+   */
+  public static Path pathOf(String resource) throws URISyntaxException, IOException {
+    Path pathToResource;
+
+    /*
+     1. get URI of resource relative to current process (thread)
+
+     we can't use a given class here - the resource would be resolved relative to this class, i.e.
+     relative to a given (sub-) project:
+     - e.g. using Crafting.class.getResource(resource).toURI() would resolve relative to
+     subproject "dungeon"
+     - e.g. using DrawComponent.class.getResource(resource).toURI() would resolve relative to
+     subproject "game"
+    */
+    URI uri = Thread.currentThread().getContextClassLoader().getResource(resource).toURI();
+
+    /*
+      2. get Path to resource
+      - in local file system just use the URI
+      - in JAR we need to create a new FileSystem on top of the URI
+    */
+    if (uri.getScheme().equals("jar")) {
+      FileSystem fs;
+      try {
+        fs = FileSystems.getFileSystem(uri);
+      } catch (FileSystemNotFoundException fsnfe) {
+        fs = FileSystems.newFileSystem(uri, Collections.emptyMap());
+      }
+      pathToResource = fs.getPath(resource); // absolute to/in JAR, relative to resources root
+    } else {
+      pathToResource = Paths.get(uri); // absolute to local file system
+    }
+
+    return pathToResource;
+  }
+
+  /**
+   * Open an InputStream on Path p
+   *
+   * <p>Cases: (a) path is absolute: use the local file system, (b) path is relative: resolve in
+   * resources of current process
+   *
+   * <p>Intended for use in streams - returns an Optional.empty() in the event of an error, e.g. if
+   * no InputStream could be created for the Path.
+   *
+   * @param p Path to open
+   * @return new Optional<InputStream> for Path p
+   */
+  public static Optional<InputStream> newInputStream(Path p) {
+    InputStream stream = null;
+
+    if (p.isAbsolute()) {
+      // looks like we are operating from local file system (path is absolute)
+      try {
+        stream = Files.newInputStream(p);
+      } catch (IOException e) {
+        LOGGER.log(CustomLogLevel.ERROR, "Error opening path '" + p + "' as InputStream");
+      }
+    } else {
+      // path is relative, so try to load it via resources folder of the current process
+      stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(p.toString());
+    }
+
+    return Optional.ofNullable(stream);
+  }
+}


### PR DESCRIPTION
Dieser PR soll den Zugriff auf die Ressourcen verbessern. 

Die Ressourcen-Ordner werden über Gradle konfiguriert und sollen dann im Programm transparent genutzt werden. Dabei gibt es mehrere Fälle zu unterscheiden:

1. Welche Klasse in welchem Sub-Projekt versucht auf eine Ressource zuzugreifen? In welchem Kontext passiert das? 
2. Wird das Programm vom lokalen Filesystem (`./gradlew ...`) bzw. über die IDE gestartet? Wird das Programm aus dem Starter.jar heraus gestartet?
3. Müssen die Testfälle gesondert behandelt werden?

Betroffen sind dem Augenschein nach (vgl. Arbeiten in #1366) die Klassen [game/src/core/components/DrawComponent.java](https://github.com/Dungeon-CampusMinden/Dungeon/blob/master/game/src/core/components/DrawComponent.java), [`dungeon/src/contrib/crafting/Crafting.java`](https://github.com/Dungeon-CampusMinden/Dungeon/blob/master/dungeon/src/contrib/crafting/Crafting.java) und [`dungeon/test/dslToGame/TestDslFileLoader.java`](https://github.com/Dungeon-CampusMinden/Dungeon/blob/master/dungeon/test/dslToGame/TestDslFileLoader.java).

---

Frage (3) lässt sich am schnellsten beantworten: Für die Testfälle wird in der `build.gradle` ein eigener Ressourcen-Ordner definiert. Dieser steht dann in den Tests genauso zur Verfügung wie sonst der "normale" Asset-Ordner. Eine gesonderte Behandlung erscheint **nicht** notwendig, es muss lediglich dafür gesorgt werden, dass die für die Testfälle nötigen Assets auch im Test-Ressourcen-Ordner zur Verfügung stehen.

---

Frage (1): Üblicherweise würde man per `DrawComponent.class.getResource("character/knight")` auf Ressourcen der Klasse zugreifen. Dabei ergibt sich u.U. ein Problem, wenn diese im Sub-Projekt `Game` angesiedelte Klasse im Kontext des Sub-Projekts `Dungeon` genutzt wird (von dort aufgerufen wird). Deshalb wird hier stattdessen der Class-Loader des aktuellen Prozesses (Threads) genutzt: `Thread.currentThread().getContextClassLoader().getResource(resource)`, damit man immer auf die im jeweiligen Projektkontext gültigen Ressourcen zugreift.

---

Frage (2): Beim Start vom lokalen Filesystem kann man das Konstrukt `.class.getResource()` nutzen und bekommt die passende URL im Dateisystem zurück. Dabei handelt es sich um einen absoluten Pfad im lokalen Dateisystem zum Ressourcen-Ordner im Build-Ordner. Damit kann man dann mit den üblichen Methoden weiterarbeiten und die Datei öffnen und einlesen (`Paths.get()` und `Files.newInputStream()`). 

Wenn man dagegen aus dem JAR startet, funktioniert das nicht mehr, weil hier keine gültige URL gebildet wird: Es wird ein anderes Schema für die URL verwendet, ebenso ist der Dateiname noch mit dem Namen der JAR-Datei "geschmückt". Nach der Erkennung des Schemas bietet es sich hier an, auf der URL ein neues Filesystem zu erstellen (oder ein bereits existierendes zu nutzen) und die Ressource hierin aufzulösen. Das Pfad-Objekt hat einen absoluten Pfad innerhalb des JAR (innerhalb des neuen virtuellen Filesystems), gleichzeitig ist dieser Pfad aber relativ zum lokalen Ressourcen-Ordner. Zum eigentlichen Einlesen der Ressource wird dann `.getResourceAsStream()` mit dem Pfad-Objekt empfohlen (wobei auf dem neuen virtuellen Dateisystem eigentlich auch der normale Datei-Zugriff gehen sollte).

Um dem Problem mit den Leerzeichen und Umlauten im Pfad zu begegnen, wird statt `.getResource(resource)` die URI-Variante `.getResource(resource).toURI()` genutzt. Darin werden die Leerzeichen und Umlaute korrekt kodiert und stellen kein Problem mehr da.

--- 

Status:

- [ ] Hilfsklasse mit statischen Methoden für den uniformen Zugriff auf Ressourcen 
- [ ] [`dungeon/src/contrib/crafting/Crafting.java`](https://github.com/Dungeon-CampusMinden/Dungeon/blob/master/dungeon/src/contrib/crafting/Crafting.java): Anpassung des Einlesen von Recipes aus dem "recipes/"-Ordner
- [ ] [game/src/core/components/DrawComponent.java](https://github.com/Dungeon-CampusMinden/Dungeon/blob/master/game/src/core/components/DrawComponent.java): Einlesen und Bauen der Texturen
- [ ] [`dungeon/test/dslToGame/TestDslFileLoader.java`](https://github.com/Dungeon-CampusMinden/Dungeon/blob/master/dungeon/test/dslToGame/TestDslFileLoader.java): ???

---

closes #1361 
