### PR TITLE
Dependabot: add blockly sub-project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: "weekly"
     labels: []
+  - package-ecosystem: "npm"
+    directory: "/blockly"
+    schedule:
+      interval: "weekly"
+    labels: []


### PR DESCRIPTION
add dependabot configuration for blockly sub-project (npm)