### PR TITLE
Dojo: ändere Textur des Zauberers in Level 2 (Pattern-Abfrage)

### DIFF
--- a/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
+++ b/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
@@ -76,7 +76,7 @@ public class Fragen_Pattern extends Room {
     // add boss
     zauberer = new Entity("Zauberer von Patternson");
     zauberer.add(new PositionComponent());
-    zauberer.add(new DrawComponent(new SimpleIPath("character/wizard")));
+    zauberer.add(new DrawComponent(new SimpleIPath("character/monster/orc_shaman")));
 
     setNextTask();
 

--- a/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
+++ b/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
@@ -27,7 +27,7 @@ import task.tasktype.quizquestion.FreeText;
  * Informationen für den Spieler über diesen Raum:
  *
  * <p>In diesem Raum müssen verschiedene Design Patterns anhand eines UML-Klassendiagramms erkannt
- * werden. Die erkannten Design Patterns müssen dann dem Zauberer mitgeteilt werden.
+ * werden. Die erkannten Design Patterns müssen dann dem Schamanen mitgeteilt werden.
  */
 public class Fragen_Pattern extends Room {
   private final String FILENAME = "dojo-dungeon/todo-assets/Fragen_Pattern/UML_Klassendiagramm";
@@ -74,7 +74,7 @@ public class Fragen_Pattern extends Room {
 
   private Entity questBoss() throws IOException {
     // add boss
-    zauberer = new Entity("Zauberer von Patternson");
+    zauberer = new Entity("Schamane der Patterns");
     zauberer.add(new PositionComponent());
     zauberer.add(new DrawComponent(new SimpleIPath("character/monster/orc_shaman")));
 

--- a/dojo-dungeon/src/starter/DojoStarter.java
+++ b/dojo-dungeon/src/starter/DojoStarter.java
@@ -191,7 +191,7 @@ public class DojoStarter {
                 DojoStarter::buildRoom_Fragen_Pattern,
                 () ->
                     OkDialog.showOkDialog(
-                        "In diesem Raum müssen verschiedene Design Patterns anhand eines UML-Klassendiagramms erkannt werden. Die erkannten Design Patterns müssen dann dem Zauberer mitgeteilt werden. - Sprich mit dem Zauberer.",
+                        "In diesem Raum müssen verschiedene Design Patterns anhand eines UML-Klassendiagramms erkannt werden. Die erkannten Design Patterns müssen dann dem Schamanen mitgeteilt werden. - Sprich mit dem Schamanen.",
                         "\"Die Vulkanhöhle\" (Raum 2)",
                         () -> {})),
             new BuildRoomData(


### PR DESCRIPTION
Der Zauberer im zweiten Raum im zweiten Level hat die selbe Textur wie der Held. Das sieht nicht besonders gelungen aus und könnte bei den Studis zu Verwirrung führen. 

Dieser PR behebt das Problem und weist dem Zauberer eine Orc-Schamanen-Textur zu.


closes #1516 