### PR TITLE
Dungeon: Add support for parameterized crafting ingredients

### DIFF
--- a/dungeon/src/contrib/crafting/Crafting.java
+++ b/dungeon/src/contrib/crafting/Crafting.java
@@ -171,8 +171,20 @@ public final class Crafting {
 
         String type = ingredient.getString("type");
         if (type.equals("item")) {
-          CraftingIngredient ci = Item.getItem(id).getDeclaredConstructor().newInstance();
-          ingredientsArray[i] = ci;
+          if (item.has("param")) {
+            @SuppressWarnings("unchecked")
+            Constructor<? extends Item>[] itemConstructor =
+                (Constructor<? extends Item>[]) Item.getItem(id).getDeclaredConstructors();
+            Object[] params = parseParams(item.get("param"));
+            Constructor<?> fittingCons = findFittingConstructor(itemConstructor, params);
+            if (fittingCons == null) {
+              throw new RuntimeException("No fitting constructor found for item: " + id);
+            }
+            ingredientsArray[i] = (CraftingIngredient) fittingCons.newInstance(params);
+          } else {
+            CraftingIngredient ci = Item.getItem(id).getDeclaredConstructor().newInstance();
+            ingredientsArray[i] = ci;
+          }
         } else {
           throw new RuntimeException("Unknown ingredient type: " + type);
         }
@@ -187,10 +199,10 @@ public final class Crafting {
 
         String type = result.getString("type");
         if (type.equals("item")) {
-          @SuppressWarnings("unchecked")
-          Constructor<? extends Item>[] itemConstructor =
-              (Constructor<? extends Item>[]) Item.getItem(id).getDeclaredConstructors();
           if (item.has("param")) {
+            @SuppressWarnings("unchecked")
+            Constructor<? extends Item>[] itemConstructor =
+                (Constructor<? extends Item>[]) Item.getItem(id).getDeclaredConstructors();
             Object[] params = parseParams(item.get("param"));
             Constructor<?> fittingCons = findFittingConstructor(itemConstructor, params);
             if (fittingCons == null) {


### PR DESCRIPTION
Dieser Pull Request erweitert das Crafting-System, um Parameter für Crafting-Zutaten zu unterstützen. Das ermöglicht die Erstellung von komplexeren Gegenständen durch die Verwendung von Konstruktoren mit Parametern.

- `Crafting.java`: Logik hinzugefügt, um Parameter für Crafting-Zutaten zu verarbeiten. Wenn ein `item` Parameter hat, wird der passende Konstruktor gesucht und mit diesen Parametern aufgerufen. Verbesserte Fehlerbehandlung für fehlende Konstruktoren.

Die dient als Ergänzung zu #1558.