### PR TITLE
Dungeon: Add activation state to AI and Spiky components

### DIFF
--- a/dungeon/src/contrib/components/AIComponent.java
+++ b/dungeon/src/contrib/components/AIComponent.java
@@ -33,6 +33,7 @@ public final class AIComponent implements Component {
   private final Consumer<Entity> fightBehavior;
   private final Consumer<Entity> idleBehavior;
   private final Function<Entity, Boolean> shouldFight;
+  private boolean active = true;
 
   /**
    * Create an AIComponent with the given behavior.
@@ -66,7 +67,10 @@ public final class AIComponent implements Component {
    * @return Transition function between idle and fight behavior.
    */
   public Function<Entity, Boolean> shouldFight() {
-    return shouldFight;
+    if (!this.active) {
+      return (entity) -> false;
+    }
+    return this.shouldFight;
   }
 
   /**
@@ -75,7 +79,7 @@ public final class AIComponent implements Component {
    * @return Function that implements the fight behavior.
    */
   public Consumer<Entity> fightBehavior() {
-    return fightBehavior;
+    return this.fightBehavior;
   }
 
   /**
@@ -84,6 +88,27 @@ public final class AIComponent implements Component {
    * @return Function that implements the idle behavior.
    */
   public Consumer<Entity> idleBehavior() {
-    return idleBehavior;
+    if (!this.active) {
+      return (entity) -> {};
+    }
+    return this.idleBehavior;
+  }
+
+  /**
+   * Set the active state of the AI.
+   *
+   * @param active The new active state.
+   */
+  public void active(boolean active) {
+    this.active = active;
+  }
+
+  /**
+   * Get the active state of the AI.
+   *
+   * @return The current active state.
+   */
+  public boolean active() {
+    return this.active;
   }
 }

--- a/dungeon/src/contrib/components/SpikyComponent.java
+++ b/dungeon/src/contrib/components/SpikyComponent.java
@@ -31,9 +31,9 @@ import core.Component;
 public final class SpikyComponent implements Component {
   private final int damageAmount;
   private final DamageType damageType;
-
   private final int coolDown;
   private int currentCoolDown;
+  private boolean active = true;
 
   /**
    * Create a new {@link SpikyComponent}.
@@ -73,7 +73,7 @@ public final class SpikyComponent implements Component {
    * @return true if the cool down is 0, false if not.
    */
   public boolean isActive() {
-    return currentCoolDown == 0;
+    return this.active() && this.currentCoolDown == 0;
   }
 
   /** Set the current cool down to the cool down configured in the constructor. */
@@ -84,5 +84,23 @@ public final class SpikyComponent implements Component {
   /** Reduce the current cool down by one. */
   public void reduceCoolDown() {
     currentCoolDown = Math.max(0, currentCoolDown - 1);
+  }
+
+  /**
+   * Is the spiky component active?
+   *
+   * @return true if the spiky component is active, false if not.
+   */
+  public boolean active() {
+    return this.active;
+  }
+
+  /**
+   * Set the active state of the spiky component.
+   *
+   * @param active The new active state.
+   */
+  public void active(boolean active) {
+    this.active = active;
   }
 }


### PR DESCRIPTION
Dieser PR führt einen Aktivierungszustand für die `AIComponent `und `SpikyComponent` ein, um eine flexiblere Kontrolle über das Verhalten von Entitäten zu ermöglichen.

- **AIComponent.java**:
  - Hinzufügung eines `active` Feldes mit Getter- und Setter-Methoden.
  - Anpassung der `shouldFight()` und `idleBehavior()` Methoden, um den Aktivierungszustand zu berücksichtigen.

- **SpikyComponent.java**:
  - Hinzufügung eines `active` Feldes mit Getter- und Setter-Methoden.
  - Anpassung der `isActive()` Methode, um den neuen Aktivierungszustand zu berücksichtigen.

Diese Änderungen wurden eingeführt, um eine Kontrolle über das Verhalten von Entitäten zu ermöglichen, ohne die Komponenten entfernen zu müssen. Dies kann besonders nützlich sein für temporäre Deaktivierungen, beispielsweise während bestimmter Ereignisse.

Man könnte in Zukunft in Erwägung ziehen, dieses Aktivierungskonzept direkt in das Interface für Komponenten zu integrieren, um eine konsistente Implementierung über alle Komponenten hinweg zu gewährleisten.