### PR TITLE
Gradle: fix logging config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,11 @@ allprojects {
         dependsOn classes
         standardInput = System.in
         ignoreExitValue true
-        systemProperties System.properties
+        systemProperty 'BASELOGDIR', project.baseLogDir
     }
 
     clean {
-        delete System.getProperty('BASELOGDIR')
+        delete project.baseLogDir
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-systemProp.BASELOGDIR=logs/
+baseLogDir=logs/


### PR DESCRIPTION
In #1469 wurde die Konfiguration des Log-Ordner auf eine System Property umgestellt. Der konfigurierte Wert kommt korrekt in den Sub-Projekten an und wird auch innerhalb der Java-Methoden (beispielsweise https://github.com/Dungeon-CampusMinden/Dungeon/blob/69d2a1dc56923f43acb377da980cebc7642e38e7/game/src/core/utils/logging/LoggerConfig.java#L29) korrekt gelesen. 

**Aber es macht auf einmal einen Unterschied**, ob man 
- (a) `./gradlew dungeon:runStarter` (oder einen beliebigen anderen Starter) auf der Konsole aufruft, oder 
- (b) aus der IDE heraus anklickt. 
 
Im ersten Fall (Konsole) wird der Log-Ordner auf einmal im Top-Level-Ordner erzeugt (**falsch**!) und der Logger findet den Ordner anschließend nicht, da er anschließend im Subprojekt danach sucht!?! Beim Start aus der IDE oder dem Debugger passt das Verhalten dagegen.

Es scheint so zu sein, dass das Weiterreichen _aller_ System Properties in den Exec-Task-Einstellungen via `systemProperties System.properties` dieses abweichende Verhalten hervorruft. Der Grund ist aktuell unklar. Wenn man stattdessen die gewünschte Property _einzeln_ setzt (etwa mit `systemProperty 'BASELOGDIR', project.baseLogDir`), verhält sich der Build/Start wie erwartet.


Dieser PR stellt die Konfiguration deshalb um: In `gradle.properties` wird eine einfache "Gradle Property" statt einer "System Property" angelegt. Diese wird im `gradle.build` einzeln für die Java-Exec-Tasks gesetzt.


Folgende manuelle Tests wurden unter macOS durchgeführt:

1. Konsole: `./gradlew clean  game:runBasicStarter`
2. Konsole: `./gradlew clean  dungeon:runStarter`
3. IDE: Start von `game:runBasicStarter` und `dungeon:runStarter`, jeweils vorher `clean` ausgeführt
4. IDE: Start von `dungeon:runStarter` im Debug-Modus
5. Konsole: `./gradlew clean  dungeon:buildStarterJar  &&  mv dungeon/build/libs/Starter.jar .  &&  ./gradlew clean  &&  java -jar Starter.jar` (Bauen des Starter.jar, Löschen evtl. vorhandener Log-Ordner, Start per `java -jar`) 

In den Fällen (1) bis (4) wird die gesetzte Property in Gradle und in Java ausgewertet. Im Fall (5) ist diese nicht gesetzt, so dass der Java-Code auf den hart codierten Fallback zurückfällt.


fixes https://github.com/Dungeon-CampusMinden/dojo-dungeon/issues/21
