### PR TITLE
Dungeon: Add Health Event Observer System

### DIFF
--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -63,7 +63,7 @@ public final class HealthSystem extends System {
     hsd.hc.clearDamage();
     hsd.hc.currentHealthpoints(hsd.hc.currentHealthpoints() - dmgAmount);
     observers.forEach(
-        observer -> observer.onHeathEvent(hsd.e, hsd.hc, IHealthObserver.HealthEvent.DAMAGE));
+        observer -> observer.onHealthEvent(hsd.e, hsd.hc, IHealthObserver.HealthEvent.DAMAGE));
 
     // return data object to enable method chaining/streaming
     return hsd;
@@ -132,7 +132,7 @@ public final class HealthSystem extends System {
     // Entity appears to be dead, so let's clean up the mess
     hsd.hc.triggerOnDeath(hsd.e);
     observers.forEach(
-        observer -> observer.onHeathEvent(hsd.e, hsd.hc, IHealthObserver.HealthEvent.DEATH));
+        observer -> observer.onHealthEvent(hsd.e, hsd.hc, IHealthObserver.HealthEvent.DEATH));
 
     Game.remove(hsd.e);
   }

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -62,8 +62,7 @@ public final class HealthSystem extends System {
     // reset all damage objects in health component and apply damage
     hsd.hc.clearDamage();
     hsd.hc.currentHealthpoints(hsd.hc.currentHealthpoints() - dmgAmount);
-    observers.forEach(
-        observer -> observer.onHealthEvent(hsd.e, hsd.hc, IHealthObserver.HealthEvent.DAMAGE));
+    observers.forEach(observer -> observer.onHealthEvent(hsd, IHealthObserver.HealthEvent.DAMAGE));
 
     // return data object to enable method chaining/streaming
     return hsd;
@@ -131,12 +130,17 @@ public final class HealthSystem extends System {
   private void removeDeadEntities(final HSData hsd) {
     // Entity appears to be dead, so let's clean up the mess
     hsd.hc.triggerOnDeath(hsd.e);
-    observers.forEach(
-        observer -> observer.onHealthEvent(hsd.e, hsd.hc, IHealthObserver.HealthEvent.DEATH));
+    observers.forEach(observer -> observer.onHealthEvent(hsd, IHealthObserver.HealthEvent.DEATH));
 
     Game.remove(hsd.e);
   }
 
-  // private record to hold all data during streaming
-  private record HSData(Entity e, HealthComponent hc, DrawComponent dc) {}
+  /**
+   * Record class to store the data of an entity with HealthComponent and DrawComponent.
+   *
+   * @param e The entity that owns the components
+   * @param hc The HealthComponent of the entity
+   * @param dc The DrawComponent of the entity
+   */
+  public record HSData(Entity e, HealthComponent hc, DrawComponent dc) {}
 }

--- a/dungeon/src/contrib/utils/components/health/IHealthObserver.java
+++ b/dungeon/src/contrib/utils/components/health/IHealthObserver.java
@@ -21,7 +21,7 @@ public interface IHealthObserver {
    * @param healthComponent The health component of the entity.
    * @param healthEvent The type of health event (DAMAGE or DEATH).
    */
-  void onHeathEvent(Entity entity, HealthComponent healthComponent, HealthEvent healthEvent);
+  void onHealthEvent(Entity entity, HealthComponent healthComponent, HealthEvent healthEvent);
 
   /**
    * HealthEvent is an enumeration that represents the type of health event.

--- a/dungeon/src/contrib/utils/components/health/IHealthObserver.java
+++ b/dungeon/src/contrib/utils/components/health/IHealthObserver.java
@@ -1,0 +1,42 @@
+package contrib.utils.components.health;
+
+import contrib.components.HealthComponent;
+import core.Entity;
+
+/**
+ * This interface is specifically designed to observe health events in the game. It defines a single
+ * method, onHealthEvent, which is called to notify the observer of health-related changes in the
+ * entity it is observing.
+ *
+ * <p>It is used by the {@link contrib.systems.HealthSystem HealthSystem} to notify observers of
+ * health events.
+ *
+ * @see HealthEvent
+ */
+public interface IHealthObserver {
+  /**
+   * Called to notify the observer of health-related changes in the entity it is observing.
+   *
+   * @param entity The entity that the health event is related to.
+   * @param healthComponent The health component of the entity.
+   * @param healthEvent The type of health event (DAMAGE or DEATH).
+   */
+  void onHeathEvent(Entity entity, HealthComponent healthComponent, HealthEvent healthEvent);
+
+  /**
+   * HealthEvent is an enumeration that represents the type of health event.
+   *
+   * <p>It has the following values:
+   *
+   * <ul>
+   *   <li>DAMAGE: Represents a damage event.
+   *   <li>DEATH: Represents a death event.
+   * </ul>
+   */
+  enum HealthEvent {
+    /** Represents a damage event. */
+    DAMAGE,
+    /** Represents a death event. */
+    DEATH
+  }
+}

--- a/dungeon/src/contrib/utils/components/health/IHealthObserver.java
+++ b/dungeon/src/contrib/utils/components/health/IHealthObserver.java
@@ -1,7 +1,6 @@
 package contrib.utils.components.health;
 
-import contrib.components.HealthComponent;
-import core.Entity;
+import contrib.systems.HealthSystem;
 
 /**
  * This interface is specifically designed to observe health events in the game. It defines a single
@@ -17,11 +16,10 @@ public interface IHealthObserver {
   /**
    * Called to notify the observer of health-related changes in the entity it is observing.
    *
-   * @param entity The entity that the health event is related to.
-   * @param healthComponent The health component of the entity.
+   * @param hsData The data of the entity with HealthComponent and DrawComponent.
    * @param healthEvent The type of health event (DAMAGE or DEATH).
    */
-  void onHealthEvent(Entity entity, HealthComponent healthComponent, HealthEvent healthEvent);
+  void onHealthEvent(HealthSystem.HSData hsData, HealthEvent healthEvent);
 
   /**
    * HealthEvent is an enumeration that represents the type of health event.


### PR DESCRIPTION
Dieser PR führt ein Observer-System für Gesundheitsereignisse ein, das es ermöglicht, auf Treffer- und Todesereignisse zu reagieren und entsprechende Methoden auszuführen.

- **HealthSystem.java**:
  - Implementierung einer Liste von IHealthObserver-Objekten
  - Hinzufügen von Methoden zum Registrieren und Entfernen von Observern
  - Benachrichtigung der Observer bei Schadens- und Todesereignissen
  - HSData wurde auf public angepasst sodass es vom Interface verwendet werden kann

- **IHealthObserver.java**:
  - Definition des IHealthObserver-Interfaces mit der Methode onHealthEvent
  - Einführung des HealthEvent-Enums für DAMAGE und DEATH Ereignisse
