### PR TITLE
Core: Add support for interaction of entities with tile pits

### DIFF
--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -53,7 +53,7 @@ public final class HeroFactory {
     hero.add(cc);
     PositionComponent poc = new PositionComponent();
     hero.add(poc);
-    hero.add(new VelocityComponent(X_SPEED_HERO, Y_SPEED_HERO));
+    hero.add(new VelocityComponent(X_SPEED_HERO, Y_SPEED_HERO, (e) -> {}, true));
     hero.add(new DrawComponent(HERO_FILE_PATH));
     HealthComponent hc =
         new HealthComponent(

--- a/dungeon/src/contrib/utils/components/skill/DamageProjectile.java
+++ b/dungeon/src/contrib/utils/components/skill/DamageProjectile.java
@@ -160,7 +160,7 @@ public abstract class DamageProjectile implements Consumer<Entity> {
     Point velocity = SkillTools.calculateVelocity(startPoint, targetPoint, projectileSpeed);
 
     // Add the VelocityComponent to the projectile
-    VelocityComponent vc = new VelocityComponent(velocity.x, velocity.y, onWallHit);
+    VelocityComponent vc = new VelocityComponent(velocity.x, velocity.y, onWallHit, true);
     projectile.add(vc);
 
     // Add the ProjectileComponent with the initial and target positions to the projectile

--- a/game/src/core/components/VelocityComponent.java
+++ b/game/src/core/components/VelocityComponent.java
@@ -39,6 +39,7 @@ public final class VelocityComponent implements Component {
   private float previousXVelocity;
   private float previousYVelocity;
   private Consumer<Entity> onWallHit;
+  private boolean canEnterOpenPits;
 
   /**
    * Create a new VelocityComponent with the given configuration.
@@ -46,32 +47,37 @@ public final class VelocityComponent implements Component {
    * @param xVelocity Speed with which the entity can move on the x-axis.
    * @param yVelocity Speed with which the entity can move on the y-axis.
    * @param onWallHit Callback that will be executed if the entity runs against a wall.
+   * @param canEnterOpenPits Whether the entity enter open pit tiles.
    */
-  public VelocityComponent(float xVelocity, float yVelocity, Consumer<Entity> onWallHit) {
+  public VelocityComponent(
+      float xVelocity, float yVelocity, Consumer<Entity> onWallHit, boolean canEnterOpenPits) {
     this.currentXVelocity = 0;
     this.currentYVelocity = 0;
     this.xVelocity = xVelocity;
     this.yVelocity = yVelocity;
     this.onWallHit = onWallHit;
+    this.canEnterOpenPits = canEnterOpenPits;
   }
 
   /**
-   * Create a new VelocityComponent with the given configuration.
+   * Create a new VelocityComponent with the given configuration. By default, the entity will not be
+   * able to enter open pit tiles.
    *
    * @param xVelocity Speed with which the entity can move on the x-axis.
    * @param yVelocity Speed with which the entity can move on the y-axis.
    */
   public VelocityComponent(float xVelocity, float yVelocity) {
-    this(xVelocity, yVelocity, DEFAULT_ON_WALL_HIT);
+    this(xVelocity, yVelocity, DEFAULT_ON_WALL_HIT, false);
   }
 
   /**
    * Create a new VelocityComponent with the default configuration.
    *
    * <p>In the default configuration, the movement speed is set to 0, so the entity will not move.
+   * And the entity will not be able to enter open pit tiles.
    */
   public VelocityComponent() {
-    this(0, 0, DEFAULT_ON_WALL_HIT);
+    this(0, 0);
   }
 
   /**
@@ -230,5 +236,23 @@ public final class VelocityComponent implements Component {
    */
   public Consumer<Entity> onWallHit() {
     return onWallHit;
+  }
+
+  /**
+   * Set whether the entity can enter open pit tiles.
+   *
+   * @param canEnterOpenPits Whether the entity can enter open pit tiles.
+   */
+  public void canEnterOpenPits(boolean canEnterOpenPits) {
+    this.canEnterOpenPits = canEnterOpenPits;
+  }
+
+  /**
+   * Get whether the entity can enter open pit tiles.
+   *
+   * @return Whether the entity can enter open pit tiles.
+   */
+  public boolean canEnterOpenPits() {
+    return this.canEnterOpenPits;
   }
 }

--- a/game/src/core/systems/VelocitySystem.java
+++ b/game/src/core/systems/VelocitySystem.java
@@ -8,6 +8,8 @@ import core.System;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.components.VelocityComponent;
+import core.level.Tile;
+import core.level.utils.LevelElement;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import core.utils.components.draw.CoreAnimationPriorities;
@@ -67,18 +69,22 @@ public final class VelocitySystem extends System {
     float newX = vsd.pc.position().x + velocity.x;
     float newY = vsd.pc.position().y + velocity.y;
     boolean hitWall = false;
+    boolean canEnterOpenPits =
+        vsd.e.fetch(VelocityComponent.class).map(VelocityComponent::canEnterOpenPits).orElse(false);
     try {
-      if (Game.tileAT(new Point(newX, newY)).isAccessible()) {
+      if (this.isAccessible(Game.tileAT(new Point(newX, newY)), canEnterOpenPits)) {
         // no change in direction
         vsd.pc.position(new Point(newX, newY));
         this.movementAnimation(vsd);
-      } else if (Game.tileAT(new Point(newX, vsd.pc.position().y)).isAccessible()) {
+      } else if (this.isAccessible(
+          Game.tileAT(new Point(newX, vsd.pc.position().y)), canEnterOpenPits)) {
         // redirect not moving along y
         hitWall = true;
         vsd.pc.position(new Point(newX, vsd.pc.position().y));
         this.movementAnimation(vsd);
         vsd.vc.currentYVelocity(0.0f);
-      } else if (Game.tileAT(new Point(vsd.pc.position().x, newY)).isAccessible()) {
+      } else if (this.isAccessible(
+          Game.tileAT(new Point(vsd.pc.position().x, newY)), canEnterOpenPits)) {
         // redirect not moving along x
         hitWall = true;
         vsd.pc.position(new Point(vsd.pc.position().x, newY));
@@ -103,6 +109,19 @@ public final class VelocitySystem extends System {
       vsd.pc().position(PositionComponent.ILLEGAL_POSITION);
       LOGGER.warning("Entity " + e + " is out of bound");
     }
+  }
+
+  /**
+   * Small helper function to check if a tile is accessible and also considers if the entity can
+   * enter empty tiles.
+   *
+   * @param tile The tile to check.
+   * @param canEnterPitTiles If the entity can enter PIT tiles.
+   * @return true if the tile is accessible, false if not.
+   */
+  private boolean isAccessible(Tile tile, boolean canEnterPitTiles) {
+    return tile.isAccessible()
+        || (canEnterPitTiles && tile.levelElement().equals(LevelElement.PIT));
   }
 
   private void movementAnimation(VSData vsd) {


### PR DESCRIPTION
Ich habe eine Möglichkeit hinzugefügt, das Entitäten wie z.B. Projektile offene Pit-Tiles betreten können.

- `HeroFactory.java`: VelocityComponent für den Helden so angepasst, dass er in Pit-Tiles fallen kann.
- `DamageProjectile.java`: VelocityComponent für Projektile so angepasst, dass sie über Pit-Tiles fliegen können.
- `VelocityComponent.java`: Neue Eigenschaft `canEnterOpenPits` hinzugefügt, um zu bestimmen, ob eine Entität offene Pit-Tiles betreten kann.
- `VelocitySystem.java`: Überprüfung hinzugefügt, ob eine Entität Pit-Tiles betreten kann.
