### PR TITLE
Dungeon: do not modify the entity stream whilst streaming (HealthSystem)

### DIFF
--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -96,7 +96,7 @@ public final class HealthSystem extends System {
     int dmgAmount = Stream.of(DamageType.values()).mapToInt(hsd.hc::calculateDamageOf).sum();
 
     // do the dance
-    doDamageAndAnimation(hsd, dmgAmount);
+    doDamageAndAnimation(hsd.dc, dmgAmount);
 
     // reset all damage objects in health component and apply damage
     hsd.hc.clearDamage();
@@ -106,12 +106,12 @@ public final class HealthSystem extends System {
     return hsd;
   }
 
-  private void doDamageAndAnimation(final HSData hsd, final int dmgAmount) {
+  private void doDamageAndAnimation(final DrawComponent dc, final int dmgAmount) {
     if (dmgAmount > 0) {
-      Optional<Animation> hitAnimation = hsd.dc.animation(AdditionalAnimations.HIT);
+      Optional<Animation> hitAnimation = dc.animation(AdditionalAnimations.HIT);
       // we have some damage - let's show a little dance
       hitAnimation.ifPresent(
-          animation -> hsd.dc.queueAnimation(animation.duration(), AdditionalAnimations.HIT));
+          animation -> dc.queueAnimation(animation.duration(), AdditionalAnimations.HIT));
     }
   }
 

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -33,7 +33,12 @@ public final class HealthSystem extends System {
   public void execute() {
     Map<Boolean, List<HSData>> deadOrAlive =
         filteredEntityStream(HealthComponent.class, DrawComponent.class)
-            .map(this::buildDataObject)
+            .map(
+                e ->
+                    new HSData(
+                        e,
+                        e.fetch(HealthComponent.class).orElseThrow(),
+                        e.fetch(DrawComponent.class).orElseThrow()))
             .collect(Collectors.partitioningBy(hsd -> hsd.hc.isDead()));
 
     // apply damage to all entities which are still alive
@@ -78,13 +83,6 @@ public final class HealthSystem extends System {
     deathAnimation.ifPresent(
         animation -> hsd.dc.queueAnimation(animation.duration(), AdditionalAnimations.DIE));
     return hsd;
-  }
-
-  private HSData buildDataObject(final Entity entity) {
-    return new HSData(
-        entity,
-        entity.fetch(HealthComponent.class).orElseThrow(),
-        entity.fetch(DrawComponent.class).orElseThrow());
   }
 
   private HSData applyDamage(final HSData hsd) {

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -109,9 +109,7 @@ public final class HealthSystem extends System {
   private void doAnimation(final DrawComponent dc, final int dmgAmount) {
     if (dmgAmount > 0) {
       // we have some damage - let's show a little dance
-      dc.animation(AdditionalAnimations.HIT)
-          .ifPresent(
-              animation -> dc.queueAnimation(animation.duration(), AdditionalAnimations.HIT));
+      dc.queueAnimation(AdditionalAnimations.HIT);
     }
   }
 

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -108,10 +108,10 @@ public final class HealthSystem extends System {
 
   private void doAnimation(final DrawComponent dc, final int dmgAmount) {
     if (dmgAmount > 0) {
-      Optional<Animation> hitAnimation = dc.animation(AdditionalAnimations.HIT);
       // we have some damage - let's show a little dance
-      hitAnimation.ifPresent(
-          animation -> dc.queueAnimation(animation.duration(), AdditionalAnimations.HIT));
+      dc.animation(AdditionalAnimations.HIT)
+          .ifPresent(
+              animation -> dc.queueAnimation(animation.duration(), AdditionalAnimations.HIT));
     }
   }
 

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -95,8 +95,14 @@ public final class HealthSystem extends System {
   private HSData applyDamage(final HSData hsd) {
     int dmgAmount = Stream.of(DamageType.values()).mapToInt(hsd.hc::calculateDamageOf).sum();
 
+    // do the dance
     doDamageAndAnimation(hsd, dmgAmount);
 
+    // reset all damage objects in health component and apply damage
+    hsd.hc.clearDamage();
+    hsd.hc.currentHealthpoints(hsd.hc.currentHealthpoints() - dmgAmount);
+
+    // return data object to enable method chaining/streaming
     return hsd;
   }
 
@@ -107,9 +113,6 @@ public final class HealthSystem extends System {
       hitAnimation.ifPresent(
           animation -> hsd.dc.queueAnimation(animation.duration(), AdditionalAnimations.HIT));
     }
-    // reset all damage objects in health component and apply damage
-    hsd.hc.clearDamage();
-    hsd.hc.currentHealthpoints(hsd.hc.currentHealthpoints() - dmgAmount);
   }
 
   private void removeDeadEntities(final HSData hsd) {

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -95,8 +95,8 @@ public final class HealthSystem extends System {
   private HSData applyDamage(final HSData hsd) {
     int dmgAmount = Stream.of(DamageType.values()).mapToInt(hsd.hc::calculateDamageOf).sum();
 
-    // do the dance
-    doAnimation(hsd.dc, dmgAmount);
+    // if we have some damage, let's show a little dance
+    if (dmgAmount > 0) hsd.dc.queueAnimation(AdditionalAnimations.HIT);
 
     // reset all damage objects in health component and apply damage
     hsd.hc.clearDamage();
@@ -104,13 +104,6 @@ public final class HealthSystem extends System {
 
     // return data object to enable method chaining/streaming
     return hsd;
-  }
-
-  private void doAnimation(final DrawComponent dc, final int dmgAmount) {
-    if (dmgAmount > 0) {
-      // we have some damage - let's show a little dance
-      dc.queueAnimation(AdditionalAnimations.HIT);
-    }
   }
 
   private void removeDeadEntities(final HSData hsd) {

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -66,9 +66,9 @@ public final class HealthSystem extends System {
 
   private HSData activateDeathAnimation(final HSData hsd) {
     // set DeathAnimation as active animation
-    Optional<Animation> deathAnimation = hsd.dc.animation(AdditionalAnimations.DIE);
-    deathAnimation.ifPresent(
-        animation -> hsd.dc.queueAnimation(animation.duration(), AdditionalAnimations.DIE));
+    hsd.dc.queueAnimation(AdditionalAnimations.DIE);
+
+    // return data object to enable method chaining/streaming
     return hsd;
   }
 

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -51,6 +51,28 @@ public final class HealthSystem extends System {
         .forEach(this::removeDeadEntities);
   }
 
+  private HSData applyDamage(final HSData hsd) {
+    int dmgAmount = Stream.of(DamageType.values()).mapToInt(hsd.hc::calculateDamageOf).sum();
+
+    // if we have some damage, let's show a little dance
+    if (dmgAmount > 0) hsd.dc.queueAnimation(AdditionalAnimations.HIT);
+
+    // reset all damage objects in health component and apply damage
+    hsd.hc.clearDamage();
+    hsd.hc.currentHealthpoints(hsd.hc.currentHealthpoints() - dmgAmount);
+
+    // return data object to enable method chaining/streaming
+    return hsd;
+  }
+
+  private HSData activateDeathAnimation(final HSData hsd) {
+    // set DeathAnimation as active animation
+    Optional<Animation> deathAnimation = hsd.dc.animation(AdditionalAnimations.DIE);
+    deathAnimation.ifPresent(
+        animation -> hsd.dc.queueAnimation(animation.duration(), AdditionalAnimations.DIE));
+    return hsd;
+  }
+
   /**
    * Tests the existence and current status of the DeathAnimation of an entity.
    *
@@ -75,28 +97,6 @@ public final class HealthSystem extends System {
     return !hasDeathAnimation.test(dc)
         || isAnimationLooping.test(dc)
         || isAnimationFinished.test(dc);
-  }
-
-  private HSData activateDeathAnimation(final HSData hsd) {
-    // set DeathAnimation as active animation
-    Optional<Animation> deathAnimation = hsd.dc.animation(AdditionalAnimations.DIE);
-    deathAnimation.ifPresent(
-        animation -> hsd.dc.queueAnimation(animation.duration(), AdditionalAnimations.DIE));
-    return hsd;
-  }
-
-  private HSData applyDamage(final HSData hsd) {
-    int dmgAmount = Stream.of(DamageType.values()).mapToInt(hsd.hc::calculateDamageOf).sum();
-
-    // if we have some damage, let's show a little dance
-    if (dmgAmount > 0) hsd.dc.queueAnimation(AdditionalAnimations.HIT);
-
-    // reset all damage objects in health component and apply damage
-    hsd.hc.clearDamage();
-    hsd.hc.currentHealthpoints(hsd.hc.currentHealthpoints() - dmgAmount);
-
-    // return data object to enable method chaining/streaming
-    return hsd;
   }
 
   private void removeDeadEntities(final HSData hsd) {

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -7,7 +7,6 @@ import core.Entity;
 import core.Game;
 import core.System;
 import core.components.DrawComponent;
-import core.utils.components.MissingComponentException;
 import core.utils.components.draw.Animation;
 import java.util.List;
 import java.util.Map;
@@ -82,16 +81,10 @@ public final class HealthSystem extends System {
   }
 
   private HSData buildDataObject(final Entity entity) {
-
-    HealthComponent hc =
-        entity
-            .fetch(HealthComponent.class)
-            .orElseThrow(() -> MissingComponentException.build(entity, HealthComponent.class));
-    DrawComponent ac =
-        entity
-            .fetch(DrawComponent.class)
-            .orElseThrow(() -> MissingComponentException.build(entity, DrawComponent.class));
-    return new HSData(entity, hc, ac);
+    return new HSData(
+        entity,
+        entity.fetch(HealthComponent.class).orElseThrow(),
+        entity.fetch(DrawComponent.class).orElseThrow());
   }
 
   private HSData applyDamage(final HSData hsd) {

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -96,7 +96,7 @@ public final class HealthSystem extends System {
     int dmgAmount = Stream.of(DamageType.values()).mapToInt(hsd.hc::calculateDamageOf).sum();
 
     // do the dance
-    doDamageAndAnimation(hsd.dc, dmgAmount);
+    doAnimation(hsd.dc, dmgAmount);
 
     // reset all damage objects in health component and apply damage
     hsd.hc.clearDamage();
@@ -106,7 +106,7 @@ public final class HealthSystem extends System {
     return hsd;
   }
 
-  private void doDamageAndAnimation(final DrawComponent dc, final int dmgAmount) {
+  private void doAnimation(final DrawComponent dc, final int dmgAmount) {
     if (dmgAmount > 0) {
       Optional<Animation> hitAnimation = dc.animation(AdditionalAnimations.HIT);
       // we have some damage - let's show a little dance

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -43,7 +43,7 @@ public final class HealthSystem extends System {
     // handle dead entities
     deadOrAlive.get(true).stream()
         .map(this::activateDeathAnimation)
-        .filter(this::testDeathAnimationStatus)
+        .filter(this::isDeathAnimationFinished)
         .forEach(this::removeDeadEntities);
   }
 
@@ -58,7 +58,7 @@ public final class HealthSystem extends System {
    * @param hsd HSData to check Animations in.
    * @return true if Entity can be removed from the game.
    */
-  private boolean testDeathAnimationStatus(final HSData hsd) {
+  private boolean isDeathAnimationFinished(final HSData hsd) {
     DrawComponent dc = hsd.dc;
     // test if hsd has a DeathAnimation
     Predicate<DrawComponent> hasDeathAnimation =

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -93,9 +93,10 @@ public final class HealthSystem extends System {
   }
 
   private HSData applyDamage(final HSData hsd) {
+    int dmgAmount = Stream.of(DamageType.values()).mapToInt(hsd.hc::calculateDamageOf).sum();
 
-    doDamageAndAnimation(
-        hsd, Stream.of(DamageType.values()).mapToInt(hsd.hc::calculateDamageOf).sum());
+    doDamageAndAnimation(hsd, dmgAmount);
+
     return hsd;
   }
 

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -7,10 +7,8 @@ import core.Entity;
 import core.Game;
 import core.System;
 import core.components.DrawComponent;
-import core.utils.components.draw.Animation;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -31,6 +29,7 @@ public final class HealthSystem extends System {
 
   @Override
   public void execute() {
+    // filter entities for components and partition into alive and dead
     Map<Boolean, List<HSData>> deadOrAlive =
         filteredEntityStream(HealthComponent.class, DrawComponent.class)
             .map(
@@ -85,7 +84,6 @@ public final class HealthSystem extends System {
    * @return true if Entity can be removed from the game.
    */
   private boolean isDeathAnimationFinished(final HSData hsd) {
-    DrawComponent dc = hsd.dc;
     // test if hsd has a DeathAnimation
     Predicate<DrawComponent> hasDeathAnimation =
         (drawComponent) -> drawComponent.hasAnimation(AdditionalAnimations.DIE);
@@ -94,9 +92,9 @@ public final class HealthSystem extends System {
     // test if Animation has finished playing
     Predicate<DrawComponent> isAnimationFinished = DrawComponent::isCurrentAnimationFinished;
 
-    return !hasDeathAnimation.test(dc)
-        || isAnimationLooping.test(dc)
-        || isAnimationFinished.test(dc);
+    return !hasDeathAnimation.test(hsd.dc)
+        || isAnimationLooping.test(hsd.dc)
+        || isAnimationFinished.test(hsd.dc);
   }
 
   private void removeDeadEntities(final HSData hsd) {


### PR DESCRIPTION
Dieser PR behebt das Problem, dass im `HealthSystem` bei der Iteration über den Entity-Stream bereits Entitäten aus dem Game und damit der Basisdatenstruktur für den Stream selbst gelöscht werden. 

Eine Modifikation des Streams in einer Stream-Operation ist i.d.R. nicht zulässig und führt zu undefiniertem Verhalten. Nach dem Mergen dieses PRs wird zunächst über die gefilterten Entitäten iteriert und wie bisher das Datenobjekt gebaut. Danach werden alle Objekte gefiltert, ob die Entität noch lebendig ist oder nicht, und der Stream damit abgeschlossen. Die lebendigen Entitäten werden danach separat behandelt, dito die nicht mehr lebendigen Entitäten. Das Löschen in Game sollte nun gefahrlos sein, weil wir uns nicht mehr in der Iteration der Ursprungsdatenstruktur befinden.


**Erst nach #1580 mergen!** (Die Änderungen an `DrawComponent` sind Teil von #1580.)

~~fixes #1578~~ (#1578 does actually not need fixing, but this will improve readability anyway.) 