### PR TITLE
Gradle: cleanup blockly configuration

### DIFF
--- a/blockly/build.gradle
+++ b/blockly/build.gradle
@@ -1,17 +1,13 @@
-plugins {
-    id 'java'
-}
-
-
 dependencies {
-    implementation project(":dungeon")
+    implementation project(':dungeon')
 }
 
 
 sourceSets.main.java.srcDirs = ['src/']
+sourceSets.main.resources.srcDirs = ['assets/']
 
 processResources {
-    from new File(project(':game').projectDir,    '/assets')
+    from new File(project(':game').projectDir, '/assets')
     from new File(project(':dungeon').projectDir, '/assets')
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }


### PR DESCRIPTION
Räume die Konfiguration des Blockly-Subprojekts ein wenig auf:

- Entferne das Plugin "java". Dieses wird global definiert, kein Bedarf für eine Wiederholung hier.
- Füge eine Konfiguration für die Assets ein. Wir haben hier zwar keine eigenen Assets, nutzen aber die aus `game` und `dungeon`. Interessanterweise scheint es auch ohne diesen expliziten Pfad zu funktionieren, aber nun ist es explizit.
- Passe die Schreibweisen an die anderen Gradle-Konfigurationsfiles an.