### PR TITLE
Dungeon: Add signs and util-methods for dialogs

### DIFF
--- a/dungeon/src/contrib/components/SignComponent.java
+++ b/dungeon/src/contrib/components/SignComponent.java
@@ -1,0 +1,94 @@
+package contrib.components;
+
+import contrib.hud.dialogs.OkDialog;
+import core.Component;
+import core.Entity;
+import core.utils.Point;
+import java.util.function.BiConsumer;
+
+/**
+ * The SignComponent class implements the Component interface. It represents a sign in the game with
+ * a title and text.
+ *
+ * @see contrib.entities.SignFactory#createSign(String, String, Point, BiConsumer) createSign
+ */
+public class SignComponent implements Component {
+  /** The default title for a sign. */
+  public static final String DEFAULT_TITLE = "Schild";
+
+  private String text;
+  private String title;
+
+  /**
+   * Constructs a new SignComponent with the specified text and title.
+   *
+   * @param text The text of the sign.
+   * @param title The title of the sign.
+   */
+  public SignComponent(String text, String title) {
+    // removes newlines and empty spaces and multiple spaces from the title and text
+    title = title.replaceAll("\\s+", " ").trim();
+    text = text.replaceAll("\\s+", " ").trim();
+    this.text = text;
+    this.title = title;
+  }
+
+  /**
+   * Constructs a new SignComponent with the specified text and a default title ("Schild").
+   *
+   * @param text The text of the sign.
+   */
+  public SignComponent(String text) {
+    this(text, DEFAULT_TITLE);
+  }
+
+  /**
+   * Returns the text of the sign.
+   *
+   * @return The text of the sign.
+   */
+  public String text() {
+    return this.text;
+  }
+
+  /**
+   * Sets the text of the sign.
+   *
+   * @param text The text to set.
+   */
+  public void text(String text) {
+    this.text = text;
+  }
+
+  /**
+   * Returns the title of the sign.
+   *
+   * @return The title of the sign.
+   */
+  public String title() {
+    return this.title;
+  }
+
+  /**
+   * Sets the title of the sign.
+   *
+   * @param title The title to set.
+   */
+  public void title(String title) {
+    this.title = title;
+  }
+
+  /**
+   * Displays a dialog with the sign's text and title.
+   *
+   * @return The dialog entity.
+   */
+  public Entity showDialog() {
+    return OkDialog.showOkDialog(this.text, this.title, () -> {});
+  }
+
+  @Override
+  public String toString() {
+    return "SignComponent{title='" + this.title + "', text='" + this.text + "'}";
+  }
+}

