### PR TITLE
Core: Add getter for Entity name

### DIFF
--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -136,7 +136,7 @@ public final class Entity implements Comparable<Entity> {
   }
 
   /**
-   * Get the name of this entity
+   * Get the name of this entity.
    *
    * @return the name of this entity
    */

--- a/game/src/core/Entity.java
+++ b/game/src/core/Entity.java
@@ -135,6 +135,15 @@ public final class Entity implements Comparable<Entity> {
     this.name = name;
   }
 
+  /**
+   * Get the name of this entity
+   *
+   * @return the name of this entity
+   */
+  public String name() {
+    return name;
+  }
+
   @Override
   public String toString() {
     if (name.contains("_" + id)) return name;


### PR DESCRIPTION
Dieser PR fügt einen Getter für den Namen eines Entity hinzu, um die Konsistenz und Vollständigkeit der Entity-Klasse zu verbessern.

* `Entity.java`: Hinzufügen der Methode `name()` diese gibt den Name des Entity zurück

Diese Methode wird später im DevDungeon benötigt um Entities wieder zu finden.