### PR TITLE
Dungeon: refactor LevelNode to use getFirst()

### DIFF
--- a/dungeon/src/contrib/level/generator/graphBased/levelGraph/LevelNode.java
+++ b/dungeon/src/contrib/level/generator/graphBased/levelGraph/LevelNode.java
@@ -72,8 +72,8 @@ public final class LevelNode {
     List<Direction> freeDirections = possibleConnectDirections(other);
     if (!freeDirections.isEmpty()) {
       Collections.shuffle(freeDirections);
-      if (other.connect(this, Direction.opposite(freeDirections.get(0))))
-        return connect(other, freeDirections.get(0));
+      if (other.connect(this, Direction.opposite(freeDirections.getFirst())))
+        return connect(other, freeDirections.getFirst());
     }
     return false;
   }


### PR DESCRIPTION
`contrib/level/generator/graphBased/levelGraph/LevelNode.java`: use `getFirst()`  (available since Java 21) to retrieve first element of a list/set instead of `get(0)` to improve readability. 
no changes in API, just minor refactoring.