--- a/dungeon/src/contrib/entities/SignFactory.java
+++ b/dungeon/src/contrib/entities/SignFactory.java
@@ -1,0 +1,73 @@
+package contrib.entities;
+
+import contrib.components.InteractionComponent;
+import contrib.components.SignComponent;
+import contrib.hud.DialogUtils;
+import core.Entity;
+import core.components.DrawComponent;
+import core.components.PositionComponent;
+import core.utils.Point;
+import core.utils.components.MissingComponentException;
+import core.utils.components.draw.Animation;
+import core.utils.components.path.SimpleIPath;
+import java.util.function.BiConsumer;
+
+/**
+ * The SignFactory class is responsible for creating sign entities in the game.
+ *
+ * @see SignComponent SignComponent
+ * @see DialogUtils DialogUtils
+ */
+public class SignFactory {
+
+  private static final float DEFAULT_INTERACTION_RADIUS = 2.5f;
+  private static final Animation SIGN_TEXTURE =
+      Animation.fromSingleImage(new SimpleIPath("objects/mailbox/mailbox_2.png"));
+
+  /**
+   * Creates a sign entity with a default title at a given position.
+   *
+   * @param text The text of the sign.
+   * @param pos The position where the sign will be created.
+   * @return The created sign entity.
+   * @see #createSign(String, String, Point, BiConsumer) createSign
+   * @see SignComponent#DEFAULT_TITLE
+   */
+  public static Entity createSign(String text, Point pos) {
+    return createSign(text, SignComponent.DEFAULT_TITLE, pos, (a, b) -> {});
+  }
+
+  /**
+   * Creates a sign entity at a given position.
+   *
+   * @param text The text of the sign.
+   * @param title The title of the sign.
+   * @param pos The position where the sign will be created.
+   * @param onInteract The function to execute when the sign is interacted with.
+   * @return The created sign entity.
+   * @see SignComponent
+   */
+  public static Entity createSign(
+      String text, String title, Point pos, BiConsumer<Entity, Entity> onInteract) {
+    Entity sign = new Entity("sign");
+
+    sign.add(new PositionComponent(pos));
+    sign.add(new DrawComponent(SIGN_TEXTURE));
+    sign.add(new SignComponent(text, title));
+    sign.add(
+        new InteractionComponent(
+            DEFAULT_INTERACTION_RADIUS,
+            true,
+            (entity, who) -> {
+              SignComponent sc =
+                  entity
+                      .fetch(SignComponent.class)
+                      .orElseThrow(
+                          () -> MissingComponentException.build(entity, SignComponent.class));
+              onInteract.accept(entity, who);
+              sc.showDialog();
+            }));
+
+    return sign;
+  }
+}

--- a/dungeon/src/contrib/hud/DialogUtils.java
+++ b/dungeon/src/contrib/hud/DialogUtils.java
@@ -1,0 +1,95 @@
+package contrib.hud;
+
+import contrib.hud.dialogs.OkDialog;
+import core.Entity;
+import core.utils.IVoidFunction;
+import java.util.Iterator;
+import java.util.function.Function;
+import task.Task;
+import task.game.hud.QuizUI;
+import task.game.hud.UIAnswerCallback;
+import task.tasktype.Quiz;
+
+/**
+ * The DialogUtils class is responsible for displaying text popups and quizzes to the player.
+ *
+ * @see OkDialog
+ * @see QuizUI
+ * @see Quiz
+ */
+public class DialogUtils {
+
+  /**
+   * Displays a text popup.
+   *
+   * @param text The text of the popup.
+   * @param title The title of the popup.
+   * @return The popup entity.
+   * @see OkDialog#showOkDialog(String, String, IVoidFunction) showOkDialog
+   */
+  public static Entity showTextPopup(String text, String title) {
+    return showTextPopup(text, title, () -> {});
+  }
+
+  /**
+   * Displays a text popup. Upon closing the popup, the onFinished function is executed.
+   *
+   * @param text The text of the popup.
+   * @param title The title of the popup.
+   * @param onFinished The function to execute when the popup is closed.
+   * @return The popup entity.
+   * @see OkDialog#showOkDialog(String, String, IVoidFunction) showOkDialog
+   */
+  public static Entity showTextPopup(String text, String title, IVoidFunction onFinished) {
+    // removes newlines and empty spaces and multiple spaces from the title and text
+    title = title.replaceAll("\\s+", " ").trim();
+    text = text.replaceAll("\\s+", " ").trim();
+    return OkDialog.showOkDialog(text, title, onFinished);
+  }
+
+  /**
+   * Presents a quiz to the player. If the player answers correctly, the next quiz is presented.
+   * Otherwise, the player is shown the correct answer. When all quizzes have been solved, the
+   * onFinished function is executed.
+   *
+   * @param quizIterator The iterator of quizzes to present.
+   * @param onFinished The function to execute when all quizzes have been solved.
+   * @see QuizUI#showQuizDialog(Quiz, Function) showQuizDialog
+   */
+  public static void presentQuiz(Iterator<Quiz> quizIterator, IVoidFunction onFinished) {
+    if (!quizIterator.hasNext()) {
+      // All quizzes have been correctly solved
+      onFinished.execute();
+      return;
+    }
+
+    Quiz quiz = quizIterator.next();
+    QuizUI.showQuizDialog(
+        quiz,
+        (Entity hudEntity) ->
+            UIAnswerCallback.uiCallback(
+                quiz,
+                hudEntity,
+                (task, taskContents) -> {
+                  task.gradeTask(taskContents);
+                  boolean correctAnswered = task.state() == Task.TaskState.FINISHED_CORRECT;
+                  String output = "You have ";
+                  if (correctAnswered) {
+                    output += "correctly ";
+                  } else {
+                    output += "incorrectly ";
+                  }
+                  output += "solved the task";
+
+                  OkDialog.showOkDialog(
+                      output,
+                      "Result",
+                      () -> {
+                        if (correctAnswered) {
+                          // If the answer is correct, present the next quiz
+                          presentQuiz(quizIterator, onFinished);
+                        }
+                      });
+                }));
+  }
+}

