### PR TITLE
Core: add open/close functionality to exit tiles

### DIFF
--- a/game/src/core/level/elements/tile/ExitTile.java
+++ b/game/src/core/level/elements/tile/ExitTile.java
@@ -14,6 +14,9 @@ import core.utils.components.path.IPath;
  */
 public class ExitTile extends Tile {
 
+  private static final int DEFAULT_CLOSE_TINT = 0xFF000066;
+  private boolean open = true;
+
   /**
    * Creates a new Tile.
    *
@@ -24,6 +27,43 @@ public class ExitTile extends Tile {
   public ExitTile(
       final IPath texturePath, final Coordinate globalPosition, final DesignLabel designLabel) {
     super(texturePath, globalPosition, designLabel);
+
     levelElement = LevelElement.EXIT;
+  }
+
+  /**
+   * Open the exit.
+   *
+   * <p>The player can now exit the level.
+   */
+  public void open() {
+    this.tintColor(-1); // reset tint
+    open = true;
+  }
+
+  /**
+   * Close the exit.
+   *
+   * <p>The player can no longer exit the level.
+   */
+  public void close() {
+    this.tintColor(DEFAULT_CLOSE_TINT);
+    open = false;
+  }
+
+  /**
+   * Check if the exit is open.
+   *
+   * @return true if the exist is open, false if not.
+   */
+  public boolean isOpen() {
+    return open;
+  }
+
+  @Override
+  public String toString() {
+    String tileStr = super.toString();
+    tileStr = tileStr.replace("Tile", "ExitTile").replace("}", "");
+    return tileStr + ", open=" + this.open + "}";
   }
 }

--- a/game/src/core/level/elements/tile/ExitTile.java
+++ b/game/src/core/level/elements/tile/ExitTile.java
@@ -38,7 +38,7 @@ public class ExitTile extends Tile {
    */
   public void open() {
     this.tintColor(-1); // reset tint
-    open = true;
+    this.open = true;
   }
 
   /**
@@ -48,7 +48,7 @@ public class ExitTile extends Tile {
    */
   public void close() {
     this.tintColor(DEFAULT_CLOSE_TINT);
-    open = false;
+    this.open = false;
   }
 
   /**
@@ -57,7 +57,7 @@ public class ExitTile extends Tile {
    * @return true if the exist is open, false if not.
    */
   public boolean isOpen() {
-    return open;
+    return this.open;
   }
 
   @Override

--- a/game/test/core/level/TileLevelAPITest.java
+++ b/game/test/core/level/TileLevelAPITest.java
@@ -11,6 +11,7 @@ import core.Game;
 import core.components.PlayerComponent;
 import core.components.PositionComponent;
 import core.level.elements.ILevel;
+import core.level.elements.tile.ExitTile;
 import core.level.generator.IGenerator;
 import core.level.utils.Coordinate;
 import core.level.utils.DesignLabel;
@@ -228,9 +229,10 @@ public class TileLevelAPITest {
     hero.add(new PlayerComponent());
     Game.add(hero);
 
-    Tile end = Mockito.mock(Tile.class);
+    ExitTile end = Mockito.mock(ExitTile.class);
     Point p = new Point(3, 3);
     when(end.position()).thenReturn(p);
+    when(end.isOpen()).thenReturn(true);
     when(level.tileAt((Point) any())).thenReturn(end);
     Mockito.when(level.endTile()).thenReturn(end);
 


### PR DESCRIPTION
Ich habe hinzugefügt, dass `ExitTiles` jetzt offen und geschlossen sein können. Da es keine Textur für geschlossen gibt, werden sie rot eingefärbt. Wenn sie geschlossen sind, teleportieren sie nicht zum nächsten Level. Außerdem habe ich den Test angepasst, sodass der Exit dort offen ist. Standardmäßig ist der Exit offen. Das LevelSystem wurde überarbeitet, um eine onEndTile-Callback-Funktion hinzuzufügen. Standardmäßig wird das nächste Level geladen, und die Callback-Funktion wird nur aufgerufen, wenn das Exit-Tile offen ist. `isTilePitAndOpen` wurde hinzugefügt, um offene Pits nicht zu rendern, da die "Textur" einfach leer sein soll. Dies kann später angepasst bzw. wieder gelöscht werden, falls eine Textur dafür vorhanden ist. `isOnDoor` wurde überarbeitet und verwendet keine Schleife mehr, sondern prüft einfach, ob das Entity auf einer Tür steht. Außerdem kann otherDoor null sein, sodass man auch Türen haben kann, die nicht teleportieren. Das macht den Code robuster.

- `ExitTile.java`: Funktionalität zum Öffnen und Schließen von Exit-Tiles hinzugefügt.
- `LevelSystem.java`: Überarbeitet, um onEndTile-Callback-Funktion hinzuzufügen und isTilePitAndOpen-Methode einzuführen.
   - `isOnDoor`-Methode überarbeitet, um die Robustheit und Performance zu erhöhen.
- Test angepasst, sodass der Exit dort offen ist.
