### PR TITLE
Dungeon: allow intrinsic duration when enqueuing an animation as next animation (DrawComponent)

### DIFF
--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -176,11 +176,11 @@ public final class DrawComponent implements Component {
   }
 
   /**
-   * Enqueue the first existing animation to be considered as the next animation to be played.
+   * Enqueue the first existing animation in the queue of animations to be played next.
    *
-   * <p>Animations are given as a number of {@link IPath} objects. The first actually existing
-   * animation will be added to the queue. The duration of the animation (i.e. how many frames *
-   * should the animation be displayed) is specified by the given parameter.
+   * <p>Animations to be considered are given as a number of {@link IPath} objects. The first
+   * actually existing animation will be added to the queue. The duration of this animation (i.e.
+   * how many frames should the animation be displayed) is specified by the given parameter.
    *
    * @param forFrames Number of frames the animation is to be displayed for
    * @param next List of potential next animations (represented via <code>IPath</code> objects)
@@ -192,11 +192,12 @@ public final class DrawComponent implements Component {
   }
 
   /**
-   * Enqueue the first existing animation to be considered as the next animation to be played.
+   * Enqueue the first existing animation in the queue of animations to be played next.
    *
-   * <p>Animations are given as a number of {@link IPath} objects. The first actually existing
-   * animation will be added to the queue. The number of steps in this animation is used as the
-   * duration of the animation (i.e. how many frames the animation should be displayed).
+   * <p>Animations to be considered are given as a number of {@link IPath} objects. The first
+   * actually existing animation will be added to the queue. The number of steps in this animation
+   * is used as the duration of the animation (i.e. how many frames the animation should be
+   * displayed).
    *
    * @param next List of potential next animations (represented via <code>IPath</code> objects)
    */
@@ -208,11 +209,13 @@ public final class DrawComponent implements Component {
   }
 
   /**
-   * Enqueue the first existing animation to be considered as the next animation to be played.
+   * Enqueue the first existing animation in the queue of animations to be played next.
    *
-   * <p>Animations are given as a number of {@link IPath} objects. The first actually existing
-   * animation will be added to the queue. The duration of the animation (i.e. how many frames
-   * should the animation be displayed) is specified in the given consumer function.
+   * <p>Animations to be considered are given as a number of {@link IPath} objects. The first
+   * actually existing animation will be added to the queue. The duration of the animation (i.e. how
+   * many frames should the animation be displayed) is specified in the given consumer function.
+   *
+   * <p>This is an internal auxiliary function.
    *
    * @param fn Function to perform the actual enqueuing
    * @param next List of potential next animations (represented via <code>IPath</code> objects)

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -177,19 +177,6 @@ public final class DrawComponent implements Component {
   /**
    * Queue up an Animation to be considered as the next played Animation.
    *
-   * <p>Animations are given as an {@link IPath} Array or multiple variables. Animation length is
-   * set to one frame. If you need to queue longer Animations, use {@link #queueAnimation(int,
-   * IPath...)}. The First existing Animation * will be added to the queue.
-   *
-   * @param next Array of IPaths representing the Animation.
-   */
-  public void queueAnimation(final IPath... next) {
-    queueAnimation(1, next);
-  }
-
-  /**
-   * Queue up an Animation to be considered as the next played Animation.
-   *
    * <p>Animations are given as an {@link IPath} Array or multiple variables. The First existing
    * Animation will be added to the queue. If the Animation is already added, the remaining Frames
    * are set to the highest of remaining or new.
@@ -214,6 +201,21 @@ public final class DrawComponent implements Component {
         return;
       }
     }
+  }
+
+  /**
+   * Queue up an Animation to be considered as the next played Animation.
+   *
+   * <p>Animations are given as an {@link IPath} Array or multiple variables. Animation length is
+   * set to the number of frames given for an animation. If you need to queue longer Animations, use
+   * {@link #queueAnimation(int, IPath...)}. The first existing Animation will be added to the
+   * queue.
+   *
+   * @param next Array of IPaths representing the Animation.
+   */
+  public void queueAnimation(final IPath... next) {
+    Arrays.stream(next)
+        .forEach(path -> animation(path).ifPresent(anim -> queueAnimation(anim.duration(), path)));
   }
 
   /**


### PR DESCRIPTION
Die Methode `queueAnimation` hat eine Überladung, mit der man Animationen in die Warteschlange stellen kann, ohne explizit eine Dauer anzugeben.

Aus irgendeinem (nicht näher erklärten) Grund wurde in diesem Fall die Dauer auf **1 Frame** gesetzt statt auf die intrinsische Dauer der jeweiligen Animation. 

Dieser PR behebt das und nutzt die intrinsische Dauer einer Animation, sofern keine explizite Dauer angegeben wird. Dadurch vereinfacht sich das Handling in `HealthSystem` signifikant.