### PR TITLE
DSL: fix links in docs

### DIFF
--- a/dungeon/doc/readme.md
+++ b/dungeon/doc/readme.md
@@ -170,7 +170,7 @@ verwendet. Die definierte Abhängigkeit lässt sich wie folgt lesen: `Aufgabe1` 
 `Aufgabe2` und `Aufgabe2` bildet eine Sequenz mit `Aufgabe3`. Hierdurch muss `Aufgabe1` zuerst bearbeitet werden,
 danach muss `Aufgabe2` bearbeitet werden und abschließend `Aufgabe3`. Ob eine Aufgabe richtig oder falsch bearbeitet
 wird spielt hierbei keine Rolle. Für eine Auflistung und Erklärung aller Abhängigkeitstypen siehe
-[TODO: Dokumentation zu Abhängigkeitstypen](https://github.com/Dungeon-CampusMinden/Dungeon/issues/1215).
+[Dokumentation Aufgabenabhängigkeiten](control_mechanisms/petri_nets.md).
 
 Das oben vorgestellte Skript kann wie unter [Starten des Dungeon Systems](#starten-des-dungeon-systems) beschrieben
 gestartet werden.


### PR DESCRIPTION
In der [Readme.md](https://github.com/Dungeon-CampusMinden/Dungeon/blob/master/dungeon/doc/readme.md) wird noch auf das mitlerweile geschlossene [Issue 1215](https://github.com/Dungeon-CampusMinden/Dungeon/issues/1215) verlinkt. Aus dem Kommentar 'Fixes https://github.com/Dungeon-CampusMinden/Dungeon/issues/1215 (als Link auf die Petri-Netz-Doku)' am zugehörigen [Pull Request 1300](https://github.com/Dungeon-CampusMinden/Dungeon/pull/1300) habe ich den gemeinten Link geschlussfolgert. 