### PR TITLE
Dungeon: support multiple contents simultaneously in Task and Quiz

### DIFF
--- a/dojo-dungeon/src/dojo/rooms/rooms/boss/Fragen_Lambda.java
+++ b/dojo-dungeon/src/dojo/rooms/rooms/boss/Fragen_Lambda.java
@@ -122,10 +122,7 @@ public class Fragen_Lambda extends Room {
     Quiz.Content c2 = new Quiz.Content("Eine anonyme Klasse");
     Quiz.Content c3 = new Quiz.Content("Ein spezieller Datentyp");
     Quiz.Content c4 = new Quiz.Content("Ein Interface mit nur einer Methode");
-    question.addAnswer(c1);
-    question.addAnswer(c2);
-    question.addAnswer(c3);
-    question.addAnswer(c4);
+    question.addAnswer(c1, c2, c3, c4);
     return new QuestionAndAnswers(question, Set.of(c1));
   }
 
@@ -137,11 +134,7 @@ public class Fragen_Lambda extends Room {
     Quiz.Content c3 = new Quiz.Content("test");
     Quiz.Content c4 = new Quiz.Content("get");
     Quiz.Content c5 = new Quiz.Content("set");
-    question.addAnswer(c1);
-    question.addAnswer(c2);
-    question.addAnswer(c3);
-    question.addAnswer(c4);
-    question.addAnswer(c5);
+    question.addAnswer(c1, c2, c3, c4, c5);
     return new QuestionAndAnswers(question, Set.of(c3));
   }
 
@@ -153,11 +146,7 @@ public class Fragen_Lambda extends Room {
     Quiz.Content c3 = new Quiz.Content("Comparator");
     Quiz.Content c4 = new Quiz.Content("EventListener");
     Quiz.Content c5 = new Quiz.Content("ActionListener");
-    question.addAnswer(c1);
-    question.addAnswer(c2);
-    question.addAnswer(c3);
-    question.addAnswer(c4);
-    question.addAnswer(c5);
+    question.addAnswer(c1, c2, c3, c4, c5);
     return new QuestionAndAnswers(question, Set.of(c1, c2, c3, c5));
   }
 

--- a/dungeon/src/task/Task.java
+++ b/dungeon/src/task/Task.java
@@ -33,7 +33,7 @@ import task.game.content.QuestItem;
  * #content} collection.
  *
  * <p>The internal collection can be queried as a stream using {@link #contentStream()}, and
- * manipulated using {@link #addContent(TaskContent)}.
+ * manipulated using {@link #addContent(TaskContent...)}.
  *
  * <p>Each task is associated with a {@link TaskComponent} that handles the meta-control of the
  * task.
@@ -328,13 +328,15 @@ public abstract class Task {
   }
 
   /**
-   * Add given element to the internal {@link #content} collection.
+   * Add given elements to the internal {@link #content} collection.
    *
-   * @param content element to add to the internal collection
+   * @param content elements to add to the internal collection
    */
-  public void addContent(final TaskContent content) {
-    content.task(this);
-    this.content.add(content);
+  public void addContent(final TaskContent... content) {
+    for (TaskContent c : content) {
+      c.task(this);
+      this.content.add(c);
+    }
   }
 
   /**

--- a/dungeon/src/task/TaskContent.java
+++ b/dungeon/src/task/TaskContent.java
@@ -44,7 +44,7 @@ public abstract class TaskContent {
    * Set the reference to the task if no reference is set yet.
    *
    * <p>If the reference was set, this Content will not automatically register itself at the Task.
-   * Call {@link Task#addContent(TaskContent)} for that.
+   * Call {@link Task#addContent(TaskContent...)} for that.
    *
    * <p>Note: You cannot change the reference because then this content must be removed from the
    * Task, and at the moment there is no functionality for that because we don't think we will need

--- a/dungeon/src/task/game/hud/QuizDialogDesign.java
+++ b/dungeon/src/task/game/hud/QuizDialogDesign.java
@@ -19,7 +19,7 @@ public class QuizDialogDesign {
   /** The name of the answers group. */
   public static final String ANSWERS_GROUP_NAME = "Answers";
 
-  private static final String QUIZ_MESSAGE_TASK = "Aufgabestellung";
+  private static final String QUIZ_MESSAGE_TASK = "Aufgabenstellung";
   private static final String QUIZ_MESSAGE_SOLUTION = "Lösung";
 
   /**

--- a/dungeon/src/task/tasktype/Quiz.java
+++ b/dungeon/src/task/tasktype/Quiz.java
@@ -23,7 +23,7 @@ import task.tasktype.quizquestion.SingleChoice;
  * the question is asked via the UI, the {@link QuizUI} will configure the UI for the question based
  * on that type.
  *
- * <p>Add a {@link Content} answer by using the {@link #addAnswer(Quiz.Content)} method. Use the
+ * <p>Add a {@link Content} answer by using the {@link #addAnswer(Content...)} method. Use the
  * {@link #contentStream()} method to get the answers as a stream.
  *
  * <p>The question will be stored as {@link Content} and can be accessed via {@link #question()}.
@@ -99,21 +99,25 @@ public abstract class Quiz extends Task {
   }
 
   /**
-   * Add a {@link Content} answer instance as a possible answer for this question.
+   * Add a {@link Content} answers instance as a possible answer for this question.
    *
    * <p>If the answer has no task reference yet, the reference will be set to this task and the
    * answer will be added to this task's content. If the answer already has a task reference, the
    * answer will not be added to this task's content.
    *
-   * @param answer The answer (can contain a path to images).
+   * @param answers The answers (can contain a path to images).
    * @return true if the answer was added to this task's content, false if not.
    */
-  public boolean addAnswer(Quiz.Content answer) {
-    if (answer.task(this)) {
-      addContent(answer);
-      return true;
+  public boolean addAnswer(Quiz.Content... answers) {
+    boolean added = true;
+    for (Quiz.Content answer : answers) {
+      if (answer.task(this)) {
+        this.addContent(answer);
+      } else {
+        added = false;
+      }
     }
-    return false;
+    return added;
   }
 
   /**


### PR DESCRIPTION
Ich habe die Methoden angepasst, sodass man mehrere Inhalte (Contents) gleichzeitig zu einer Aufgabe (Task) oder einem Quiz hinzufügen kann. Zudem wurde ein Tippfehler behoben. Im Dojo-Dungeon wurden die neuen Signaturen bereits übernommen, was den Code lesbarer und kompakter macht.

- `Task.java`: `addContent` Methode so geändert, dass mehrere Inhalte gleichzeitig hinzugefügt werden können.
- `TaskContent.java`: Dokumentation angepasst, um die neue `addContent(TaskContent...)` Methode zu reflektieren.
- `Quiz.java`: `addAnswer` Methode so geändert, dass mehrere Antworten gleichzeitig hinzugefügt werden können.
- `QuizDialogDesign.java`: Tippfehler in der Variablen `QUIZ_MESSAGE_TASK` korrigiert.
- `Fragen_Lambda.java` im Dojo-Dungeon: Code auf neue Signatur geändert, um die Lesbarkeit zu verbessern und Zeilen zu reduzieren.