--- a/dungeon/src/contrib/hud/DialogUtils.java
+++ b/dungeon/src/contrib/hud/DialogUtils.java
@@ -79,7 +79,7 @@ public class DialogUtils {
                   } else {
                     output += "incorrectly ";
                   }
-                  output += "solved the task";
+                  output += "solved the quiz";
 
                   OkDialog.showOkDialog(
                       output,

--- a/dungeon/src/task/game/hud/UIAnswerCallback.java
+++ b/dungeon/src/task/game/hud/UIAnswerCallback.java
@@ -58,7 +58,7 @@ public final class UIAnswerCallback {
    * @return foo
    * @see UIUtils
    */
-  static BiFunction<TextDialog, String, Boolean> uiCallback(
+  public static BiFunction<TextDialog, String, Boolean> uiCallback(
       Quiz quest, Entity hudEntity, BiConsumer<Task, Set<TaskContent>> dslCallback) {
     return (textDialog, id) -> {
       if (Objects.equals(id, DEFAULT_DIALOG_CONFIRM)) {


### PR DESCRIPTION
Der Pull Request fügt Schilder und Utility-Methoden hinzu, die es erlaubt Text-Popups und Fragen im Spiel anzuzeigen. 

- **SignComponent.java**:
  - Klasse `SignComponent` hinzugefügt, die ein Schild mit Titel und Text darstellt.
  - Konstruktoren für das Setzen von Titel und Text, mit Behandlung von Leerzeichen.
  - Methoden zum Abrufen und Setzen von Titel und Text und zum Anzeigen eines Dialogs.
  
- **SignFactory.java**:
  - Klasse `SignFactory` hinzugefügt, um Schilder im Spiel zu erstellen.
  - Methoden `createSign(Text, Pos)` und `createSign(Text, Titel, Pos, onInteract)` um Schilder mit Standard- oder benutzerdefinierten Titeln und `onInteract` zu erstellen.
  - Verwendet `SignComponent` für Schildeigenschaften und `InteractionComponent` für Interaktionen.

- **DialogUtils.java**:
  - Die Klasse `DialogUtils` wurde hinzugefügt, um Text-Popups und Quizfragen zu verwenden.
  - Methoden `showTextPopup(Text, Titel)` und `showTextPopup(Text, Titel, onFinished)` zur Anzeige von Text-Popups mit optionalem Callback beim Schließen des Popups.
  - Methode `presentQuiz(Iterator<Quiz>, IVoidFunction)`, um dem Spieler eine Menge von Quizfragen zu stellen, mit einer Callback die aufgerufen wird, wenn alle Fragen richtig beantwortet wurden.

- **UIAnswerCallback.java**:
  - Aktualisierte `uiCallback` Methodensignatur auf public für externe Verwendung. (siehe `presentQuiz`)

Der Methode `presentQuiz` könnte man einen Parameter geben, der die "Feedback"-Texte kontrolliert. Auch könnte man die Methode in `task.game.hud` verschieben. Aber so sollte es erstmal DSL nicht stören.