### PR TITLE
Gradle: fix ANTLR configuration

### DIFF
--- a/dungeon/build.gradle
+++ b/dungeon/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 }
 
 
-sourceSets.main.java.srcDirs = ['src/', "$projectDir/build/generated-src/antlr/main/"]
+sourceSets.main.java.srcDirs = ['src/', "$projectDir/build/generated-src/"]
 sourceSets.main.resources.srcDirs = ['assets/']
 
 sourceSets.test.java.srcDirs = ['test/']


### PR DESCRIPTION
Im Dungeon-Projekt wurde der Ordner 'build/generated-src/antlr/main/' als zusätzlicher Java-Sourceordner konfiguriert. Das ist für die IDE ein Problem, da der Subpfad 'antlr/main/' das Package darstellt - das (generierte) Package 'antlr.main' kann also nicht gefunden werden.

Dies fällt auf, wenn man in der IDE eine der DSL-Klassen öffnet, die mit dem generierten Parser zusammenhängen - es ist alles "rot".

Dieser PR korrigiert dies und konfiguriert nur den Oberordner 'build/generated-src/' als weiteren Java-Sourceordner. Damit findet die IDE darunter das generierte Package 'antlr/main/'.

Warum ist da bisher noch niemand drüber gestolpert?