### PR TITLE
Logger: change internal API to support the configuration of the log level during setup

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -15,6 +15,7 @@ import core.utils.components.path.SimpleIPath;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.logging.Level;
 import server.Server;
 
 public class Client {
@@ -22,7 +23,7 @@ public class Client {
     // toggle this to off, if you want to use the default level generator
     boolean useRoomBasedLevel = false;
 
-    Game.initBaseLogger();
+    Game.initBaseLogger(Level.WARNING);
     Debugger debugger = new Debugger();
     // start the game
     configGame();

--- a/dojo-dungeon/src/starter/DojoStarter.java
+++ b/dojo-dungeon/src/starter/DojoStarter.java
@@ -3,10 +3,11 @@ package starter;
 import core.Game;
 import core.utils.components.path.SimpleIPath;
 import java.io.IOException;
+import java.util.logging.Level;
 
 public class DojoStarter {
   public static void main(String[] args) throws IOException {
-    Game.initBaseLogger();
+    Game.initBaseLogger(Level.WARNING);
     Game.loadConfig(new SimpleIPath("dungeon_config.json"), KeyboardConfig.class);
     Game.disableAudio(true);
     Game.frameRate(30);

--- a/dungeon/src/starter/RandomDungeon.java
+++ b/dungeon/src/starter/RandomDungeon.java
@@ -18,7 +18,7 @@ public class RandomDungeon {
   private static final String BACKGROUND_MUSIC = "sounds/background.wav";
 
   public static void main(String[] args) throws IOException {
-    Game.initBaseLogger(Level.ALL);
+    Game.initBaseLogger(Level.WARNING);
     Debugger debugger = new Debugger();
     configGame();
     onSetup();

--- a/dungeon/src/starter/RandomDungeon.java
+++ b/dungeon/src/starter/RandomDungeon.java
@@ -11,13 +11,14 @@ import core.Game;
 import core.level.utils.LevelSize;
 import core.utils.components.path.SimpleIPath;
 import java.io.IOException;
+import java.util.logging.Level;
 
 public class RandomDungeon {
 
   private static final String BACKGROUND_MUSIC = "sounds/background.wav";
 
   public static void main(String[] args) throws IOException {
-    Game.initBaseLogger();
+    Game.initBaseLogger(Level.ALL);
     Debugger debugger = new Debugger();
     configGame();
     onSetup();

--- a/dungeon/src/starter/RoomBasedDungeon.java
+++ b/dungeon/src/starter/RoomBasedDungeon.java
@@ -21,7 +21,7 @@ public class RoomBasedDungeon {
   private static final String BACKGROUND_MUSIC = "sounds/background.wav";
 
   public static void main(String[] args) throws IOException {
-    Game.initBaseLogger(Level.ALL);
+    Game.initBaseLogger(Level.WARNING);
     Debugger debugger = new Debugger();
     // start the game
     configGame();

--- a/dungeon/src/starter/RoomBasedDungeon.java
+++ b/dungeon/src/starter/RoomBasedDungeon.java
@@ -15,12 +15,13 @@ import core.utils.components.path.SimpleIPath;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.logging.Level;
 
 public class RoomBasedDungeon {
   private static final String BACKGROUND_MUSIC = "sounds/background.wav";
 
   public static void main(String[] args) throws IOException {
-    Game.initBaseLogger();
+    Game.initBaseLogger(Level.ALL);
     Debugger debugger = new Debugger();
     // start the game
     configGame();

--- a/dungeon/src/starter/Starter.java
+++ b/dungeon/src/starter/Starter.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -247,7 +248,7 @@ public class Starter {
   }
 
   private static void configGame() throws IOException {
-    Game.initBaseLogger();
+    Game.initBaseLogger(Level.WARNING);
     Game.windowTitle("DSL Dungeon");
     Game.frameRate(30);
     Game.disableAudio(false);

--- a/dungeon/test/manual/YesNoDialogTest.java
+++ b/dungeon/test/manual/YesNoDialogTest.java
@@ -7,6 +7,7 @@ import contrib.hud.dialogs.YesNoDialog;
 import contrib.systems.HudSystem;
 import core.Game;
 import core.utils.IVoidFunction;
+import java.util.logging.Level;
 
 /**
  * This is a manual test for the YesNODialog.
@@ -20,7 +21,7 @@ import core.utils.IVoidFunction;
 public class YesNoDialogTest {
 
   public static void main(String[] args) {
-    Game.initBaseLogger();
+    Game.initBaseLogger(Level.ALL);
     Game.add(new HudSystem());
     Game.userOnFrame(
         () -> {

--- a/dungeon/test/manual/quizquestion/CallbackTest.java
+++ b/dungeon/test/manual/quizquestion/CallbackTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import java.util.logging.Level;
 import task.Task;
 import task.TaskContent;
 import task.game.components.TaskComponent;
@@ -55,7 +56,7 @@ public class CallbackTest {
   }
 
   public static void main(String[] args) throws IOException {
-    Game.initBaseLogger();
+    Game.initBaseLogger(Level.ALL);
     // start the game
 
     LevelSystem.levelSize(LevelSize.SMALL);

--- a/dungeon/test/manual/quizquestion/QuizQuestionUITest.java
+++ b/dungeon/test/manual/quizquestion/QuizQuestionUITest.java
@@ -9,6 +9,7 @@ import core.Game;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.logging.Level;
 import task.Task;
 import task.TaskContent;
 import task.game.hud.QuizUI;
@@ -29,7 +30,7 @@ import task.tasktype.quizquestion.SingleChoice;
 public class QuizQuestionUITest {
 
   public static void main(String[] args) {
-    Game.initBaseLogger();
+    Game.initBaseLogger(Level.ALL);
     Game.add(new HudSystem());
     Game.userOnFrame(
         () -> {

--- a/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
+++ b/dungeon/test/manual/taskgeneration/TaskGenerationTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.logging.Level;
 import task.Task;
 import task.TaskContent;
 import task.game.components.TaskComponent;
@@ -37,7 +38,7 @@ public class TaskGenerationTest {
   static DSLInterpreter interpreter = new DSLInterpreter();
 
   public static void main(String[] args) throws IOException {
-    Game.initBaseLogger();
+    Game.initBaseLogger(Level.ALL);
     LevelSystem.levelSize(LevelSize.MEDIUM);
     Game.loadConfig(
         new SimpleIPath("dungeon_config.json"),

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -193,7 +193,7 @@ public final class Game {
    * log messages into the log files. This is a concenience method.
    */
   public static void initBaseLogger() {
-    PreRunConfiguration.initBaseLogger(Level.ALL);
+    Game.initBaseLogger(Level.ALL);
   }
 
   /**

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -174,11 +175,25 @@ public final class Game {
   }
 
   /**
-   * Initializes the base logger. Removes the console handler and puts all log messages in the log
+   * Initialize the base logger.
+   *
+   * <p>Set a logging level, and remove the console handler, and write all log messages into the log
    * files.
+   *
+   * @param level Set logging level to {@code level}
+   */
+  public static void initBaseLogger(Level level) {
+    PreRunConfiguration.initBaseLogger(level);
+  }
+
+  /**
+   * Initialize the base logger.
+   *
+   * <p>Set the logging level to {@code Level.ALL}, and remove the console handler, and write all
+   * log messages into the log files. This is a concenience method.
    */
   public static void initBaseLogger() {
-    PreRunConfiguration.initBaseLogger();
+    PreRunConfiguration.initBaseLogger(Level.ALL);
   }
 
   /**

--- a/game/src/core/game/PreRunConfiguration.java
+++ b/game/src/core/game/PreRunConfiguration.java
@@ -7,6 +7,7 @@ import core.utils.components.path.SimpleIPath;
 import core.utils.logging.LoggerConfig;
 import java.io.IOException;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 
 /**
  * Offers API functions for the configuration of the game.
@@ -214,11 +215,15 @@ public final class PreRunConfiguration {
   }
 
   /**
-   * Initializes the base logger. Removes the console handler and puts all log messages in the log
+   * Initialize the base logger.
+   *
+   * <p>Set a logging level, and remove the console handler, and write all log messages into the log
    * files.
+   *
+   * @param level Set logging level to {@code level}
    */
-  public static void initBaseLogger() {
-    LoggerConfig.initBaseLogger();
+  public static void initBaseLogger(Level level) {
+    LoggerConfig.initBaseLogger(level);
   }
 
   /**

--- a/game/src/core/utils/logging/LoggerConfig.java
+++ b/game/src/core/utils/logging/LoggerConfig.java
@@ -14,7 +14,7 @@ import java.util.logging.SimpleFormatter;
 /**
  * Configuration for the Logger in the Dungeon.
  *
- * <p>Call {@link #initBaseLogger()} at the start of the program.
+ * <p>Call {@link #initBaseLogger} at the start of the program.
  *
  * <p>Will create a new Logfile and write the log messages into it. Disables the output of log
  * messages on the shell.
@@ -45,13 +45,21 @@ public final class LoggerConfig {
     }
   }
 
-  /** Creates a new base logger that records all occurring logs to a file. */
-  public static void initBaseLogger() {
+  /**
+   * Initialize the base logger.
+   *
+   * <p>Set a logging level, and remove the console handler, and write all log messages into the log
+   * files.
+   *
+   * @param level Set logging level to {@code level}
+   */
+  public static void initBaseLogger(Level level) {
     baseLogger = Logger.getLogger("");
-    baseLogger.setLevel(Level.ALL);
-    // remove console handler
+    baseLogger.setLevel(level);
+
     baseLogger.removeHandler(baseLogger.getHandlers()[0]);
     createCustomFileHandler();
+
     baseLogger.addHandler(customFileHandler);
   }
 }

--- a/game/src/core/utils/logging/LoggerConfig.java
+++ b/game/src/core/utils/logging/LoggerConfig.java
@@ -58,8 +58,8 @@ public final class LoggerConfig {
     baseLogger.setLevel(level);
 
     baseLogger.removeHandler(baseLogger.getHandlers()[0]);
-    createCustomFileHandler();
 
+    createCustomFileHandler();
     baseLogger.addHandler(customFileHandler);
   }
 }

--- a/game/src/starter/BasicStarter.java
+++ b/game/src/starter/BasicStarter.java
@@ -4,11 +4,12 @@ import core.Game;
 import core.configuration.KeyboardConfig;
 import core.utils.components.path.SimpleIPath;
 import java.io.IOException;
+import java.util.logging.Level;
 
 public class BasicStarter {
 
   public static void main(String[] args) throws IOException {
-    Game.initBaseLogger();
+    Game.initBaseLogger(Level.WARNING);
     Game.loadConfig(new SimpleIPath("dungeon_config.json"), KeyboardConfig.class);
     Game.disableAudio(true);
     Game.frameRate(30);


### PR DESCRIPTION
Der Logger ist per Default so konfiguriert, in **jedem Durchlauf** der Gameloop wirklich einfach **ALLE Logmeldungen** rauszuschreiben. Dadurch werden schnell mehrere Hunderte Megabyte an Daten erzeugt, was im Nicht-Debugging-Einsatz problematisch werden kann (und auch schlicht unsinnig ist) ...

Dieser PR ändert die API in Bezug auf die Logging-Initialisierung und erlaubt es, bei der Initialisierung des `baseLogger` das gewünschte Log-Level mitzugeben. 

Durch das hohe (und zunächst nicht direkt erklärliche) Maß an Indirektionen beim Setup des Loggers sind u.a. folgende Klassen betroffen:

1. Starter (diverse): In den Startern in den verschiedenen Sub-Projekten wird i.d.R. in der Methode `configGame()` die Initialisierung des Loggers per `Game.initBaseLogger()` vorgenommen. **Änderung**: Es wird ab jetzt ein konkretes Log-Level mitgegeben: 
    - Bei den Startern für das normale Spiel ist dies das `Level.WARNING`, um die wirklich wichtigen Meldungen nicht zu verpassen und die vielen Info-Meldungen zu unterdrücken, und 
    - bei den "manuellen Testfällen" von @malt-r ist es `Level.ALL` und entspricht damit dem bisherigen Verhalten.
3. `core.Game`: Die Methode `public static void initBaseLogger()` wird in der äußeren API von den "Kunden" genutzt (Starter). Um rückwärtskompatibel zu bleiben, wird diese Methode mit **einer neuen zusätzlichen Methode** `public static void initBaseLogger(Level level)` **überladen**, die das Setzen des Log-Levels durch den Kunden erlaubt. Die alte parameter-lose Methode delegiert mit `Level.ALL` an die neue Methode - dadurch **ergibt sich für die Kunden (die i.d.R. `Game` nutzen) keine Änderungen**.
4. `core.game.PreRunConfiguration`: Die Methode `public static void initBaseLogger()` wird um einen neuen Parameter `Level level` ergänzt. **Achtung**: Damit ist diese Änderung streng genommen _nicht rückwärtskompatibel._ Allerdings ist die Methode `PreRunConfiguration#initBaseLogger` nicht für die Kunden gedacht und wird lediglich in/von `Game#initBaseLogger` aufgerufen ("innere API").
5. `core.utils.logging.LoggerConfig`: Die Methode `public static void initBaseLogger()` wird um einen neuen Parameter `Level level` ergänzt. **Achtung**: Damit ist diese Änderung streng genommen _nicht rückwärtskompatibel_. Allerdings ist diese Methode `LoggerConfig#initBaseLogger` nicht für die Kunden gedacht und wird lediglich in/von `PreRunConfiguration#initBaseLogger` aufgerufen ("innere API").


siehe #1466 

---

Nachtrag: Die Logik und die Tiefe der Verschachtelung der Konfigurationsklassen erschließt sich nicht von sich aus. Hier muss dringend über ein Refactoring nachgedacht werden. (=> https://github.com/Dungeon-CampusMinden/Dungeon/discussions/1384)

