### PR TITLE
Dungeon: improve item dropping logic, introduce fallback to hero's position

### DIFF
--- a/dungeon/src/contrib/utils/components/interaction/DropItemsInteraction.java
+++ b/dungeon/src/contrib/utils/components/interaction/DropItemsInteraction.java
@@ -3,8 +3,8 @@ package contrib.utils.components.interaction;
 import contrib.components.InteractionComponent;
 import contrib.components.InventoryComponent;
 import contrib.item.Item;
-import contrib.utils.level.NoTileFoundException;
 import core.Entity;
+import core.Game;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.level.utils.Coordinate;
@@ -12,8 +12,6 @@ import core.level.utils.LevelUtils;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import core.utils.components.draw.CoreAnimations;
-import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -33,22 +31,17 @@ import java.util.function.Consumer;
 public final class DropItemsInteraction implements BiConsumer<Entity, Entity> {
 
   /**
-   * Small Helper to determine the position of the dropped item. Implements a simple circle drop.
+   * Maximum radius to drop an item from the entity position. If the item cannot be dropped within
+   * this radius, it will be dropped at the hero's position.
    *
-   * @param positionComponent The PositionComponent of the chest.
-   * @param radian Radian of the current Item.
-   * @return A Point in a unit vector around the chest.
+   * @see #tryDropItem(Item, PositionComponent)
    */
-  private static Point calculateDropPosition(
-      final PositionComponent positionComponent, double radian) {
-    return new Point(
-        (float) Math.cos(radian * Math.PI) + positionComponent.position().x,
-        (float) Math.sin(radian * Math.PI) + positionComponent.position().y);
-  }
+  private static final int MAX_ITEM_DROP_RADIUS = 10;
 
   /**
    * Will drop all the items inside the {@link InventoryComponent} of the associated entity on the
-   * floor.
+   * floor. If an item cannot be dropped within a certain radius of the entity, it will be dropped
+   * at the hero's position. If the hero is not present, the item will be dropped at (0, 0).
    *
    * <p>Note: The entity that will use this function needs an {@link InventoryComponent} and a
    * {@link PositionComponent}. A {@link DrawComponent} is optional.
@@ -68,26 +61,12 @@ public final class DropItemsInteraction implements BiConsumer<Entity, Entity> {
         entity
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-    Item[] itemData = inventoryComponent.items();
-    double count = itemData.length;
-    // used for calculation of drop position
-    AtomicInteger index = new AtomicInteger();
-    Arrays.stream(itemData)
-        .forEach(
-            item -> {
-              if (item != null) {
-                if (!item.drop(
-                    calculateDropPosition(positionComponent, index.getAndIncrement() / count))) {
-                  Coordinate randomTile =
-                      LevelUtils.randomAccessibleTileCoordinateInRange(
-                              positionComponent.position(), 1)
-                          .orElseThrow(
-                              () -> new NoTileFoundException("No Tile was found for " + entity));
 
-                  item.drop(randomTile.toPoint());
-                }
-              }
-            });
+    for (Item item : inventoryComponent.items()) {
+      if (item != null && !this.tryDropItem(item, positionComponent)) {
+        this.dropItemAtHeroPosition(item);
+      }
+    }
 
     entity
         .fetch(DrawComponent.class)
@@ -95,5 +74,42 @@ public final class DropItemsInteraction implements BiConsumer<Entity, Entity> {
             x ->
                 x.animation(CoreAnimations.IDLE_RIGHT)
                     .ifPresent(y -> x.queueAnimation(y.duration(), CoreAnimations.IDLE_RIGHT)));
+  }
+
+  /**
+   * Try to drop an item in a random accessible tile in a range of {@link #MAX_ITEM_DROP_RADIUS}
+   * from the entity position.
+   *
+   * @param item The item to drop
+   * @param positionComponent The position component of the entity
+   * @return true if the item was dropped, false otherwise
+   * @see LevelUtils#randomAccessibleTileCoordinateInRange(Point, float)
+   */
+  private boolean tryDropItem(Item item, PositionComponent positionComponent) {
+    for (int i = 1; i <= MAX_ITEM_DROP_RADIUS; i++) {
+      Coordinate randomTile =
+          LevelUtils.randomAccessibleTileCoordinateInRange(positionComponent.position(), i)
+              .orElse(null);
+      if (randomTile != null) {
+        item.drop(randomTile.toPoint());
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Drop the item at the hero position. If the hero is not present, the item will be dropped at (0,
+   * 0).
+   *
+   * @param item The item to drop
+   */
+  private void dropItemAtHeroPosition(Item item) {
+    Point heroPosition =
+        Game.hero()
+            .flatMap(hero -> hero.fetch(PositionComponent.class))
+            .map(PositionComponent::position)
+            .orElseGet(() -> new Point(0, 0));
+    item.drop(heroPosition);
   }
 }


### PR DESCRIPTION
Dieser PR verbessert die Logik von Item-Drops aus Inventaren.

Die Änderungen führen eine robustere Methode zum Finden geeigneter Ablagepositionen ein und implementieren einen Fallback-Mechanismus für Fälle, in denen keine geeignete Position in der Nähe gefunden werden kann.

- **DropItemsInteraction.java**:
  - Einführung einer neuen Konstante `MAX_ITEM_DROP_RADIUS` zur Begrenzung des Suchradius für Ablagepositionen.
  - Implementierung der Methode `tryDropItem()`, die versucht, ein Item in einem zufälligen zugänglichen Feld innerhalb eines bestimmten Radius abzulegen.
  - Neue Methode `dropItemAtHeroPosition()` als Fallback-Lösung.
  - Aktualisierung der `accept()`-Methode zur Verwendung der neuen Logik.
  - Entfernung nicht mehr benötigter Importe und Hilfsmethoden.

Diese Änderungen wurden eingeführt, um das Verhalten von Item-Drops zu verbessern, insbesondere wenn Monster sterben. Die neue Variante ist deutlich robuster und behandelt Szenarien, in denen Monster auf einem Null-Tile oder auf nicht zugänglichen Tiles (wie Wänden oder zukünftig geplanten PITs) sterben.

Durch die Implementierung eines größeren Suchradius und eines Fallback-Mechanismus zur Heldenposition wird sichergestellt, dass Items immer an einer zugänglichen Stelle landen.