### PR TITLE
Dungeon: do not throw exceptions in stream operations (refactoring, SpikeSystem)

### DIFF
--- a/dungeon/src/contrib/systems/SpikeSystem.java
+++ b/dungeon/src/contrib/systems/SpikeSystem.java
@@ -20,6 +20,7 @@ public final class SpikeSystem extends System {
   @Override
   public void execute() {
     filteredEntityStream(SpikyComponent.class)
-        .forEach(e -> e.fetch(SpikyComponent.class).orElseThrow().reduceCoolDown());
+        .flatMap((e -> e.fetch(SpikyComponent.class).stream()))
+        .forEach(sc -> sc.reduceCoolDown());
   }
 }

--- a/dungeon/src/contrib/systems/SpikeSystem.java
+++ b/dungeon/src/contrib/systems/SpikeSystem.java
@@ -21,7 +21,7 @@ public final class SpikeSystem extends System {
   @Override
   public void execute() {
     filteredEntityStream(SpikyComponent.class)
-        .map((e -> e.fetch(SpikyComponent.class)))
+        .map(e -> e.fetch(SpikyComponent.class))
         .flatMap((Optional::stream))
         .forEach(SpikyComponent::reduceCoolDown);
   }

--- a/dungeon/src/contrib/systems/SpikeSystem.java
+++ b/dungeon/src/contrib/systems/SpikeSystem.java
@@ -21,6 +21,6 @@ public final class SpikeSystem extends System {
   public void execute() {
     filteredEntityStream(SpikyComponent.class)
         .flatMap((e -> e.fetch(SpikyComponent.class).stream()))
-        .forEach(sc -> sc.reduceCoolDown());
+        .forEach(SpikyComponent::reduceCoolDown);
   }
 }

--- a/dungeon/src/contrib/systems/SpikeSystem.java
+++ b/dungeon/src/contrib/systems/SpikeSystem.java
@@ -3,6 +3,7 @@ package contrib.systems;
 import contrib.components.SpikyComponent;
 import core.System;
 import core.components.PositionComponent;
+import java.util.Optional;
 
 /**
  * Reduces the current cool down for each {@link SpikyComponent} once per frame. Entities with the
@@ -20,7 +21,8 @@ public final class SpikeSystem extends System {
   @Override
   public void execute() {
     filteredEntityStream(SpikyComponent.class)
-        .flatMap((e -> e.fetch(SpikyComponent.class).stream()))
+        .map((e -> e.fetch(SpikyComponent.class)))
+        .flatMap((Optional::stream))
         .forEach(SpikyComponent::reduceCoolDown);
   }
 }

--- a/dungeon/src/contrib/systems/SpikeSystem.java
+++ b/dungeon/src/contrib/systems/SpikeSystem.java
@@ -22,7 +22,7 @@ public final class SpikeSystem extends System {
   public void execute() {
     filteredEntityStream(SpikyComponent.class)
         .map(e -> e.fetch(SpikyComponent.class))
-        .flatMap((Optional::stream))
+        .flatMap(Optional::stream)
         .forEach(SpikyComponent::reduceCoolDown);
   }
 }


### PR DESCRIPTION
see https://github.com/Dungeon-CampusMinden/Dungeon/pull/1564#discussion_r1660926970

In 

```java
public void execute() {
     filteredEntityStream(SpikyComponent.class)
         .forEach(e -> e.fetch(SpikyComponent.class).orElseThrow().reduceCoolDown());
}
```

wird ein Stream aller Entitäten mit einer `SpikyComponent` vom `System` angefordert. Bei der Iteration über diese Entitäten wird dann (a) die `SpikyComponent` extrahiert, (b) eine Exception geworfen im Nichtvorhandensein-Fall, und (c) auf der Component eine Methode aufgerufen.

Dies ist aus zwei Gründen problematisch: Zum werden mehrere Operationen in die `forEach`-Schleife verpackt, und zum anderen sollte man keine Exceptions in einer Stream-Operation werfen. (OK, das dürfte hier in der Realität auch nie passieren, da wir ja vorher exakt nach der Component gefiltert hatten. Dennoch.)

Dieser PR führt ein Refactoring durch und erledigt **in jedem Stream-Step eine Sache**. Außerdem wird **keine Exception** mehr in der Stream-Verarbeitung geworfen, sondern Entitäten, die zwischen `System#filteredEntityStream` und dem `forEach` auf geheimnisvolle Weise ihre `SpikyComponent` verloren haben sollten, werden einfach ignoriert.

Keine Änderung der API und/oder des Verhaltens.