### PR TITLE
Core: add utility methods to Point and Coordinate

### DIFF
--- a/game/src/core/level/utils/Coordinate.java
+++ b/game/src/core/level/utils/Coordinate.java
@@ -59,7 +59,7 @@ public class Coordinate {
   }
 
   /**
-   * Convert Coordinate to Point centered in the tile
+   * Convert Coordinate to Point centered in the tile.
    *
    * @return Coordinate converted to a point;
    */

--- a/game/src/core/level/utils/Coordinate.java
+++ b/game/src/core/level/utils/Coordinate.java
@@ -59,6 +59,15 @@ public class Coordinate {
   }
 
   /**
+   * Convert Coordinate to Point centered in the tile
+   *
+   * @return Coordinate converted to a point;
+   */
+  public Point toCenteredPoint() {
+    return new Point(x + 0.5f, y + 0.5f);
+  }
+
+  /**
    * Creates a new Coordinate which has the sum of the Coordinates.
    *
    * @param other which Coordinate to add
@@ -66,5 +75,20 @@ public class Coordinate {
    */
   public Coordinate add(final Coordinate other) {
     return new Coordinate(this.x + other.x, this.y + other.y);
+  }
+
+  @Override
+  public String toString() {
+    return "Coordinate{" + "x=" + x + ", y=" + y + '}';
+  }
+
+  /**
+   * Calculates the distance between this Coordinate and another Coordinate.
+   *
+   * @param other The other Coordinate to calculate the distance to.
+   * @return The distance between this Coordinate and the other Coordinate.
+   */
+  public int distance(Coordinate other) {
+    return Math.abs(x - other.x) + Math.abs(y - other.y);
   }
 }

--- a/game/src/core/utils/Point.java
+++ b/game/src/core/utils/Point.java
@@ -108,4 +108,19 @@ public final class Point {
   public boolean equals(final Point other) {
     return Math.abs(x - other.x) < EPSILON && Math.abs(y - other.y) < EPSILON;
   }
+
+  @Override
+  public String toString() {
+    return "Point{" + "x=" + x + ", y=" + y + '}';
+  }
+
+  /**
+   * Calculates the Euclidean distance between this point and the given point.
+   *
+   * @param otherPos The point to which the distance is calculated.
+   * @return The Euclidean distance between this point and the given point.
+   */
+  public double distance(Point otherPos) {
+    return Math.sqrt(Math.pow(otherPos.x - x, 2) + Math.pow(otherPos.y - y, 2));
+  }
 }


### PR DESCRIPTION
Ich habe ein paar Utils-Methoden zu `Point` und `Coordinate` hinzugefügt, um die Vollständigkeit zu erhöhen und als Debug-Hilfe später zu dienen. Das sollte die Benutzerfreundlichkeit etwas verbesseren für diese Klassen.

- `Coordinate.java`: Methoden `toCenteredPoint`, `toString` und `distance` hinzugefügt.
  - `toCenteredPoint`: Konvertiert eine `Coordinate` in einen zentrierten Punkt des Tiles.
  - `distance`: Berechnet die Manhattan-Distanz zwischen zwei `Coordinates`.
- `Point.java`: Methoden `toString` und `distance` hinzugefügt.
  - `distance`: Berechnet die euklidische Distanz zwischen zwei `Points`.