### PR TITLE
Dungeon: mute distant entities via proximity filter (IdleSoundSystem)

### DIFF
--- a/dungeon/src/contrib/systems/IdleSoundSystem.java
+++ b/dungeon/src/contrib/systems/IdleSoundSystem.java
@@ -29,26 +29,27 @@ public final class IdleSoundSystem extends System {
     super(IdleSoundComponent.class);
   }
 
-  private static boolean isEntityNearby(Entity entity) {
-    Point heroPosition =
-        Game.hero()
-            .flatMap(h -> h.fetch(PositionComponent.class))
-            .map(PositionComponent::position)
-            .orElse(null);
-
+  private static boolean isEntityNearby(Point heroPos, Entity entity) {
     Point entityPosition =
         entity.fetch(PositionComponent.class).map(PositionComponent::position).orElse(null);
 
-    if ((heroPosition != null) && (entityPosition != null))
-      return Point.calculateDistance(heroPosition, entityPosition) < DISTANCE_THRESHOLD;
+    if (heroPos == null || entityPosition == null) {
+      return false;
+    }
 
-    return false;
+    double distance = heroPos.distance(entityPosition);
+
+    return distance < DISTANCE_THRESHOLD;
   }
 
   @Override
   public void execute() {
+    Point heroPos =
+        Game.hero()
+            .flatMap(e -> e.fetch(PositionComponent.class).map(PositionComponent::position))
+            .orElse(null);
     entityStream()
-        .filter(IdleSoundSystem::isEntityNearby)
+        .filter(e -> isEntityNearby(heroPos, e))
         .forEach(
             e ->
                 playSound(

--- a/dungeon/src/contrib/systems/IdleSoundSystem.java
+++ b/dungeon/src/contrib/systems/IdleSoundSystem.java
@@ -30,24 +30,19 @@ public final class IdleSoundSystem extends System {
   }
 
   private static boolean isEntityNearby(Entity entity) {
-    Entity hero = Game.hero().orElse(null);
-    if (hero == null) {
-      return false;
-    }
+    Point heroPosition =
+        Game.hero()
+            .flatMap(h -> h.fetch(PositionComponent.class))
+            .map(PositionComponent::position)
+            .orElse(null);
 
-    PositionComponent heroPositionComponent = hero.fetch(PositionComponent.class).orElse(null);
-    PositionComponent entityPositionComponent = entity.fetch(PositionComponent.class).orElse(null);
+    Point entityPosition =
+        entity.fetch(PositionComponent.class).map(PositionComponent::position).orElse(null);
 
-    if (heroPositionComponent == null || entityPositionComponent == null) {
-      return false;
-    }
+    if ((heroPosition != null) && (entityPosition != null))
+      return Point.calculateDistance(heroPosition, entityPosition) < DISTANCE_THRESHOLD;
 
-    Point heroPosition = heroPositionComponent.position();
-    Point entityPosition = entityPositionComponent.position();
-
-    double distance = heroPosition.distance(entityPosition);
-
-    return distance < DISTANCE_THRESHOLD;
+    return false;
   }
 
   @Override

--- a/dungeon/src/contrib/systems/IdleSoundSystem.java
+++ b/dungeon/src/contrib/systems/IdleSoundSystem.java
@@ -29,7 +29,7 @@ public final class IdleSoundSystem extends System {
     super(IdleSoundComponent.class);
   }
 
-  private static boolean onlyKeepNearbyEntities(Entity entity) {
+  private static boolean isEntityNearby(Entity entity) {
     Entity hero = Game.hero().orElse(null);
     if (hero == null) {
       return false;
@@ -53,7 +53,7 @@ public final class IdleSoundSystem extends System {
   @Override
   public void execute() {
     entityStream()
-        .filter(IdleSoundSystem::onlyKeepNearbyEntities)
+        .filter(IdleSoundSystem::isEntityNearby)
         .forEach(
             e ->
                 playSound(


### PR DESCRIPTION
Ich habe einen Filter hinzugefügt, der dafür sorgt, dass nur nahegelegene Monster Geräusche machen, da aktuell alle Monster zu hören sind und das die Spieler verwirren kann.

- `IdleSoundSystem.java`: Filter hinzugefügt, um nur nahegelegene Entities Geräusche machen zu lassen.
  - `DISTANCE_THRESHOLD` definiert, um die maximale Distanz festzulegen, innerhalb derer Geräusche gehört werden können.
  - Methode `onlyKeepNearbyEntities` hinzugefügt, die prüft, ob eine Entity innerhalb der festgelegten Distanz zum Helden ist.
