### PR TITLE
Gradle: configure the logging base folder via a system property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,17 +24,15 @@ allprojects {
         mavenCentral()
     }
 
-    ext.baseLogDir = 'logs/'
-
     tasks.withType(JavaExec).configureEach {
         dependsOn classes
         standardInput = System.in
         ignoreExitValue true
-        systemProperty 'BASELOGDIR', "$baseLogDir"
+        systemProperties System.properties
     }
 
     clean {
-        delete "$baseLogDir"
+        delete System.getProperty('BASELOGDIR')
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,17 @@ allprojects {
         mavenCentral()
     }
 
+    ext.baseLogDir = 'logs/'
+
     tasks.withType(JavaExec).configureEach {
         dependsOn classes
         standardInput = System.in
         ignoreExitValue true
+        systemProperty 'BASELOGDIR', "$baseLogDir"
     }
 
     clean {
-        delete 'logs/'
+        delete "$baseLogDir"
     }
 }
 

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -79,7 +79,7 @@ public abstract class Task {
     try {
       SimpleDateFormat dateFormat = new SimpleDateFormat("dd-MM-yyyy'T'HH-mm-ss");
       String timestamp = dateFormat.format(new Date());
-      String directoryPath = "./logs/solutions/";
+      String directoryPath = System.getProperty("BASELOGDIR", "logs/") + "solutions/";
       String filepath = directoryPath + timestamp + ".log";
       Files.createDirectories(Paths.get(directoryPath));
       FileHandler fileHandler = new FileHandler(filepath);

--- a/game/src/core/utils/logging/LoggerConfig.java
+++ b/game/src/core/utils/logging/LoggerConfig.java
@@ -26,7 +26,7 @@ public final class LoggerConfig {
   private static void createCustomFileHandler() {
     SimpleDateFormat dateFormat = new SimpleDateFormat("dd-MM-yyyy'T'HH-mm-ss");
     String timestamp = dateFormat.format(new Date());
-    String directoryPath = "./logs/systemlogs/";
+    String directoryPath = System.getProperty("BASELOGDIR", "logs/") + "systemlogs/";
     String filepath = directoryPath + timestamp + ".log";
     File newLogFile = new File(filepath);
     try {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+systemProp.BASELOGDIR=logs/


### PR DESCRIPTION
In #1467 wurde eine Abhängigkeit zwischen Code und Gradle-Konfiguration eingeführt: Der Name des Ordners, in dem die Log-Dateien abgelegt werden sollen, wurde bereits vor #1467 an zwei Stellen im Code fest definiert und in #1467 nun auch noch einmal in der `build.gradle`, um in den `clean`-Tasks die Log-Ordner löschen zu können.

Dieser PR hebt diese Einschränkung auf und definiert den Basis-Log-Ordner in `gradle.properties` und instrumentiert damit den Java-Code:

1. In `gradle.properties` wird eine System-Property `BASELOGDIR` für den Log-Ordner definiert. Diese wird im `clean`-Task benutzt, und zusätzlich werden alle System Properties den `Exec`-Tasks als solche mitgegeben (unschön, aber sonst kommen diese da nicht an). Damit wird auch die System-Property `BASELOGDIR` innerhalb der Java-Methoden sichtbar gemacht.
3. In `core.utils.logging.LoggerConfig` und `task.Task` wird der Basisordner für das Logging über die System Property `BASELOGDIR` abgefragt und um die gewünschten Unterordner ergänzt. Falls die System Property nicht gesetzt sein sollte, wird als Default der bisher genutzte String gesetzt.

Es werden keine Änderungen in der API und/oder im beobachtbaren Verhalten durch diesen PR eingeführt.

(follow-up to #1467)