### PR TITLE
Dungeon: Add support for parameterized crafting recipes and enhanced health potions

### DIFF
--- a/dungeon/assets/recipes/healtpotion_berry.recipe
+++ b/dungeon/assets/recipes/healtpotion_berry.recipe
@@ -11,14 +11,10 @@
         {
             "type": "item",
             "item": {
-                "id": "ItemResourceBerry",
-                "count": 1
-            }
-        },
-        {
-            "type": "item",
-            "item": {
-                "id": "ItemPotionWater",
+                "id": "ItemPotionHealth",
+                "param": [
+                    "contrib.item.HealthPotionType:WEAK",
+                ],
                 "count": 1
             }
         }
@@ -28,6 +24,9 @@
             "type": "item",
             "item": {
                 "id": "ItemPotionHealth",
+                "param": [
+                    "contrib.item.HealthPotionType:NORMAL",
+                ],
                 "count": 1
             }
         }

--- a/dungeon/assets/recipes/healtpotion_mushroom.recipe
+++ b/dungeon/assets/recipes/healtpotion_mushroom.recipe
@@ -21,6 +21,9 @@
             "type": "item",
             "item": {
                 "id": "ItemPotionHealth",
+                "param": [
+                    "contrib.item.HealthPotionType:WEAK",
+                ],
                 "count": 1
             }
         }

--- a/dungeon/src/contrib/item/HealthPotionType.java
+++ b/dungeon/src/contrib/item/HealthPotionType.java
@@ -1,0 +1,43 @@
+package contrib.item;
+
+/** The types of health potions that can be created. Each type has a different healing amount. */
+public enum HealthPotionType {
+  /** A weak health potion that restores a small amount of health. */
+  WEAK(7),
+  /** A normal health potion that restores a moderate amount of health. */
+  NORMAL(15),
+  /** A greater health potion that restores a large amount of health. */
+  GREATER(30);
+
+  /** The amount of health that this type of potion restores when used. */
+  private final int healAmount;
+
+  /**
+   * Constructs a new health potion type with the specified healing amount.
+   *
+   * @param healAmount The amount of health that this type of potion restores when used.
+   */
+  HealthPotionType(int healAmount) {
+    this.healAmount = healAmount;
+  }
+
+  /**
+   * Returns the amount of health that this type of potion restores when used.
+   *
+   * @return The healing amount of this potion type.
+   */
+  public int getHealAmount() {
+    return this.healAmount;
+  }
+
+  /**
+   * Returns the name of the health potion type. The name is formatted with the first letter in
+   * uppercase and the rest in lowercase.
+   *
+   * @return The formatted name of the health potion type.
+   */
+  public String getName() {
+    String name = this.name();
+    return name.substring(0, 1).toUpperCase() + name.substring(1).toLowerCase();
+  }
+}

