### PR TITLE
Core: allow Tile to be transparent

### DIFF
--- a/game/src/core/level/Tile.java
+++ b/game/src/core/level/Tile.java
@@ -271,7 +271,7 @@ public abstract class Tile {
   /**
    * Gets the tint color of the tile. This color is used to tint the tile's texture.
    *
-   * @return The tint color of the tile. Null if no tint is set.
+   * @return The tint color of the tile.
    */
   public int tintColor() {
     return this.tintColor;

--- a/game/src/core/level/Tile.java
+++ b/game/src/core/level/Tile.java
@@ -277,6 +277,26 @@ public abstract class Tile {
     return this.tintColor;
   }
 
+  @Override
+  public String toString() {
+    return "Tile{"
+        + "position="
+        + this.position()
+        + ", friction="
+        + this.friction()
+        + ", designLabel="
+        + this.designLabel()
+        + ", texturePath="
+        + this.texturePath().pathString()
+        + ", levelElement="
+        + this.levelElement()
+        + ", visible="
+        + this.visible()
+        + ", tintColor="
+        + this.tintColor()
+        + '}';
+  }
+
   /** The direction of a tile. */
   @DSLType(name = "tile_direction")
   public enum Direction {

--- a/game/src/core/level/Tile.java
+++ b/game/src/core/level/Tile.java
@@ -230,8 +230,18 @@ public abstract class Tile {
   }
 
   /**
-   * Sets the visibility of the tile. If the tile is visible, it gets drawn. If it is not visible,
-   * it is hidden.
+   * Checks if the player can see through this tile. This depends on the level element of the tile.
+   * Some level elements may be transparent or just a pit. Others may be walls or closed doors.
+   *
+   * @return True if the player can see through this tile, false otherwise.
+   */
+  public boolean canSeeThrough() {
+    return levelElement.canSeeThrough();
+  }
+
+  /**
+   * Sets the visibility of the tile. If the tile is visible, it can be seen by the player. If it is
+   * not visible, it is hidden.
    *
    * @param b The visibility status to set. True for visible, false for hidden.
    */

--- a/game/src/core/level/elements/ILevel.java
+++ b/game/src/core/level/elements/ILevel.java
@@ -254,6 +254,9 @@ public interface ILevel extends IndexedGraph<Tile> {
             changeInto,
             tile.designLabel());
     level.layout()[tile.coordinate().y][tile.coordinate().x] = newTile;
+    newTile.index(tile.index());
+    newTile.tintColor(tile.tintColor());
+    newTile.visible(tile.visible());
     level.addTile(newTile);
   }
 

--- a/game/src/core/level/elements/tile/DoorTile.java
+++ b/game/src/core/level/elements/tile/DoorTile.java
@@ -116,4 +116,22 @@ public class DoorTile extends Tile {
     if (open && (otherDoor == null || otherDoor.isOpen())) return texturePath;
     else return closedTexturePath;
   }
+
+  @Override
+  public String toString() {
+    String tileStr = super.toString();
+    tileStr = tileStr.replace("Tile", "DoorTile").replace("}", "");
+    String doorStepStr = this.doorstep == null ? "null" : this.doorstep.coordinate().toString();
+    String otherDoorStr = this.otherDoor == null ? "null" : this.otherDoor.coordinate().toString();
+    return tileStr
+        + ", closedTexturePath="
+        + this.closedTexturePath.pathString()
+        + ", open="
+        + this.open
+        + ", Doorstep="
+        + doorStepStr
+        + ", OtherDoor="
+        + otherDoorStr
+        + "}";
+  }
 }

--- a/game/src/core/level/elements/tile/DoorTile.java
+++ b/game/src/core/level/elements/tile/DoorTile.java
@@ -45,6 +45,11 @@ public class DoorTile extends Tile {
     else return levelElement.value();
   }
 
+  @Override
+  public boolean canSeeThrough() {
+    return this.open;
+  }
+
   /**
    * Connects this door with its other side in another room.
    *

--- a/game/src/core/level/utils/LevelElement.java
+++ b/game/src/core/level/utils/LevelElement.java
@@ -3,37 +3,49 @@ package core.level.utils;
 /** Each type of field in a level can be represented by an integer value. */
 public enum LevelElement {
   /** This field is a blank. */
-  SKIP(false),
+  SKIP(false, false),
   /** This field is a floor-field. */
-  FLOOR(true),
+  FLOOR(true, true),
   /** This field is a wall-field. */
-  WALL(false),
+  WALL(false, false),
   /** This field is a hole-field. */
-  HOLE(false),
+  HOLE(false, false),
   /** This field is the exit-field to the next level. */
-  EXIT(true),
+  EXIT(true, false),
   /** This field is a pit-field. */
-  PIT(false),
+  PIT(false, true),
   /** This field is a door-field. */
-  DOOR(true);
+  DOOR(true, true);
 
   private final boolean accessible;
+  private final boolean canSeeThrough;
 
   /**
    * Represents a level element with accessibility information.
    *
    * @param accessible The accessibility value of the element.
+   * @param canSeeThrough The Entity can see through this element.
    */
-  LevelElement(boolean accessible) {
+  LevelElement(boolean accessible, boolean canSeeThrough) {
     this.accessible = accessible;
+    this.canSeeThrough = canSeeThrough;
   }
 
   /**
    * Checks if the element is accessible.
    *
-   * @return true if the element is accessible, code false if not.
+   * @return true if the element is accessible, false if not.
    */
   public boolean value() {
     return accessible;
+  }
+
+  /**
+   * Checks if the element can be seen through.
+   *
+   * @return true if the element can be seen through, false if not.
+   */
+  public boolean canSeeThrough() {
+    return canSeeThrough;
   }
 }


### PR DESCRIPTION
Ich habe ein Attribut `canSeeThrough` zu Tiles hinzugefügt, das angibt, ob ein Tile durchsichtig ist oder nicht. Dies kann z.B. für ein Fog-of-War verwendet werden. Türen haben diese Eigenschaft überschrieben bekommen und sind nur durchsichtig, wenn sie offen sind. Außerdem habe ich die `toString` Methode zu Tiles und Doors hinzugefügt, um das Debuggen zu erleichtern. Die Methode `changeTileElementType` wurde angepasst, um auch Parameter für das AI-Pathfinding, die Tint-Farbe und die Sichtbarkeit zu übernehmen, wenn das Element geändert wird.

- `Tile.java`: Neue Methode `canSeeThrough` hinzugefügt und `toString` Methode erweitert.
- `ILevel.java`: Methode `changeTileElementType` angepasst, um Pfadfindungs-Parameter, Tint-Farbe und Sichtbarkeit zu übernehmen.
- `DoorTile.java`: `canSeeThrough` Methode überschrieben, damit Türen nur durchsichtig sind, wenn sie offen sind.
- `LevelElement.java`: Neue Eigenschaft `canSeeThrough` hinzugefügt, um anzugeben, ob ein Level-Element durchsichtig ist.
