### PR TITLE
Core: Add visibility and tinting options for entities and tiles

### DIFF
--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -60,6 +60,8 @@ public final class DrawComponent implements Component {
 
   private Map<String, Animation> animationMap = null;
   private Animation currentAnimation;
+  private int tintColor = -1; // -1 means no tinting
+  private boolean isVisible = true;
 
   /**
    * Create a new DrawComponent.
@@ -462,6 +464,26 @@ public final class DrawComponent implements Component {
   }
 
   /**
+   * Check if the component is visible. If the component is visible, it will be drawn by the {@link
+   * core.systems.DrawSystem}.
+   *
+   * @return true if the component is visible, false if not.
+   */
+  public boolean isVisible() {
+    return isVisible;
+  }
+
+  /**
+   * Set the visibility of the component. If the component is visible, it will be drawn by the
+   * {@link core.systems.DrawSystem}.
+   *
+   * @param visible The new visibility status to set. True for visible, false for hidden.
+   */
+  public void setVisible(boolean visible) {
+    isVisible = visible;
+  }
+
+  /**
    * Load animations if the game is running in the IDE (or over the shell).
    *
    * @param path Path to the animations.
@@ -484,5 +506,23 @@ public final class DrawComponent implements Component {
         LOGGER.log(CustomLogLevel.ERROR, "Could not load animations from directory", e);
       }
     }
+  }
+
+  /**
+   * Returns the tint color of the DrawComponent.
+   *
+   * @return The tint color of the DrawComponent. If the tint color is -1, no tint is applied.
+   */
+  public int tintColor() {
+    return this.tintColor;
+  }
+
+  /**
+   * Sets the tint color of the DrawComponent. Set it to -1 to remove the tint.
+   *
+   * @param tintColor The new tint color to set.
+   */
+  public void tintColor(int tintColor) {
+    this.tintColor = tintColor;
   }
 }