--- a/dungeon/src/contrib/item/Item.java
+++ b/dungeon/src/contrib/item/Item.java
@@ -14,6 +14,7 @@ import core.utils.components.draw.Animation;
 import core.utils.logging.CustomLogLevel;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.logging.Logger;
 
 /**
@@ -33,6 +34,9 @@ import java.util.logging.Logger;
  */
 public class Item implements CraftingIngredient, CraftingResult {
   private static final Logger LOGGER = Logger.getLogger(Item.class.getSimpleName());
+
+  /** Random object used to generate random numbers for item related things. */
+  public static final Random RANDOM = new Random();
 
   /**
    * Maps identifiers in crafting recipes (e.g. {@link ItemResourceBerry}) to their corresponding

--- a/dungeon/src/contrib/item/concreteItem/ItemPotionHealth.java
+++ b/dungeon/src/contrib/item/concreteItem/ItemPotionHealth.java
@@ -2,38 +2,93 @@ package contrib.item.concreteItem;
 
 import contrib.components.HealthComponent;
 import contrib.components.InventoryComponent;
+import contrib.crafting.CraftingIngredient;
+import contrib.item.HealthPotionType;
 import contrib.item.Item;
 import contrib.utils.components.health.Damage;
 import contrib.utils.components.health.DamageType;
 import core.Entity;
 import core.utils.components.draw.Animation;
+import core.utils.components.path.IPath;
 import core.utils.components.path.SimpleIPath;
 
 /**
- * A Health-Potion that restores hit point on usage.
- *
- * <p>Can be used for crafting.
+ * This class represents a health potion item in the game. The health potion can be used to restore
+ * health points to the entity that uses it. The amount of health restored is determined by the
+ * heal_amount attribute. The health potion has a default texture that is used for its visual
+ * representation in the game.
  */
 public final class ItemPotionHealth extends Item {
 
-  private static final int HEAL_AMOUNT = 50;
+  /** The default texture for all health potions. */
+  public static final IPath DEFAULT_TEXTURE = new SimpleIPath("items/potion/health_potion.png");
 
-  /** Create a new Health-Potion. */
-  public ItemPotionHealth() {
+  /** The amount of health that this potion restores when used. */
+  private final int heal_amount;
+
+  /**
+   * Constructs a new health potion with the specified type. The type determines the name and the
+   * healing amount of the potion. The {@link #DEFAULT_TEXTURE default texture} is used for the
+   * visual representation of the potion.
+   *
+   * @param type The type of the health potion to be created.
+   */
+  public ItemPotionHealth(HealthPotionType type) {
     super(
-        "Health Potion",
-        "A health potion. It heals you for " + HEAL_AMOUNT + " health points.",
-        Animation.fromSingleImage(new SimpleIPath("items/potion/health_potion.png")));
+        type.getName() + " Health Potion",
+        "It heals you for " + type.getHealAmount() + " health points.",
+        Animation.fromSingleImage(DEFAULT_TEXTURE));
+    this.heal_amount = type.getHealAmount();
   }
 
+  /**
+   * Constructs a new health potion with the specified name, healing amount, and texture.
+   *
+   * @param itemName The name of the health potion.
+   * @param healAmount The amount of health that the potion restores when used.
+   * @param texture The texture used for the visual representation of the potion.
+   */
+  public ItemPotionHealth(String itemName, int healAmount, IPath texture) {
+    super(
+        itemName,
+        "It heals you for " + healAmount + " health points.",
+        Animation.fromSingleImage(texture));
+    this.heal_amount = healAmount;
+  }
+
+  /**
+   * Uses the health potion on the specified entity. The potion is removed from the entity's
+   * inventory and the entity is healed by the heal_amount.
+   *
+   * @param e The entity that uses the potion.
+   */
   @Override
   public void use(final Entity e) {
     e.fetch(InventoryComponent.class)
         .ifPresent(
             component -> {
               component.remove(this);
-              e.fetch(HealthComponent.class)
-                  .ifPresent(hc -> hc.receiveHit(new Damage(-HEAL_AMOUNT, DamageType.HEAL, null)));
+              this.healUser(this.heal_amount, e);
             });
+  }
+
+  /**
+   * Heals the specified entity by the specified amount. The healing is done by applying negative
+   * damage to the specified amount to the entity.
+   *
+   * @param amount The amount of health to restore to the entity.
+   * @param e The entity to heal.
+   */
+  private void healUser(int amount, Entity e) {
+    e.fetch(HealthComponent.class)
+        .ifPresent(hc -> hc.receiveHit(new Damage(-amount, DamageType.HEAL, null)));
+  }
+
+  @Override
+  public boolean match(final CraftingIngredient input) {
+    if (!(input instanceof ItemPotionHealth other)) {
+      return super.match(input);
+    }
+    return other.heal_amount == this.heal_amount;
   }
 }

--- a/dungeon/src/contrib/utils/components/item/ItemGenerator.java
+++ b/dungeon/src/contrib/utils/components/item/ItemGenerator.java
@@ -1,5 +1,6 @@
 package contrib.utils.components.item;
 
+import contrib.item.HealthPotionType;
 import contrib.item.Item;
 import contrib.item.concreteItem.*;
 import java.util.Random;
@@ -19,12 +20,36 @@ public final class ItemGenerator {
    * @return A new random Item.
    */
   public static Item generateItemData() {
-    return switch (RANDOM.nextInt(8)) {
-      case 0 -> new ItemPotionHealth();
-      case 1, 2 -> new ItemPotionWater();
-      case 3, 4 -> new ItemResourceBerry();
-      case 5, 6 -> new ItemResourceEgg();
+    return switch (RANDOM.nextInt(9)) {
+      case 0, 1 -> new ItemPotionHealth(getWeightedRandomHealthPotionType());
+      case 2, 3 -> new ItemPotionWater();
+      case 4, 5 -> new ItemResourceBerry();
+      case 6, 7 -> new ItemResourceEgg();
       default -> new ItemResourceMushroomRed();
     };
+  }
+
+  /**
+   * This method returns a randomly selected potion type based on a weighted system. The weights are
+   * as follows: - 75% WEAK - 20% MEDIUM - 5% GREATER
+   *
+   * <p>These weights are based on the likelihood of the player finding a potion of a certain type.
+   *
+   * @return A randomly selected potion type based on the weighted system.
+   */
+  private static HealthPotionType getWeightedRandomHealthPotionType() {
+    HealthPotionType[] types = HealthPotionType.values();
+
+    float[] chances = {0.75f, 0.05f, 0.00f}; /* 75%, 20%, 5% */
+    float random = Item.RANDOM.nextFloat();
+
+    for (int i = 0; i < chances.length; i++) {
+      if (random < chances[i]) {
+        return types[i];
+      }
+      random -= chances[i];
+    }
+
+    return types[types.length - 1];
   }
 }

--- a/dungeon/test/contrib/crafting/CraftingTest.java
+++ b/dungeon/test/contrib/crafting/CraftingTest.java
@@ -2,6 +2,7 @@ package contrib.crafting;
 
 import static org.junit.Assert.*;
 
+import contrib.item.HealthPotionType;
 import contrib.item.Item;
 import contrib.item.concreteItem.ItemPotionHealth;
 import contrib.item.concreteItem.ItemPotionWater;
@@ -27,7 +28,7 @@ public class CraftingTest {
     CraftingIngredient[] recipeIngredient = {
       new ItemPotionWater(), new ItemResourceMushroomRed(), new ItemResourceMushroomRed(),
     };
-    CraftingResult[] recipeResults = {new ItemPotionHealth()};
+    CraftingResult[] recipeResults = {new ItemPotionHealth(HealthPotionType.NORMAL)};
     Recipe recipe = new Recipe(false, recipeIngredient, recipeResults);
     Crafting.addRecipe(recipe);
 
@@ -53,7 +54,7 @@ public class CraftingTest {
     CraftingIngredient[] recipeIngredient = {
       new ItemPotionWater(), new ItemResourceMushroomRed(), new ItemResourceMushroomRed(),
     };
-    CraftingResult[] recipeResults = {new ItemPotionHealth()};
+    CraftingResult[] recipeResults = {new ItemPotionHealth(HealthPotionType.NORMAL)};
     Recipe recipe = new Recipe(true, recipeIngredient, recipeResults);
     Crafting.addRecipe(recipe);
 
@@ -79,7 +80,7 @@ public class CraftingTest {
     CraftingIngredient[] recipeIngredient = {
       new ItemPotionWater(), new ItemResourceMushroomRed(), new ItemResourceMushroomRed(),
     };
-    CraftingResult[] recipeResults = {new ItemPotionHealth()};
+    CraftingResult[] recipeResults = {new ItemPotionHealth(HealthPotionType.NORMAL)};
     Recipe recipe = new Recipe(true, recipeIngredient, recipeResults);
     Crafting.addRecipe(recipe);
 
@@ -104,7 +105,7 @@ public class CraftingTest {
     CraftingIngredient[] recipeIngredient = {
       new ItemPotionWater(), new ItemResourceMushroomRed(), new ItemResourceMushroomRed(),
     };
-    CraftingResult[] recipeResults = {new ItemPotionHealth()};
+    CraftingResult[] recipeResults = {new ItemPotionHealth(HealthPotionType.NORMAL)};
     Recipe recipeOrdered = new Recipe(true, recipeIngredient, recipeResults);
     Recipe recipeUnordered = new Recipe(false, recipeIngredient, recipeResults);
     Crafting.addRecipe(recipeUnordered);


### PR DESCRIPTION
Ich habe eine neue Logik hinzugefügt, um Parameter für Crafting-Rezepte zu speichern, in diesem Fall verwendet für das Enum, dass die Stärke von Heiltränken steuert. Auf diese Weise haben wir drei Stärken von Heiltränken, die jeweils eine unterschiedliche Menge heilen. Ich habe auch die Tests angepasst und den zufälligen Gegenstandsdrops hinzugefügt, sodass jede Stärke fallen gelassen werden kann, wobei schwächere Heiltränke wahrscheinlicher sind. Die Heiltränke haben nun je nach Stärke einen anderen Namen und Beschreibung.

- `healtpotion_berry.recipe` und `healtpotion_mushroom.recipe`: Parameter hinzugefügt, um die Stärke des Heiltranks zu definieren.
- `Crafting.java`: Logik hinzugefügt, um Parameter aus JSON-Werten zu analysieren und Konstruktoren mit diesen Parametern zu finden.
- `HealthPotionType.java`: Enum für Heiltrank-Typen hinzugefügt, die die Heilmenge steuern.
- `ItemPotionHealth.java`: Angepasst, um verschiedene Heiltrank-Typen und Heilungsmengen zu unterstützen.
- `ItemGenerator.java`: Zufällige Heiltrank-Typen basierend auf gewichteten Wahrscheinlichkeiten hinzugefügt.
- `CraftingTest.java`: Tests angepasst, um die neuen Heiltrank-Typen zu berücksichtigen.

Diese Änderungen erweitern das Crafting-System um die Möglichkeit, komplexere Gegenstände mit Parametern zu erstellen und verbessern die Vielfalt und Balance der Heiltränke im Spiel.