### PR TITLE
Dungeon: avoid building the same stream more than once (refactoring, CameraComponent)

### DIFF
--- a/game/src/core/systems/CameraSystem.java
+++ b/game/src/core/systems/CameraSystem.java
@@ -79,9 +79,10 @@ public final class CameraSystem extends System {
 
   @Override
   public void execute() {
-    if (filteredEntityStream(CameraComponent.class, PositionComponent.class).findAny().isEmpty())
-      focus();
-    else filteredEntityStream().forEach(this::focus);
+    filteredEntityStream(CameraComponent.class, PositionComponent.class)
+        .findAny()
+        .ifPresentOrElse(this::focus, this::focus);
+
     // Check if Gdx.graphics is null which happens when the game is run in headless mode (e.g.
     // in tests)
     if (Gdx.graphics != null) {


### PR DESCRIPTION
see https://github.com/Dungeon-CampusMinden/Dungeon/pull/1564#discussion_r1660951335

```java
public void execute() {
    if (filteredEntityStream(CameraComponent.class, PositionComponent.class).findAny().isEmpty())
       focus();
     else filteredEntityStream().forEach(this::focus);
```

Hier wird der Stream bis zu 2x gebaut, was (a) aufwändig und (b) schlecht lesbar ist.

Zudem wird bei Vorliegen eines oder mehrerer Entitäten mit einer `CameraComponent` für **alle** Entitäten in einer nicht vorhersehbaren Reihenfolge die Methode `focus(e)` aufgerufen - die zuletzt iterierte Entität "gewinnt", da es nur eine Kamera (-position) gibt.

Refactoring: Dies wird durch **einmaliges Erzeugen des Streams** und durch Nutzen einer **zufälligen Entität mit `CameraComponent`** zum Setzen der Kamera abgelöst.


Keine Änderung der API und/oder des Verhaltens.