### PR TITLE
Gradle: remove checkstyle config workaround (not needed anymore)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,17 +39,11 @@ allprojects {
     checkstyle {
         configFile = rootProject.file('.checkstyle.xml')
         // Default version vs. current version? The default version is quite old (9.3 from
-        // Jan 30, 2022), so let's go with the current version (10.14).
+        // Jan 30, 2022), so let's go with the current version (10.17).
         // However, this needs to be updated manually as Dependabot won't deal with this!
         toolVersion = '10.17.0'
         ignoreFailures = false
         maxWarnings = 0
-    }
-    // Workaround to resolve CS dependencies: https://github.com/checkstyle/checkstyle/issues/14123#issuecomment-1961029772
-    configurations.checkstyle {
-        resolutionStrategy.capabilitiesResolution.withCapability("com.google.collections:google-collections") {
-            select("com.google.guava:guava:0")
-        }
     }
 }
 


### PR DESCRIPTION
Im `build.gradle` ist ein Workaround für die bisher kaputte interne Auflösung von Abhängigkeiten in Checkstyle selbst: https://github.com/Dungeon-CampusMinden/Dungeon/blob/86a86bf2b463472e90759475b2d693925cfe5126/build.gradle#L48-L53
 
Das im Kommentar verlinkte Issue (aus dem dieser Workaround stammt) ist mittlerweile geschlossen. Der Workaround scheint nicht mehr benötigt zu werden.

Dieser PR entfernt den Workaround zur Auflösung der Checkstyle-Dependencies.



closes #1499