### PR TITLE
Gradle: amend clean task(s) to also remove huge logging folders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ allprojects {
         standardInput = System.in
         ignoreExitValue true
     }
+
+    clean {
+        delete 'logs/'
+    }
 }
 
 


### PR DESCRIPTION
Der Logger ist per Default so konfiguriert, in **jedem Durchlauf** der Gameloop wirklich einfach **ALLE Logmeldungen** rauszuschreiben. Dadurch werden schnell mehrere Hunderte Megabyte an Daten erzeugt, die nie wieder aufgeräumt werden. 

Dieser PR ergänzt alle `clean`-Tasks in Gradle, damit per `./gradlew clean` (und auch `./gradlew :game:clean` bzw. `./gradlew :dungeon:clean`, dito für die anderen konfigurierten Sub-Projekte) auch die überflüssigen Logs gelöscht werden.

Es wird dabei der automatisch erzeugte Ordner `<subproj>/logs/` entfernt.

**Achtung**: Der Ordner ist im Code hard festgelegt - entsprechend gibt es nun eine Abhängigkeit zw. Code und Gradle-Konfiguration!

siehe #1466