### PR TITLE
Dungeon: Add stayInFightMode to RangeTransition and ISkillUser interface for dynamic skill assignment

### DIFF
--- a/dungeon/src/contrib/utils/components/ai/fight/MeleeAI.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/MeleeAI.java
@@ -2,6 +2,7 @@ package contrib.utils.components.ai.fight;
 
 import com.badlogic.gdx.ai.pfa.GraphPath;
 import contrib.utils.components.ai.AIUtils;
+import contrib.utils.components.skill.ISkillUser;
 import contrib.utils.components.skill.Skill;
 import core.Entity;
 import core.Game;
@@ -12,11 +13,13 @@ import java.util.function.Consumer;
 /**
  * Implements a fight AI. The entity attacks the player if he is in a given range. When the entity
  * is not in range but in fight mode, the entity will be moving to ward the player.
+ *
+ * @see ISkillUser
  */
-public class MeleeAI implements Consumer<Entity> {
+public class MeleeAI implements Consumer<Entity>, ISkillUser {
   private final float attackRange;
   private final int delay = Game.frameRate();
-  private final Skill fightSkill;
+  private Skill fightSkill;
   private int timeSinceLastUpdate = 0;
   private GraphPath<Tile> path;
 
@@ -34,7 +37,7 @@ public class MeleeAI implements Consumer<Entity> {
   @Override
   public void accept(final Entity entity) {
     if (LevelUtils.playerInRange(entity, attackRange)) {
-      fightSkill.execute(entity);
+      useSkill(fightSkill, entity);
     } else {
       if (path == null || timeSinceLastUpdate >= delay) {
         path = LevelUtils.calculatePathToHero(entity);
@@ -43,5 +46,23 @@ public class MeleeAI implements Consumer<Entity> {
       timeSinceLastUpdate++;
       AIUtils.move(entity, path);
     }
+  }
+
+  @Override
+  public void useSkill(Skill fightSkill, Entity skillUser) {
+    if (fightSkill == null) {
+      return;
+    }
+    fightSkill.execute(skillUser);
+  }
+
+  @Override
+  public Skill getSkill() {
+    return fightSkill;
+  }
+
+  @Override
+  public void setSkill(Skill skill) {
+    this.fightSkill = skill;
   }
 }

--- a/dungeon/src/contrib/utils/components/ai/fight/MeleeAI.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/MeleeAI.java
@@ -57,12 +57,12 @@ public class MeleeAI implements Consumer<Entity>, ISkillUser {
   }
 
   @Override
-  public Skill getSkill() {
+  public Skill skill() {
     return fightSkill;
   }
 
   @Override
-  public void setSkill(Skill skill) {
+  public void skill(Skill skill) {
     this.fightSkill = skill;
   }
 }

--- a/dungeon/src/contrib/utils/components/ai/fight/RangeAI.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/RangeAI.java
@@ -4,6 +4,7 @@ import static core.level.utils.LevelUtils.accessibleTilesInRange;
 
 import com.badlogic.gdx.ai.pfa.GraphPath;
 import contrib.utils.components.ai.AIUtils;
+import contrib.utils.components.skill.ISkillUser;
 import contrib.utils.components.skill.Skill;
 import core.Entity;
 import core.Game;
@@ -17,12 +18,14 @@ import java.util.function.Consumer;
  * Implements a fight AI. The entity attacks the player if he is in a given maximum and minimum
  * range. When the entity is not in range but in fight mode, the entity will be moving to within
  * this range.
+ *
+ * @see ISkillUser
  */
-public final class RangeAI implements Consumer<Entity> {
+public final class RangeAI implements Consumer<Entity>, ISkillUser {
 
   private final float attackRange;
   private final float distance;
-  private final Skill skill;
+  private Skill skill;
   private GraphPath<Tile> path;
 
   /**
@@ -67,11 +70,29 @@ public final class RangeAI implements Consumer<Entity> {
         }
         AIUtils.move(entity, path);
       } else {
-        skill.execute(entity);
+        useSkill(skill, entity);
       }
     } else {
       path = LevelUtils.calculatePathToHero(entity);
       AIUtils.move(entity, path);
     }
+  }
+
+  @Override
+  public void useSkill(Skill skill, Entity skillUser) {
+    if (skill == null) {
+      return;
+    }
+    skill.execute(skillUser);
+  }
+
+  @Override
+  public Skill getSkill() {
+    return this.skill;
+  }
+
+  @Override
+  public void setSkill(Skill skill) {
+    this.skill = skill;
   }
 }

--- a/dungeon/src/contrib/utils/components/ai/fight/RangeAI.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/RangeAI.java
@@ -87,12 +87,12 @@ public final class RangeAI implements Consumer<Entity>, ISkillUser {
   }
 
   @Override
-  public Skill getSkill() {
+  public Skill skill() {
     return this.skill;
   }
 
   @Override
-  public void setSkill(Skill skill) {
+  public void skill(Skill skill) {
     this.skill = skill;
   }
 }

--- a/dungeon/src/contrib/utils/components/ai/transition/RangeTransition.java
+++ b/dungeon/src/contrib/utils/components/ai/transition/RangeTransition.java
@@ -11,6 +11,20 @@ import java.util.function.Function;
 public final class RangeTransition implements Function<Entity, Boolean> {
 
   private final float range;
+  private final boolean stayInFightMode;
+  private boolean hasBeenInFightMode = false;
+
+  /**
+   * Switches to combat mode when the player is within range of the entity.
+   *
+   * @param range Range of the entity.
+   * @param stayInFightMode Whether the entity should stay in fight mode after the player has left
+   *     the range.
+   */
+  public RangeTransition(float range, boolean stayInFightMode) {
+    this.range = range;
+    this.stayInFightMode = stayInFightMode;
+  }
 
   /**
    * Switches to combat mode when the player is within range of the entity.
@@ -18,11 +32,17 @@ public final class RangeTransition implements Function<Entity, Boolean> {
    * @param range Range of the entity.
    */
   public RangeTransition(float range) {
-    this.range = range;
+    this(range, false);
   }
 
   @Override
   public Boolean apply(final Entity entity) {
-    return LevelUtils.playerInRange(entity, range);
+    if (LevelUtils.playerInRange(entity, range)) {
+      hasBeenInFightMode = true;
+      return true;
+    } else {
+      return stayInFightMode
+          && hasBeenInFightMode; // Stay in fight mode if player has been in range
+    }
   }
 }

--- a/dungeon/src/contrib/utils/components/skill/ISkillUser.java
+++ b/dungeon/src/contrib/utils/components/skill/ISkillUser.java
@@ -1,0 +1,35 @@
+package contrib.utils.components.skill;
+
+import core.Entity;
+
+/**
+ * Interface for skill users. It defines methods to use a skill and to get and set a skill.
+ *
+ * <p>It is used by the {@link contrib.utils.components.ai.fight.MeleeAI MeleeAI} and {@link
+ * contrib.utils.components.ai.fight.RangeAI RangeAI} classes to use a skill when an attack is
+ * performed.
+ */
+public interface ISkillUser {
+
+  /**
+   * Uses the skill of the skill user.
+   *
+   * @param skill The skill to be used.
+   * @param skillUser The entity that uses the skill.
+   */
+  void useSkill(Skill skill, Entity skillUser);
+
+  /**
+   * Gets the skill of the skill user.
+   *
+   * @return The skill of the skill user.
+   */
+  Skill getSkill();
+
+  /**
+   * Sets the skill of the skill user.
+   *
+   * @param skill The skill to be set.
+   */
+  void setSkill(Skill skill);
+}

--- a/dungeon/src/contrib/utils/components/skill/ISkillUser.java
+++ b/dungeon/src/contrib/utils/components/skill/ISkillUser.java
@@ -24,12 +24,12 @@ public interface ISkillUser {
    *
    * @return The skill of the skill user.
    */
-  Skill getSkill();
+  Skill skill();
 
   /**
    * Sets the skill of the skill user.
    *
    * @param skill The skill to be set.
    */
-  void setSkill(Skill skill);
+  void skill(Skill skill);
 }


### PR DESCRIPTION
Dieser PR bringt zwei Änderungen mit sich, der die Anpassungsfähigkeit von AIs verbessert. Einmal der `stayInFightMode` Boolean-Parameter für die `RangeTransition`-AI, der es der AI ermöglicht, im Kampfmodus zu bleiben, auch wenn der Held wegrennt. Und ein neues Interface `ISkillUser`, das es ermöglicht, die Skills von `RangeAI` und `MeleeAI` nachträglich zu ändern.

- **MeleeAI.java** & **RangeAI.java**:
  - Interface `ISkillUser` hinzugefügt und implementiert.
  - Anpassung der Skill-Nutzung zur Verwendung der `useSkill` Methode.

- **RangeTransition.java**:
  - Hinzufügen des `stayInFightMode` Boolean-Parameters zu einen neuen Konstruktor.
  - Der bestehende Konstruktor setzt den Wert standardgemäß auf `false`.
  - Implementierung der Logik, die die AI im Kampfmodus hält, wenn der Spieler zuvor in Reichweite war.
  
- **ISkillUser.java**:
  - Das neues Interface für Skill-User erstellt.
  - Methoden zum Verwenden, Abrufen und Setzen von Skills definiert.
