### PR TITLE
Gradle: remove Gson config (not needed anymore)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,7 +8,6 @@ ext {
     junitVersion = '4.13.2'
     mockitoVersion = '5.11.0'
     antlrVersion = '4.13.1'
-    gsonVersion = '2.10.1'
 
     supportDependencies = [
         // LibGDX
@@ -19,9 +18,6 @@ ext {
         gdx_platform              : "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop",
         gdx_freetype_platform     : "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop",
         gdx_ai                    : "com.badlogicgames.gdx:gdx-ai:$aiVersion",
-
-        // Gson
-        gson                      : "com.google.code.gson:gson:$gsonVersion",
 
         // JUnit 4 and Mockito for testing
         junit                     : "junit:junit:$junitVersion",

--- a/game/build.gradle
+++ b/game/build.gradle
@@ -13,9 +13,6 @@ dependencies {
     api supportDependencies.gdx_freetype_platform
     api supportDependencies.gdx_ai
 
-    // https://mvnrepository.com/artifact/com.google.code.gson/gson
-    api supportDependencies.gson
-
     // JUnit 4 and Mockito for testing
     testImplementation supportDependencies.junit
     testImplementation supportDependencies.mockito_core


### PR DESCRIPTION
Wir haben immer noch die Abhängigkeit zu Gson in unserer Konfiguration und exportieren die sogar als "API". Dabei nutzen wir das scheinbar gar nicht (mehr) - ein grep nach "gson" und/oder "Gson" findet nichts und alle Starter/Builder/Tests laufen auch ohne Gson. 

Dieser PR entfernt Gson aus der Build-Konfiguration.