### PR TITLE
Gradle: cleanup dojo configuration

### DIFF
--- a/dojo-dungeon/build.gradle
+++ b/dojo-dungeon/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 
 dependencies {
-    api project(':dungeon')
+    implementation project(':dungeon')
 }
 
 

--- a/dojo-dungeon/build.gradle
+++ b/dojo-dungeon/build.gradle
@@ -1,8 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
-
 dependencies {
     implementation project(':dungeon')
 }

--- a/dojo-dungeon/build.gradle
+++ b/dojo-dungeon/build.gradle
@@ -6,9 +6,6 @@ dependencies {
 sourceSets.main.java.srcDirs = ['src/']
 sourceSets.main.resources.srcDirs = ['assets/']
 
-sourceSets.test.java.srcDirs = ['test/']
-sourceSets.test.resources.srcDirs = ['test_resources/']
-
 processResources {
     from new File(project(':game').projectDir, '/assets')
     from new File(project(':dungeon').projectDir, '/assets')

--- a/dojo-dungeon/build.gradle
+++ b/dojo-dungeon/build.gradle
@@ -13,7 +13,6 @@ processResources {
 }
 
 
-// start the dungeon (different configurations)
 tasks.register('runDojoStarter', JavaExec) {
     mainClass = 'starter.DojoStarter'
     classpath = sourceSets.main.runtimeClasspath

--- a/dojo-dungeon/build.gradle
+++ b/dojo-dungeon/build.gradle
@@ -13,7 +13,7 @@ processResources {
 }
 
 
-tasks.register('runDojoStarter', JavaExec) {
+tasks.register('runDojoDungeon', JavaExec) {
     mainClass = 'starter.DojoStarter'
     classpath = sourceSets.main.runtimeClasspath
 }


### PR DESCRIPTION
Räume die Konfiguration des Dojo-Dungeons ein wenig auf:

- Stufe die Dependency für das Sub-Projekt "dungeon" von `api` auf `implementation` herunter. Wir brauchen hier das Sub-Projekt "dungeon", aber wir brauchen es nicht transitiv bzw. wir wollen keine API o.ä. anbieten. 
- Entferne das Plugin "java-library". Es wurde nur für die Dependency-Settings `api` gebraucht. Da wir das nicht mehr haben/brauchen, kann das Plugin entfernt werden (es wurde "java" global gesetzt, das reicht).
- Entferne die Settings für Test-Sourcen und -Assets. Wir haben keine Tests hier.
- Benenne Start-Task in `runDojoDungeon` um, um konsistent zu den anderen Sub-Projekten zu werden
- Entferne den überflüssigen Kommentar. Entweder überall Kommentare oder nirgendwo. 