### PR TITLE
Gradle: remove Ben-Manes plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
 
 plugins {
     id 'com.diffplug.spotless' version "${spotlessVersion}"
-    id 'com.github.ben-manes.versions' version "${benmanesVersion}"
 }
 
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,13 +1,12 @@
 ext {
     // -- PLUGINS
     spotlessVersion = '6.25.0'
-    benmanesVersion = '0.51.0'
 
     // -- DEPENDENCIES
     gdxVersion = '1.12.1'
     aiVersion = '1.8.2'
     junitVersion = '4.13.2'
-    mockitoVersion = '5.11.0'
+    mockitoVersion = '5.10.0'
     antlrVersion = '4.13.1'
     gsonVersion = '2.10.1'
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ ext {
     gdxVersion = '1.12.1'
     aiVersion = '1.8.2'
     junitVersion = '4.13.2'
-    mockitoVersion = '5.10.0'
+    mockitoVersion = '5.11.0'
     antlrVersion = '4.13.1'
     gsonVersion = '2.10.1'
 


### PR DESCRIPTION
Brauchen wir `com.github.ben-manes.versions` wirklich? Das Plugin sorgt dafür, dass man auch lokal nach Updates der Gradle-Plugins und/oder genutzten Dependencies suchen kann. Da das aber Dependabot auf der CI übernimmt, ist das Plugin eigentlich überflüssig.

Dieser PR soll das Plugin entfernen. Damit sind nur noch wirklich benötigte Plugins konfiguriert.

closes #1339