### PR TITLE
Core: Fix dialog centering issue on window resize

### DIFF
--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -1,5 +1,6 @@
 package core;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.ai.pfa.GraphPath;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import core.components.PositionComponent;
@@ -58,12 +59,12 @@ public final class Game {
   }
 
   /**
-   * Retrieves the window width from the pre-run configuration.
+   * Retrieves the window width from Gdx.
    *
    * @return The window width.
    */
   public static int windowWidth() {
-    return PreRunConfiguration.windowWidth();
+    return Gdx.graphics.getWidth();
   }
 
   /**
@@ -76,12 +77,12 @@ public final class Game {
   }
 
   /**
-   * Retrieves the window height from the pre-run configuration.
+   * Retrieves the window height from Gdx.
    *
    * @return The window height.
    */
   public static int windowHeight() {
-    return PreRunConfiguration.windowHeight();
+    return Gdx.graphics.getHeight();
   }
 
   /**

--- a/game/src/core/systems/CameraSystem.java
+++ b/game/src/core/systems/CameraSystem.java
@@ -9,6 +9,7 @@ import core.Game;
 import core.System;
 import core.components.CameraComponent;
 import core.components.PositionComponent;
+import core.game.PreRunConfiguration;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
 
@@ -42,11 +43,11 @@ public final class CameraSystem extends System {
   }
 
   private static float viewportWidth() {
-    return Game.windowWidth() / FIELD_WIDTH_AND_HEIGHT_IN_PIXEL;
+    return PreRunConfiguration.windowWidth() / FIELD_WIDTH_AND_HEIGHT_IN_PIXEL;
   }
 
   private static float viewportHeight() {
-    return Game.windowHeight() / FIELD_WIDTH_AND_HEIGHT_IN_PIXEL;
+    return PreRunConfiguration.windowHeight() / FIELD_WIDTH_AND_HEIGHT_IN_PIXEL;
   }
 
   /**

--- a/game/src/core/systems/CameraSystem.java
+++ b/game/src/core/systems/CameraSystem.java
@@ -43,11 +43,13 @@ public final class CameraSystem extends System {
   }
 
   private static float viewportWidth() {
-    return PreRunConfiguration.windowWidth() / FIELD_WIDTH_AND_HEIGHT_IN_PIXEL;
+    return PreRunConfiguration.windowWidth()
+        / FIELD_WIDTH_AND_HEIGHT_IN_PIXEL; // Using PreRun to keep the same zoom
   }
 
   private static float viewportHeight() {
-    return PreRunConfiguration.windowHeight() / FIELD_WIDTH_AND_HEIGHT_IN_PIXEL;
+    return PreRunConfiguration.windowHeight()
+        / FIELD_WIDTH_AND_HEIGHT_IN_PIXEL; // Using PreRun to keep the same zoom
   }
 
   /**


### PR DESCRIPTION
Das Problem war, dass Dialoge nicht im Zentrum des Bildschirms erscheinen, wenn die Fenstergröße verändert wird. Dies lag daran, dass die Viewports von `Game` verwendet werden, welche nur die PreRun-Konfiguration lesen und nicht die aktuelle Größe der Gdx-App.

- `Game.java`: Methoden `windowWidth` und `windowHeight` verwenden jetzt Gdx anstatt PreRunConfiguration.
- `CameraSystem.java`: Beibehaltung der PreRunConfiguration in `viewportWidth` und `viewportHeight`, um denselben Zoom zu gewährleisten.