### PR TITLE
Gradle: cleanup gradle for game and dungeon

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -12,12 +12,12 @@ ext {
     supportDependencies = [
         // LibGDX
         gdx                       : "com.badlogicgames.gdx:gdx:$gdxVersion",
-        gdx_freetype              : "com.badlogicgames.gdx:gdx-freetype:$gdxVersion",
+        gdx_platform              : "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop",
         gdx_backend_lwjgl3        : "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion",
         gdx_lwjgl3_glfw_awt_macos : "com.badlogicgames.gdx:gdx-lwjgl3-glfw-awt-macos:$gdxVersion",
-        gdx_platform              : "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop",
-        gdx_freetype_platform     : "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop",
         gdx_ai                    : "com.badlogicgames.gdx:gdx-ai:$aiVersion",
+        gdx_freetype              : "com.badlogicgames.gdx:gdx-freetype:$gdxVersion",
+        gdx_freetype_platform     : "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop",
 
         // JUnit 4 and Mockito for testing
         junit                     : "junit:junit:$junitVersion",

--- a/dungeon/build.gradle
+++ b/dungeon/build.gradle
@@ -7,6 +7,15 @@ plugins {
 dependencies {
     api project(':game')
 
+    // LibGDX: expose this API to users because of core.level.elements.ILevel
+    api supportDependencies.gdx
+    api supportDependencies.gdx_platform
+    api supportDependencies.gdx_backend_lwjgl3
+    api supportDependencies.gdx_lwjgl3_glfw_awt_macos
+    api supportDependencies.gdx_ai
+    api supportDependencies.gdx_freetype
+    api supportDependencies.gdx_freetype_platform
+
     // ANTLR version 4 for DSL Grammar
     antlr supportDependencies.antlr
 
@@ -61,9 +70,10 @@ tasks.register('runRoomBasedDungeon', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
 }
 
+
 // create our Starter.jar
 tasks.register('buildStarterJar', Jar) {
-    dependsOn ':game:jar'
+    dependsOn ':game:build'
 
     manifest {
         attributes 'Main-Class': 'starter.Starter'
@@ -79,6 +89,7 @@ tasks.register('buildStarterJar', Jar) {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*module-info.class'
 }
+
 
 // some manual tests (wtf? this should be real tests! to be removed.)
 tasks.register('runCallbackTest', JavaExec) {

--- a/game/build.gradle
+++ b/game/build.gradle
@@ -4,13 +4,11 @@ plugins {
 
 
 dependencies {
-    // LibGDX
+    // LibGDX: expose this API to users because of core.level.elements.ILevel
     api supportDependencies.gdx
-    api supportDependencies.gdx_freetype
+    api supportDependencies.gdx_platform
     api supportDependencies.gdx_backend_lwjgl3
     api supportDependencies.gdx_lwjgl3_glfw_awt_macos
-    api supportDependencies.gdx_platform
-    api supportDependencies.gdx_freetype_platform
     api supportDependencies.gdx_ai
 
     // JUnit 4 and Mockito for testing


### PR DESCRIPTION
Game führt Dependencies für libGDX ein, die transitiv auch von Dungeon genutzt werden. Dieser PR soll die Sub-Projekte stärker entkoppeln, und es soll deutlicher ersichtlich werden, was im jeweiligen Sub-Projekt wirklich gebraucht wird. 

Zugleich sollte die von uns in Game und/oder Dungeon genutzte libGDX-API nicht für die Kunden von Game/Dungeon weitergegeben (_exposed_) werden - wenn jemand Dungeon als Basis nutzt und zusätzlich gern noch etwas aus libGDX in der eigenen Implementierung nutzen möchte, dann sollte er/sie/es auch selbst in der eigenen Konfiguration deklarieren (und nicht einfach stillschweigend transitiv von uns mitnutzen).

1. Führe die in Dungeon benötigten libGDX-Dependencies in der build.gradle vom Dungeon-Subprojekt explizit ein.
2. Entferne alle nicht benötigten libGDX-Depenencies aus den build.gradle im Game- und im Dungeon-Subprojekt.
3. ~~Verberge die libGDX-API, d.h. kein Exposure für die Kunden von `game` und/oder `dungeon`.~~  => das geht leider nicht, weil `core.level.elements.ILevel` direkt von einer libGDX-Klasse/-Interface erbt => #1510

