### PR TITLE
Dungeon: clear mouse movement pathfinding upon manual movement (bug fix)

### DIFF
--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -285,6 +285,10 @@ public final class HeroFactory {
           if (direction.y != 0) {
             vc.currentYVelocity(direction.y * vc.yVelocity());
           }
+          // Abort any path finding on own movement
+          if (ENABLE_MOUSE_MOVEMENT) {
+            entity.fetch(PathComponent.class).ifPresent(PathComponent::clear);
+          }
         });
   }
 


### PR DESCRIPTION
Ich habe einen Bug behoben, bei dem das Mausmovement-Pathfinding nicht gecleart wurde, wenn man sich manuell bewegt hat. Dies führte dazu, dass man, wenn man sich nicht zum letzten Path-Node bewegt hat, vom Pathfinding wieder weggesteuert wurde.

- **HeroFactory.java**:
  - Path wird vom `PathComponent` gelöscht wenn man sich bewegt.
