### PR TITLE
Dungeon: refactor UIUtils to allow load-on-demand for libGDX elements

### DIFF
--- a/dungeon/src/contrib/hud/UIUtils.java
+++ b/dungeon/src/contrib/hud/UIUtils.java
@@ -22,7 +22,7 @@ public final class UIUtils {
   /**
    * Retrieve the default skin.
    *
-   * <p>Load the skin on demand (singleton with lazy initialization). This allows to write JUnit
+   * <p>Load the skin on demand (singleton with lazy initialisation). This allows to write JUnit
    * tests for this class w/o mocking libGDX.
    *
    * @return the default skin.

--- a/dungeon/src/contrib/hud/UIUtils.java
+++ b/dungeon/src/contrib/hud/UIUtils.java
@@ -22,7 +22,8 @@ public final class UIUtils {
   /**
    * Retrieve the default skin.
    *
-   * <p>Load the skin on demand (singleton with lazy initialisation). This allows to write JUnit tests for this class w/o mocking libGDX.
+   * <p>Load the skin on demand (singleton with lazy initialisation). This allows to write JUnit
+   * tests for this class w/o mocking libGDX.
    *
    * @return the default skin.
    */

--- a/dungeon/src/contrib/hud/UIUtils.java
+++ b/dungeon/src/contrib/hud/UIUtils.java
@@ -17,8 +17,15 @@ public final class UIUtils {
   /** The default UI-Skin. */
   private static final IPath SKIN_FOR_DIALOG = new SimpleIPath("skin/uiskin.json");
 
-  public static final Skin DEFAULT_SKIN =
-      new Skin(Gdx.files.internal(SKIN_FOR_DIALOG.pathString()));
+  private static Skin DEFAULT_SKIN = null;
+
+  /** Returns the default UI-Skin with lazy loading. */
+  public static Skin getDefaultSkin() {
+    if (DEFAULT_SKIN == null) {
+      DEFAULT_SKIN = new Skin(Gdx.files.internal(SKIN_FOR_DIALOG.pathString()));
+    }
+    return DEFAULT_SKIN;
+  }
 
   /**
    * Limits the length of the string to 40 characters, after which a line break occurs

--- a/dungeon/src/contrib/hud/UIUtils.java
+++ b/dungeon/src/contrib/hud/UIUtils.java
@@ -20,7 +20,9 @@ public final class UIUtils {
   private static Skin DEFAULT_SKIN;
 
   /**
-   * Retrieves the default skin (pattern used: singleton with lazy initialization).
+   * Retrieve the default skin.
+   *
+   * <p>Load the skin on demand (singleton with lazy initialisation). This allows to write JUnit tests for this class w/o mocking libGDX.
    *
    * @return the default skin.
    */

--- a/dungeon/src/contrib/hud/UIUtils.java
+++ b/dungeon/src/contrib/hud/UIUtils.java
@@ -22,7 +22,7 @@ public final class UIUtils {
   /**
    * Retrieve the default skin.
    *
-   * <p>Load the skin on demand (singleton with lazy initialisation). This allows to write JUnit
+   * <p>Load the skin on demand (singleton with lazy initialization). This allows to write JUnit
    * tests for this class w/o mocking libGDX.
    *
    * @return the default skin.

--- a/dungeon/src/contrib/hud/UIUtils.java
+++ b/dungeon/src/contrib/hud/UIUtils.java
@@ -17,10 +17,14 @@ public final class UIUtils {
   /** The default UI-Skin. */
   private static final IPath SKIN_FOR_DIALOG = new SimpleIPath("skin/uiskin.json");
 
-  private static Skin DEFAULT_SKIN = null;
+  private static Skin DEFAULT_SKIN;
 
-  /** Returns the default UI-Skin with lazy loading. */
-  public static Skin getDefaultSkin() {
+  /**
+   * Retrieves the default skin (pattern used: singleton with lazy initialization).
+   *
+   * @return the default skin.
+   */
+  public static Skin defaultSkin() {
     if (DEFAULT_SKIN == null) {
       DEFAULT_SKIN = new Skin(Gdx.files.internal(SKIN_FOR_DIALOG.pathString()));
     }

--- a/dungeon/src/contrib/hud/dialogs/OkDialog.java
+++ b/dungeon/src/contrib/hud/dialogs/OkDialog.java
@@ -1,5 +1,7 @@
 package contrib.hud.dialogs;
 
+import static contrib.hud.UIUtils.getDefaultSkin;
+
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import contrib.hud.UIUtils;
@@ -31,7 +33,7 @@ public final class OkDialog {
   public static Entity showOkDialog(
       final String text, final String title, final IVoidFunction onOk) {
 
-    Entity entity = showOkDialog(UIUtils.DEFAULT_SKIN, text, title, onOk);
+    Entity entity = showOkDialog(getDefaultSkin(), text, title, onOk);
     Game.add(entity);
     return entity;
   }

--- a/dungeon/src/contrib/hud/dialogs/OkDialog.java
+++ b/dungeon/src/contrib/hud/dialogs/OkDialog.java
@@ -1,6 +1,6 @@
 package contrib.hud.dialogs;
 
-import static contrib.hud.UIUtils.getDefaultSkin;
+import static contrib.hud.UIUtils.defaultSkin;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -33,7 +33,7 @@ public final class OkDialog {
   public static Entity showOkDialog(
       final String text, final String title, final IVoidFunction onOk) {
 
-    Entity entity = showOkDialog(getDefaultSkin(), text, title, onOk);
+    Entity entity = showOkDialog(defaultSkin(), text, title, onOk);
     Game.add(entity);
     return entity;
   }

--- a/dungeon/src/contrib/hud/dialogs/TextDialog.java
+++ b/dungeon/src/contrib/hud/dialogs/TextDialog.java
@@ -1,6 +1,6 @@
 package contrib.hud.dialogs;
 
-import static contrib.hud.UIUtils.getDefaultSkin;
+import static contrib.hud.UIUtils.defaultSkin;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -74,7 +74,7 @@ public final class TextDialog extends Dialog {
         () -> {
           Dialog textDialog =
               DialogFactory.createTextDialog(
-                  getDefaultSkin(),
+                  defaultSkin(),
                   content,
                   buttonText,
                   windowText,

--- a/dungeon/src/contrib/hud/dialogs/TextDialog.java
+++ b/dungeon/src/contrib/hud/dialogs/TextDialog.java
@@ -1,6 +1,6 @@
 package contrib.hud.dialogs;
 
-import static contrib.hud.UIUtils.DEFAULT_SKIN;
+import static contrib.hud.UIUtils.getDefaultSkin;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -74,7 +74,7 @@ public final class TextDialog extends Dialog {
         () -> {
           Dialog textDialog =
               DialogFactory.createTextDialog(
-                  DEFAULT_SKIN,
+                  getDefaultSkin(),
                   content,
                   buttonText,
                   windowText,

--- a/dungeon/src/contrib/hud/dialogs/YesNoDialog.java
+++ b/dungeon/src/contrib/hud/dialogs/YesNoDialog.java
@@ -1,6 +1,6 @@
 package contrib.hud.dialogs;
 
-import static contrib.hud.UIUtils.getDefaultSkin;
+import static contrib.hud.UIUtils.defaultSkin;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -35,7 +35,7 @@ public final class YesNoDialog {
   public static Entity showYesNoDialog(
       final String text, final String title, final IVoidFunction onYes, final IVoidFunction onNo) {
 
-    Entity entity = showYesNoDialog(getDefaultSkin(), text, title, onYes, onNo);
+    Entity entity = showYesNoDialog(defaultSkin(), text, title, onYes, onNo);
     Game.add(entity);
     return entity;
   }

--- a/dungeon/src/contrib/hud/dialogs/YesNoDialog.java
+++ b/dungeon/src/contrib/hud/dialogs/YesNoDialog.java
@@ -1,5 +1,7 @@
 package contrib.hud.dialogs;
 
+import static contrib.hud.UIUtils.getDefaultSkin;
+
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import contrib.hud.UIUtils;
@@ -33,7 +35,7 @@ public final class YesNoDialog {
   public static Entity showYesNoDialog(
       final String text, final String title, final IVoidFunction onYes, final IVoidFunction onNo) {
 
-    Entity entity = showYesNoDialog(UIUtils.DEFAULT_SKIN, text, title, onYes, onNo);
+    Entity entity = showYesNoDialog(getDefaultSkin(), text, title, onYes, onNo);
     Game.add(entity);
     return entity;
   }

--- a/dungeon/src/contrib/systems/HealthBarSystem.java
+++ b/dungeon/src/contrib/systems/HealthBarSystem.java
@@ -1,6 +1,6 @@
 package contrib.systems;
 
-import static contrib.hud.UIUtils.getDefaultSkin;
+import static contrib.hud.UIUtils.defaultSkin;
 
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -94,7 +94,7 @@ public final class HealthBarSystem extends System {
 
   private ProgressBar createNewHealthBar(PositionComponent pc) {
     ProgressBar progressBar =
-        new ProgressBar(MIN, MAX, STEP_SIZE, false, getDefaultSkin(), "healthbar");
+        new ProgressBar(MIN, MAX, STEP_SIZE, false, defaultSkin(), "healthbar");
     progressBar.setAnimateDuration(HEALTH_BAR_UPDATE_DURATION);
     progressBar.setSize(HEALTH_BAR_WIDTH, HEALTH_BAR_HEIGHT);
     progressBar.setVisible(true);

--- a/dungeon/src/contrib/systems/HealthBarSystem.java
+++ b/dungeon/src/contrib/systems/HealthBarSystem.java
@@ -1,6 +1,6 @@
 package contrib.systems;
 
-import static contrib.hud.UIUtils.DEFAULT_SKIN;
+import static contrib.hud.UIUtils.getDefaultSkin;
 
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -94,7 +94,7 @@ public final class HealthBarSystem extends System {
 
   private ProgressBar createNewHealthBar(PositionComponent pc) {
     ProgressBar progressBar =
-        new ProgressBar(MIN, MAX, STEP_SIZE, false, DEFAULT_SKIN, "healthbar");
+        new ProgressBar(MIN, MAX, STEP_SIZE, false, getDefaultSkin(), "healthbar");
     progressBar.setAnimateDuration(HEALTH_BAR_UPDATE_DURATION);
     progressBar.setSize(HEALTH_BAR_WIDTH, HEALTH_BAR_HEIGHT);
     progressBar.setVisible(true);

--- a/dungeon/src/task/game/hud/QuizUI.java
+++ b/dungeon/src/task/game/hud/QuizUI.java
@@ -1,6 +1,6 @@
 package task.game.hud;
 
-import static contrib.hud.UIUtils.getDefaultSkin;
+import static contrib.hud.UIUtils.defaultSkin;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -138,7 +138,7 @@ public class QuizUI {
         () -> {
           Dialog quizDialog =
               createQuizDialog(
-                  getDefaultSkin(),
+                  defaultSkin(),
                   question,
                   questionMsg,
                   buttonMsg,

--- a/dungeon/src/task/game/hud/QuizUI.java
+++ b/dungeon/src/task/game/hud/QuizUI.java
@@ -1,5 +1,7 @@
 package task.game.hud;
 
+import static contrib.hud.UIUtils.getDefaultSkin;
+
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import contrib.components.UIComponent;
@@ -136,7 +138,7 @@ public class QuizUI {
         () -> {
           Dialog quizDialog =
               createQuizDialog(
-                  UIUtils.DEFAULT_SKIN,
+                  getDefaultSkin(),
                   question,
                   questionMsg,
                   buttonMsg,


### PR DESCRIPTION
Die Klasse `contrib.hud.UIUtils` enthält mit dem Feld `DEFAULT_SKIN` libGDX-Abhängigkeiten, die direkt vom ClassLoader geladen/initialisiert werden. Dadurch kann diese Klasse bisher nicht in JUnit-Tests getestet werden.

Dieser Pull-Request führt ein Refactoring durch und führt das Singleton-Pattern in der Variante Lazy-Loading ein für das Feld `DEFAULT_SKIN`: In der API wird das Feld `public static final Skin DEFAULT_SKIN` durch die neue Hilfsmethode `public static Skin defaultSkin()` ersetzt, die beim ersten Aufruf das interne statische Feld initialisiert. 

Alle abhängigen Klassen werden ebenfalls umgestellt.