--- a/game/src/core/level/Tile.java
+++ b/game/src/core/level/Tile.java
@@ -35,6 +35,8 @@ public abstract class Tile {
   protected LevelElement levelElement;
   protected transient Array<Connection<Tile>> connections = new Array<>();
   protected int index;
+  protected boolean visible = true;
+  protected int tintColor = -1; // -1 means no tint color
 
   /**
    * Create a new Tile.
@@ -225,6 +227,44 @@ public abstract class Tile {
    */
   public boolean isAccessible() {
     return levelElement.value();
+  }
+
+  /**
+   * Sets the visibility of the tile. If the tile is visible, it gets drawn. If it is not visible,
+   * it is hidden.
+   *
+   * @param b The visibility status to set. True for visible, false for hidden.
+   */
+  public void visible(boolean b) {
+    this.visible = b;
+  }
+
+  /**
+   * Gets the visibility of the tile. If the tile is visible, it can be seen by the player. If it is
+   * not visible, it is hidden.
+   *
+   * @return The visibility of the tile. True if the tile is visible, false if it is hidden.
+   */
+  public boolean visible() {
+    return this.visible;
+  }
+
+  /**
+   * Sets the tint color of the tile. This color is used to tint the tile's texture.
+   *
+   * @param color The color to set. -1 for no tint.
+   */
+  public void tintColor(int color) {
+    this.tintColor = color;
+  }
+
+  /**
+   * Gets the tint color of the tile. This color is used to tint the tile's texture.
+   *
+   * @return The tint color of the tile. Null if no tint is set.
+   */
+  public int tintColor() {
+    return this.tintColor;
   }
 
   /** The direction of a tile. */

--- a/game/src/core/systems/DrawSystem.java
+++ b/game/src/core/systems/DrawSystem.java
@@ -2,10 +2,12 @@ package core.systems;
 
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import core.Entity;
+import core.Game;
 import core.System;
 import core.components.DrawComponent;
 import core.components.PlayerComponent;
 import core.components.PositionComponent;
+import core.level.Tile;
 import core.utils.components.MissingComponentException;
 import core.utils.components.draw.Animation;
 import core.utils.components.draw.Painter;
@@ -86,8 +88,40 @@ public final class DrawSystem extends System {
     List<Entity> players = partitionedEntities.get(true);
     List<Entity> npcs = partitionedEntities.get(false);
 
-    npcs.forEach(entity -> draw(buildDataObject(entity)));
+    npcs.stream().filter(this::shouldDraw).forEach(entity -> draw(buildDataObject(entity)));
     players.forEach(entity -> draw(buildDataObject(entity)));
+  }
+
+  /**
+   * Checks if an entity should be drawn. By checking:
+   *
+   * <ol>
+   *   <li>The tile the entity is on is visible
+   *   <li>The entity itself is visible
+   * </ol>
+   *
+   * @param entity the entity to check
+   * @return true if the entity should be drawn, false otherwise
+   * @see DrawComponent#isVisible()
+   */
+  private boolean shouldDraw(Entity entity) {
+    PositionComponent pc =
+        entity
+            .fetch(PositionComponent.class)
+            .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
+
+    if (Game.currentLevel().tileAt(pc.position()) == null) {
+      return false;
+    }
+
+    DrawComponent dc =
+        entity
+            .fetch(DrawComponent.class)
+            .orElseThrow(() -> MissingComponentException.build(entity, DrawComponent.class));
+    if (!dc.isVisible()) return false;
+
+    Tile tile = Game.currentLevel().tileAt(pc.position());
+    return tile.visible();
   }
 
   private void draw(final DSData dsd) {
@@ -96,9 +130,13 @@ public final class DrawSystem extends System {
     final Animation animation = dsd.dc.currentAnimation();
     IPath currentAnimationTexture = animation.nextAnimationTexturePath();
     if (!configs.containsKey(currentAnimationTexture)) {
-      configs.put(currentAnimationTexture, new PainterConfig(currentAnimationTexture));
+      configs.put(
+          currentAnimationTexture,
+          new PainterConfig(currentAnimationTexture, 0, 0, dsd.dc.tintColor()));
     }
-    PAINTER.draw(dsd.pc.position(), currentAnimationTexture, configs.get(currentAnimationTexture));
+    PainterConfig conf = this.configs.get(currentAnimationTexture);
+    conf.tintColor(dsd.dc.tintColor());
+    PAINTER.draw(dsd.pc.position(), currentAnimationTexture, conf);
   }
 
   /**

--- a/game/src/core/systems/LevelSystem.java
+++ b/game/src/core/systems/LevelSystem.java
@@ -179,10 +179,12 @@ public final class LevelSystem extends System {
     for (Tile[] tiles : layout) {
       for (int x = 0; x < layout[0].length; x++) {
         Tile t = tiles[x];
-        if (t.levelElement() != LevelElement.SKIP) {
+        if (t.levelElement() != LevelElement.SKIP && t.visible()) {
           IPath texturePath = t.texturePath();
-          if (!mapping.containsKey(texturePath)) {
-            mapping.put(texturePath, new PainterConfig(texturePath, X_OFFSET, Y_OFFSET));
+          if (!mapping.containsKey(texturePath)
+              || (mapping.get(texturePath).tintColor() != t.tintColor())) {
+            mapping.put(
+                texturePath, new PainterConfig(texturePath, X_OFFSET, Y_OFFSET, t.tintColor()));
           }
           painter.draw(t.position(), texturePath, mapping.get(texturePath));
         }

--- a/game/src/core/utils/components/draw/Painter.java
+++ b/game/src/core/utils/components/draw/Painter.java
@@ -1,5 +1,6 @@
 package core.utils.components.draw;
 
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Sprite;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import core.systems.CameraSystem;
@@ -58,6 +59,14 @@ public class Painter {
 
       // need to be called before drawing
       batch.begin();
+
+      // tint the sprite
+      if (config.tintColor() != -1) {
+        Color color = Color.CLEAR;
+        Color.rgba8888ToColor(color, config.tintColor());
+        sprite.setColor(color);
+      }
+
       // draw sprite
       sprite.draw(batch);
       // need to be called after drawing

--- a/game/src/core/utils/components/draw/PainterConfig.java
+++ b/game/src/core/utils/components/draw/PainterConfig.java
@@ -11,10 +11,12 @@ import core.utils.components.path.IPath;
  * @see Painter
  */
 public final class PainterConfig {
+
   private final float xOffset;
   private final float yOffset;
   private final float xScaling;
   private final float yScaling;
+  private int tintColor = -1; // -1 means no tint color
 
   /**
    * Create a new PainterConfig with the given offset.
@@ -24,10 +26,11 @@ public final class PainterConfig {
    * @param texturePath Path to the texture.
    * @param xOffset The texture will be moved on the x-axis, based on this value.
    * @param yOffset The texture will be moved on the y-axis, based on this value.
+   * @param tintColor The color to tint the texture with.
    */
-  public PainterConfig(final IPath texturePath, float xOffset, float yOffset) {
+  public PainterConfig(final IPath texturePath, float xOffset, float yOffset, int tintColor) {
     // half the texture xOffset, yOffset is a quarter texture down
-    this(xOffset, yOffset, 1, TextureMap.instance().textureAt(texturePath));
+    this(xOffset, yOffset, 1, TextureMap.instance().textureAt(texturePath), tintColor);
   }
 
   /**
@@ -41,19 +44,27 @@ public final class PainterConfig {
     this(TextureMap.instance().textureAt(texturePath));
   }
 
-  private PainterConfig(float xOffset, float yOffset, float xScaling, float yScaling) {
+  private PainterConfig(
+      float xOffset, float yOffset, float xScaling, float yScaling, int tintColor) {
     this.xOffset = xOffset;
     this.yOffset = yOffset;
     this.xScaling = xScaling;
     this.yScaling = yScaling;
+    this.tintColor = tintColor;
   }
 
-  private PainterConfig(float xOffset, float yOffset, float xScaling, final Texture texture) {
-    this(xOffset, yOffset, xScaling, ((float) texture.getHeight() / (float) texture.getWidth()));
+  private PainterConfig(
+      float xOffset, float yOffset, float xScaling, final Texture texture, int tintColor) {
+    this(
+        xOffset,
+        yOffset,
+        xScaling,
+        ((float) texture.getHeight() / (float) texture.getWidth()),
+        tintColor);
   }
 
   private PainterConfig(Texture texture) {
-    this(0f, 0f, 1, texture);
+    this(0f, 0f, 1, texture, -1);
   }
 
   /**
@@ -90,5 +101,23 @@ public final class PainterConfig {
    */
   public float yScaling() {
     return yScaling;
+  }
+
+  /**
+   * Get the tint color in this configuration.
+   *
+   * @return The color to tint the texture with. -1 means no tint color.
+   */
+  public int tintColor() {
+    return this.tintColor;
+  }
+
+  /**
+   * Set the tint color in this configuration.
+   *
+   * @param tintcolor The color to tint the texture with.
+   */
+  public void tintColor(int tintcolor) {
+    this.tintColor = tintcolor;
   }
 }

--- a/game/test/core/level/TileLevelAPITest.java
+++ b/game/test/core/level/TileLevelAPITest.java
@@ -140,18 +140,29 @@ public class TileLevelAPITest {
     Tile[][] layout = new Tile[2][2];
     layout[0][0] = Mockito.mock(Tile.class);
     when(layout[0][0].levelElement()).thenReturn(elementT1);
+    when(layout[0][0].visible()).thenReturn(true);
+    when(layout[0][0].tintColor()).thenReturn(-1);
     when(layout[0][0].texturePath()).thenReturn(textureT1);
     when(layout[0][0].position()).thenReturn(coordinateT1.toPoint());
     layout[0][1] = Mockito.mock(Tile.class);
     when(layout[0][1].levelElement()).thenReturn(elementT2);
+    when(layout[0][1].visible()).thenReturn(true);
+    when(layout[0][1].tintColor()).thenReturn(-1);
+
     when(layout[0][1].texturePath()).thenReturn(textureT2);
     when(layout[0][1].position()).thenReturn(coordinateT2.toPoint());
     layout[1][0] = Mockito.mock(Tile.class);
     when(layout[1][0].levelElement()).thenReturn(elementT3);
+    when(layout[1][0].visible()).thenReturn(true);
+    when(layout[1][0].tintColor()).thenReturn(-1);
+
     when(layout[1][0].texturePath()).thenReturn(textureT3);
     when(layout[1][0].position()).thenReturn(coordinateT3.toPoint());
     layout[1][1] = Mockito.mock(Tile.class);
     when(layout[1][1].levelElement()).thenReturn(elementT4);
+    when(layout[1][1].visible()).thenReturn(false);
+    when(layout[1][1].tintColor()).thenReturn(-1);
+
     when(layout[1][1].texturePath()).thenReturn(textureT4);
     when(layout[1][1].position()).thenReturn(coordinateT4.toPoint());
 
@@ -164,20 +175,26 @@ public class TileLevelAPITest {
     verifyNoMoreInteractions(level);
 
     verify(layout[0][0]).levelElement();
+    verify(layout[0][0]).visible();
     verify(layout[0][0]).texturePath();
+    verify(layout[0][0]).tintColor();
     verify(layout[0][0]).position();
     // for some reason mockito.verify can't compare the points of the tile correctly
     verify(painter, times(3)).draw(any(Point.class), any(IPath.class), any(PainterConfig.class));
     verifyNoMoreInteractions(layout[0][0]);
 
     verify(layout[0][1]).levelElement();
+    verify(layout[0][1]).visible();
     verify(layout[0][1]).texturePath();
+    verify(layout[0][1]).tintColor();
     verify(layout[0][1]).position();
     // for some reason mockito.verify can't compare the points of the tile correctly
     verify(painter, times(3)).draw(any(Point.class), any(IPath.class), any(PainterConfig.class));
     verifyNoMoreInteractions(layout[0][1]);
     verify(layout[1][0]).levelElement();
+    verify(layout[1][0]).visible();
     verify(layout[1][0]).texturePath();
+    verify(layout[1][0]).tintColor();
     verify(layout[1][0]).position();
     // for some reason mockito.verify can't compare the points of the tile correctly
     verify(painter, times(3)).draw(any(Point.class), any(IPath.class), any(PainterConfig.class));


### PR DESCRIPTION
Das Problem war, dass es keine Möglichkeit gab, die Sichtbarkeit von Entities und Tiles zu steuern oder sie einzufärben. Dies machte es schwierig, bestimmte Objekte auszublenden oder hervorzuheben. Jetzt können Entities und Tiles eine Sichtbarkeit und Tönung haben.

- `DrawComponent.java`, `Tile.java`: Sichtbarkeits- und Tönungsfunktionen hinzugefügt.
- `DrawSystem.java`: Überprüfung der Sichtbarkeit und Anwendung der Tönung beim Rendern von Entities. Entities werden nur gerendert, wenn das Tile, auf dem sie stehen, und sie selbst sichtbar sind.
- `LevelSystem.java`, `Painter.java` und `PainterConfig.java`: Unterstützung für Tönung hinzugefügt.
- Standard-Tönung ist -1 (keine Tönung). Alternativ könnte auch 0xFFFFFFFF (weiß, also keine sichtbare Tönung) verwendet werden
- Tests angepasst (`test_execute_draw()` in `TileLevelAPITest`).