### PR TITLE
Dojo: erlaube Toleranzen bei String-Vergleichen Lösung vs. Antwort (Level 2, Pattern-Abfrage)

### DIFF
--- a/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
+++ b/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
@@ -28,9 +28,9 @@ import task.tasktype.quizquestion.FreeText;
  * werden. Die erkannten Design Patterns müssen dann dem Zauberer mitgeteilt werden.
  */
 public class Fragen_Pattern extends Room {
-  private final String fileNamePrefix =
+  private final String FILE_NAME_PREFIX =
       "dojo-dungeon/todo-assets/Fragen_Pattern/UML_Klassendiagramm";
-  private final String[] expectedPatterns = {".*?observer.*?", ".*?visitor.*?"};
+  private final String[] EXPECTED_PATTERNS = {".*?observer.*?", ".*?visitor.*?"};
   private int currentPatternIndex = 0;
   private int correctAnswerCount = 0;
   private Entity zauberer;
@@ -100,14 +100,14 @@ public class Fragen_Pattern extends Room {
           taskContents.stream().map(t -> (Quiz.Content) t).findFirst().orElseThrow().content();
       String answer = rawAnswer.toLowerCase();
 
-      if (answer.matches(expectedPatterns[currentPatternIndex])) {
+      if (answer.matches(EXPECTED_PATTERNS[currentPatternIndex])) {
         OkDialog.showOkDialog("Ihre Antwort ist korrekt!", "Antwort", () -> {});
         correctAnswerCount++;
         if (correctAnswerCount >= 2) {
           openDoors();
         }
         currentPatternIndex++;
-        if (currentPatternIndex < expectedPatterns.length) {
+        if (currentPatternIndex < EXPECTED_PATTERNS.length) {
           setNextTask();
         }
       } else {
@@ -119,7 +119,7 @@ public class Fragen_Pattern extends Room {
   private Quiz newFreeText() {
     String questionText =
         "Welches Design-Pattern wird in dem UML-Klassendiagramm unter \""
-            + fileNamePrefix
+            + FILE_NAME_PREFIX
             + (currentPatternIndex + 1)
             + ".png\" dargestellt? Es reicht das Wort ohne den Zusatz Pattern!";
     return new FreeText(questionText);

--- a/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
+++ b/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
@@ -115,9 +115,10 @@ public class Fragen_Pattern extends Room {
   }
 
   private Quiz newFreeText() {
+    String fileNamePrefix = "dojo-dungeon/todo-assets/Fragen_Pattern/UML_Klassendiagramm";
     String questionText =
         "Welches Design-Pattern wird in dem UML-Klassendiagramm unter \""
-            + "dojo-dungeon/todo-assets/Fragen_Pattern/UML_Klassendiagramm"
+            + fileNamePrefix
             + (currentPatternIndex + 1)
             + ".png\" dargestellt? Es reicht das Wort ohne den Zusatz Pattern!";
     return new FreeText(questionText);

--- a/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
+++ b/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
@@ -28,7 +28,7 @@ import task.tasktype.quizquestion.FreeText;
  * werden. Die erkannten Design Patterns müssen dann dem Zauberer mitgeteilt werden.
  */
 public class Fragen_Pattern extends Room {
-  private final String[] expectedPatterns = {"observer", "visitor"};
+  private final String[] expectedPatterns = {".*?observer.*?", ".*?visitor.*?"};
   private int currentPatternIndex = 0;
   private int correctAnswerCount = 0;
   private Entity zauberer;
@@ -96,9 +96,9 @@ public class Fragen_Pattern extends Room {
     return (task, taskContents) -> {
       String rawAnswer =
           taskContents.stream().map(t -> (Quiz.Content) t).findFirst().orElseThrow().content();
-      String answer = rawAnswer.toLowerCase(Locale.ROOT);
+      String answer = rawAnswer.toLowerCase();
 
-      if (answer.matches(".*?" + expectedPatterns[currentPatternIndex] + ".*?")) {
+      if (answer.matches(expectedPatterns[currentPatternIndex])) {
         OkDialog.showOkDialog("Ihre Antwort ist korrekt!", "Antwort", () -> {});
         correctAnswerCount++;
         if (correctAnswerCount >= 2) {

--- a/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
+++ b/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
@@ -12,9 +12,7 @@ import core.utils.components.path.SimpleIPath;
 import dojo.rooms.LevelRoom;
 import dojo.rooms.Room;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.*;
 import java.util.function.BiConsumer;
 import task.Task;
 import task.TaskContent;
@@ -30,12 +28,10 @@ import task.tasktype.quizquestion.FreeText;
  * werden. Die erkannten Design Patterns müssen dann dem Zauberer mitgeteilt werden.
  */
 public class Fragen_Pattern extends Room {
-  private final String FILENAME = "dojo-dungeon/todo-assets/Fragen_Pattern/UML_Klassendiagramm";
-  private final String[] expectedPatterns = {"Observer", "Visitor"};
+  private final String[] expectedPatterns = {"observer", "visitor"};
   private int currentPatternIndex = 0;
-
-  private Entity zauberer;
   private int correctAnswerCount = 0;
+  private Entity zauberer;
 
   /**
    * Generate a new room.
@@ -98,16 +94,11 @@ public class Fragen_Pattern extends Room {
 
   private BiConsumer<Task, Set<TaskContent>> showAnswersOnHud() {
     return (task, taskContents) -> {
-      AtomicReference<String> answers = new AtomicReference<>("");
-      taskContents.stream()
-          .map(t -> (Quiz.Content) t)
-          .forEach(t -> answers.set(answers.get() + t.content() + System.lineSeparator()));
+      String rawAnswer =
+          taskContents.stream().map(t -> (Quiz.Content) t).findFirst().orElseThrow().content();
+      String answer = rawAnswer.toLowerCase(Locale.ROOT);
 
-      // remove the automatically added \n from the answer string
-      String answer = answers.get();
-      String cleanedAnswer = answer.trim();
-
-      if (cleanedAnswer.equals(expectedPatterns[currentPatternIndex])) {
+      if (answer.matches(".*?" + expectedPatterns[currentPatternIndex] + ".*?")) {
         OkDialog.showOkDialog("Ihre Antwort ist korrekt!", "Antwort", () -> {});
         correctAnswerCount++;
         if (correctAnswerCount >= 2) {
@@ -126,7 +117,7 @@ public class Fragen_Pattern extends Room {
   private Quiz newFreeText() {
     String questionText =
         "Welches Design-Pattern wird in dem UML-Klassendiagramm unter \""
-            + FILENAME
+            + "dojo-dungeon/todo-assets/Fragen_Pattern/UML_Klassendiagramm"
             + (currentPatternIndex + 1)
             + ".png\" dargestellt? Es reicht das Wort ohne den Zusatz Pattern!";
     return new FreeText(questionText);

--- a/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
+++ b/dojo-dungeon/src/dojo/rooms/rooms/riddle/Fragen_Pattern.java
@@ -28,6 +28,8 @@ import task.tasktype.quizquestion.FreeText;
  * werden. Die erkannten Design Patterns müssen dann dem Zauberer mitgeteilt werden.
  */
 public class Fragen_Pattern extends Room {
+  private final String fileNamePrefix =
+      "dojo-dungeon/todo-assets/Fragen_Pattern/UML_Klassendiagramm";
   private final String[] expectedPatterns = {".*?observer.*?", ".*?visitor.*?"};
   private int currentPatternIndex = 0;
   private int correctAnswerCount = 0;
@@ -115,7 +117,6 @@ public class Fragen_Pattern extends Room {
   }
 
   private Quiz newFreeText() {
-    String fileNamePrefix = "dojo-dungeon/todo-assets/Fragen_Pattern/UML_Klassendiagramm";
     String questionText =
         "Welches Design-Pattern wird in dem UML-Klassendiagramm unter \""
             + fileNamePrefix


### PR DESCRIPTION
Bei der Pattern-Aufgabe in Level 2 sollen die Studierenden ihre Antwort als String eingeben, der dann gegen eine vorgegebene Lösung verglichen wird. 

Um die Studierenden nicht zu frustrieren, stellt dieser PR den Vergleich auf einen Match mit RegExp um. Dadurch werden leichte Variationen in der Antwort noch als korrekt erkannt. Beispiel: Gesucht ist "Foo". Durch den Regexp würden dann "Foo", "foo", "Foo Pattern", "Foo-Pattern", "Foomuster", ... noch als korrekt erkannt.



closes #1517 closes #1520 