### PR TITLE
Gradle: fix asset configuration

### DIFF
--- a/blockly/build.gradle
+++ b/blockly/build.gradle
@@ -12,7 +12,7 @@ sourceSets.main.java.srcDirs = ['src/']
 
 processResources {
     from new File(project(':game').projectDir,    '/assets')
-    from new File(project(':dungeon').projectDir, "/assets")
+    from new File(project(':dungeon').projectDir, '/assets')
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 

--- a/blockly/build.gradle
+++ b/blockly/build.gradle
@@ -10,6 +10,12 @@ dependencies {
 
 sourceSets.main.java.srcDirs = ['src/']
 
+processResources {
+    from new File(project(':game').projectDir,    "/assets")
+    from new File(project(':dungeon').projectDir, "/assets")
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 
 tasks.register('runBlockly', JavaExec) {
     mainClass = 'client.Client'

--- a/blockly/build.gradle
+++ b/blockly/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 sourceSets.main.java.srcDirs = ['src/']
 
 processResources {
-    from new File(project(':game').projectDir,    "/assets")
+    from new File(project(':game').projectDir,    '/assets')
     from new File(project(':dungeon').projectDir, "/assets")
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/dungeon/build.gradle
+++ b/dungeon/build.gradle
@@ -21,7 +21,7 @@ sourceSets.test.resources.srcDirs = ['test_resources/']
 sourceSets.main.antlr.srcDirs = ['src/dsl/antlr']
 
 processResources {
-    from new File(project(':game').projectDir, "/assets")
+    from new File(project(':game').projectDir, '/assets')
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 

--- a/dungeon/build.gradle
+++ b/dungeon/build.gradle
@@ -20,6 +20,11 @@ sourceSets.test.resources.srcDirs = ['test_resources/']
 
 sourceSets.main.antlr.srcDirs = ['src/dsl/antlr']
 
+processResources {
+    from new File(project(':game').projectDir, "/assets")
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 
 // store name of method parameter names in .class files (used to build
 // DSL-adapter types, which contain the names of the parameters as members)


### PR DESCRIPTION
@tgrothe Ich habe die in https://github.com/Dungeon-CampusMinden/Dungeon/issues/1426#issuecomment-1973527393 vorgeschlagenen Änderungen hier mal eingebaut:

> @tgrothe So, ich habe jetzt mal ein wenig für Dich recherchiert.
> 
> Wie eingangs erwähnt, werden die Ressourcen (Assets) beim Auflösen der Projektabhängigkeiten nicht mitgenommen. Also für `dungeon` fehlen die Assets aus `game`, obwohl dieses Subprojekt eine Dependency für `dungeon` ist. Für die .class-Files ist das kein Problem, weil Gradle hier das Jar-File aus `game` einfach in den Classpath für `dungeon` packt. Die Lösung besteht darin, die Assets aus `game` beim Bearbeiten von `dungeon` in den Build-Path von `dungeon` kopieren zu lassen: [processResources](https://docs.gradle.org/current/dsl/org.gradle.language.jvm.tasks.ProcessResources.html).
> 
> Schau Dir mal die Konfiguration vom Original-Spiel an: https://github.com/cagix/shattered-pixel-dungeon/blob/425c90135d7d666dd1f4715f165dca91a7fb449e/desktop/build.gradle#L9-L12 ... in der `build.gradle` im `desktop`-Subprojekt wird spezifiziert, dass bitte schön die Assets aus den Subprojekten `core` und `desktop` in den Build-Ordner kopiert werden sollen
> 
> ```
> processResources {
>     from new File(project(':core').projectDir, "/src/main/assets")
>     from new File(project(':desktop').projectDir,"/src/main/assets")
> }
> ```
> 
> Ich frage mich, ob das nicht bei uns auch reichen würde:
> 
> * Wenn man auf der Konsole oder aus der IDE startet, werden die abhängigen Assets mit kopiert. Damit muss man nicht sowohl im lokalen Filesystem als auch in einer JAR im Classpath nach Assets suchen - es reicht, das lokale Filesystem zu durchsuchen.
> * Wenn man das Starter.jar baut und von dort startet, sind die Assets sowieso drin. Hier muss man dann auch nur im JAR-File suchen.
> 
> (Analog auch für `blockly`.)


Du kannst jetzt sehr gut beobachten, dass beim Bauen von `dungeon` im Ordner `build/resources/` nicht nur die Assets von `dungeon` erscheinen, sondern auch die von `game`. Dito dann bei `blockly`, nur dass dort sowohl `game` als auch `dungeon` gezogen wird. Es ist auch dafür gesorgt, dass es bei Duplikaten keinen Fehler gibt.

Bitte ein Review plus lokalen Test.


fixes #1425 