### PR TITLE
Dungeon: Add animation selection by name in DrawComponent

### DIFF
--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -185,9 +185,8 @@ public final class DrawComponent implements Component {
    * @param animationName The name of the animation to set as the current animation.
    */
   public void currentAnimation(final String animationName) {
-    Animation animation = animationMap.get(animationName);
-    if (animation != null) {
-      currentAnimation = animation;
+    if (animationMap.containsKey(animationName)) {
+      currentAnimation = animationMap.get(animationName);
     } else {
       LOGGER.warning(
           "Animation "

--- a/game/src/core/components/DrawComponent.java
+++ b/game/src/core/components/DrawComponent.java
@@ -176,6 +176,27 @@ public final class DrawComponent implements Component {
   }
 
   /**
+   * Sets the current animation displayed on the entity.
+   *
+   * <p>This method attempts to set the current animation to the animation specified by the provided
+   * name. If the animation exists in the animation map, it is set as the current animation. If the
+   * animation does not exist, a warning is logged and the current animation remains unchanged.
+   *
+   * @param animationName The name of the animation to set as the current animation.
+   */
+  public void currentAnimation(final String animationName) {
+    Animation animation = animationMap.get(animationName);
+    if (animation != null) {
+      currentAnimation = animation;
+    } else {
+      LOGGER.warning(
+          "Animation "
+              + animationName
+              + " can not be set, because the given Animation could not be found.");
+    }
+  }
+
+  /**
    * Enqueue the first existing animation in the queue of animations to be played next.
    *
    * <p>Animations to be considered are given as a number of {@link IPath} objects. The first


### PR DESCRIPTION
Dieser PR fügt eine neue Methode zur `DrawComponent` hinzu, die es ermöglicht, Animationen anhand ihres Namens auszuwählen, anstatt den Pfad zu verwenden.

- **DrawComponent.java**:
  - Hinzufügen einer neuen `currentAnimation(String animationName)` Methode
  - Diese Methode ermöglicht es, die aktuelle Animation durch Angabe des Animationsnamens zu setzen

Diese Änderung bietet eine alternative und in manchen Fällen intuitivere Möglichkeit, Animationen auszuwählen. Sie ist besonders nützlich in Kontexten, in denen der Name der Animation bekannt ist, aber nicht unbedingt der vollständige Pfad.
