### PR TITLE
Core: Fixed nullpointer in `entityAtTile`

### DIFF
--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -430,23 +430,24 @@ public final class Game {
   }
 
   /**
-   * Returns the entities on the given tile.
+   * Returns the entities on the given tile. If the tile is null, an empty stream will be returned.
    *
    * @param check Tile to check for.
    * @return Stream of all entities on the given tile
    */
   public static Stream<Entity> entityAtTile(final Tile check) {
     Tile tile = Game.tileAT(check.position());
+    if (tile == null) return Stream.empty();
 
     return ECSManagment.entityStream(Set.of(PositionComponent.class))
         .filter(
             e ->
-                tileAT(
+                tile.equals(
+                    tileAT(
                         e.fetch(PositionComponent.class)
                             .orElseThrow(
                                 () -> MissingComponentException.build(e, PositionComponent.class))
-                            .position())
-                    .equals(tile));
+                            .position())));
   }
 
   /**


### PR DESCRIPTION
Das Problem war, dass die Methode `entityAtTile` einen NullPointerException warf, wenn das übergebene Tile `null` war. Dies wird nun behoben, indem ein leerer Stream zurückgegeben wird, falls das Tile `null` ist. Dies macht die Methode benutzerfreundlicher und weniger fehleranfällig, da sie vorhersehbarer auf ungültige Eingaben reagiert.

- `Game.java`: Check hinzugefügt, ob das gegebene Tile null ist, falls ja, wird ein leerer Stream zurückgegeben.