### PR TITLE
Dungeon: Add method to check for item type in inventory

### DIFF
--- a/dungeon/src/contrib/components/InventoryComponent.java
+++ b/dungeon/src/contrib/components/InventoryComponent.java
@@ -126,6 +126,19 @@ public final class InventoryComponent implements Component {
   }
 
   /**
+   * Checks if the inventory contains an item of the specified class.
+   *
+   * <p>This method uses Java Streams to iterate over the inventory array and checks if any item is
+   * an instance of the specified class.
+   *
+   * @param klass The class of the item to check for in the inventory.
+   * @return True if the inventory contains an item of the specified class, false otherwise.
+   */
+  public boolean hasItem(final Class<? extends Item> klass) {
+    return Arrays.stream(this.inventory).anyMatch(klass::isInstance);
+  }
+
+  /**
    * Transfer the given item from this inventory to the given inventory.
    *
    * <p>If the given item is not present in this inventory or the other inventory is full, the


### PR DESCRIPTION
Dieser PR führt eine neue Methode in der InventoryComponent-Klasse ein, die es ermöglicht, das Vorhandensein eines bestimmten Item-Typs im Inventar zu überprüfen.

- **InventoryComponent.java**:
  - Hinzufügen der Methode `hasItem(Class<? extends Item> klass)`
    - Überprüft, ob das Inventar ein Item der angegebenen Klasse enthält
    - Rückgabewert ist ein Boolean (true, wenn ein Item des Typs vorhanden ist, sonst false)

Für zukünftige Erweiterungen könnte auch eine Methode in Betracht gezogen werden, die den Index des ersten gefundenen Items des angegebenen Typs zurückgibt. Dies würde die Implementierung von Hotkey-Funktionalitäten für spezifische Item-Typen erleichtern.
