### PR TITLE
Dojo: DojoCompiler: Ignore cases in string comparison

### DIFF
--- a/dojo-dungeon/src/dojo/compiler/DojoCompiler.java
+++ b/dojo-dungeon/src/dojo/compiler/DojoCompiler.java
@@ -264,23 +264,25 @@ public class DojoCompiler {
 
   private boolean stage_4_2_checkFirstOutput() {
     try {
-      if (!"NaN".equals(method1.invoke(null, (String) null))) {
+      if (!"nan".equalsIgnoreCase((String) method1.invoke(null, (String) null))) {
         messages.add("output1 wrong");
         return false;
       }
-      if (!"NaN".equals(method1.invoke(null, "coffee time"))) {
+      if (!"nan".equalsIgnoreCase((String) method1.invoke(null, "coffee time"))) {
         messages.add("output1 wrong");
         return false;
       }
-      if (!"NaN".equals(method1.invoke(null, ""))) {
+      if (!"nan".equalsIgnoreCase((String) method1.invoke(null, ""))) {
         messages.add("output1 wrong");
         return false;
       }
-      if (!"Integer overflow".equals(method1.invoke(null, String.valueOf(Integer.MAX_VALUE - 1)))) {
+      if (!"integer overflow"
+          .equalsIgnoreCase((String) method1.invoke(null, String.valueOf(Integer.MAX_VALUE - 1)))) {
         messages.add("output1 wrong");
         return false;
       }
-      if (!"Integer overflow".equals(method1.invoke(null, String.valueOf(Integer.MAX_VALUE)))) {
+      if (!"integer overflow"
+          .equalsIgnoreCase((String) method1.invoke(null, String.valueOf(Integer.MAX_VALUE)))) {
         messages.add("output1 wrong");
         return false;
       }

--- a/dojo-dungeon/todo-assets/Fehler_Syntax/FehlerhafteKlasse.java
+++ b/dojo-dungeon/todo-assets/Fehler_Syntax/FehlerhafteKlasse.java
@@ -10,9 +10,9 @@ public class FehlerhafteKlasse {
    * Diese Methode soll 2 zum Zahlenwert, der im Parameter {@code in} als String übergeben wird,
    * addieren und das Ergebnis wieder in einen String umwandeln und zurückgeben.
    *
-   * <p>Wenn {@code in} {@code null} oder keine Zahl ist, soll "nan" zurückgegeben werden.
+   * <p>Wenn {@code in} {@code null} oder keine Zahl ist, soll "NaN" zurückgegeben werden.
    *
-   * <p>Wenn die Operation einen Integer-Overflow verursachen würde, soll "integer overflow"
+   * <p>Wenn die Operation einen Integer-Overflow verursachen würde, soll "Integer Overflow"
    * zurückgegeben werden.
    *
    * @param in Eingabe, zu der 2 addiert werden soll

--- a/dojo-dungeon/todo-assets/Fehler_Syntax/FehlerhafteKlasse.java
+++ b/dojo-dungeon/todo-assets/Fehler_Syntax/FehlerhafteKlasse.java
@@ -10,9 +10,9 @@ public class FehlerhafteKlasse {
    * Diese Methode soll 2 zum Zahlenwert, der im Parameter {@code in} als String übergeben wird,
    * addieren und das Ergebnis wieder in einen String umwandeln und zurückgeben.
    *
-   * <p>Wenn {@code in} {@code null} oder keine Zahl ist, soll "NaN" zurückgegeben werden.
+   * <p>Wenn {@code in} {@code null} oder keine Zahl ist, soll "nan" zurückgegeben werden.
    *
-   * <p>Wenn die Operation einen Integer-Overflow verursachen würde, soll "Integer overflow"
+   * <p>Wenn die Operation einen Integer-Overflow verursachen würde, soll "integer overflow"
    * zurückgegeben werden.
    *
    * @param in Eingabe, zu der 2 addiert werden soll


### PR DESCRIPTION
Beim Vergleich der erwarteten Antwort und der tatsächlichen Antwort (String) soll die Gross-/Klein-Schreibung keine Rolle spielen.

Dieser PR ändert den Vergleich für den Test von `FehlerhafteKlasse` entsprechend auf `equalsIgnoreCase`.


Follows from #1503 

closes #1501 