### PR TITLE
Dungeon: Adjust HealthBarSystem to show health bar only when entity is visible

### DIFF
--- a/dungeon/src/contrib/systems/HealthBarSystem.java
+++ b/dungeon/src/contrib/systems/HealthBarSystem.java
@@ -90,9 +90,9 @@ public final class HealthBarSystem extends System {
 
   private EnemyData buildDataObject(final Entity entity) {
     return new EnemyData(
+        entity.fetch(DrawComponent.class).orElseThrow(),
         entity.fetch(HealthComponent.class).orElseThrow(),
         entity.fetch(PositionComponent.class).orElseThrow(),
-        entity.fetch(DrawComponent.class).orElseThrow(),
         healthBarMapping.get(entity.id()));
   }
 

--- a/dungeon/src/contrib/systems/HealthBarSystem.java
+++ b/dungeon/src/contrib/systems/HealthBarSystem.java
@@ -73,7 +73,7 @@ public final class HealthBarSystem extends System {
 
   @Override
   public void execute() {
-    filteredEntityStream(HealthComponent.class, PositionComponent.class)
+    filteredEntityStream(DrawComponent.class, HealthComponent.class, PositionComponent.class)
         .map(this::buildDataObject)
         .forEach(this::update);
   }

--- a/dungeon/src/contrib/systems/HealthBarSystem.java
+++ b/dungeon/src/contrib/systems/HealthBarSystem.java
@@ -11,6 +11,7 @@ import contrib.components.UIComponent;
 import core.Entity;
 import core.Game;
 import core.System;
+import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.systems.CameraSystem;
 import core.utils.Point;
@@ -78,9 +79,9 @@ public final class HealthBarSystem extends System {
   }
 
   private void update(final EnemyData ed) {
-    if (ed.hc.currentHealthpoints() <= 0) ed.pb.remove();
-    // set visible only if entity lost health
-    ed.pb.setVisible(ed.hc.currentHealthpoints() != ed.hc.maximalHealthpoints());
+    // set visible only if entity lost health and if entity is visible
+    ed.pb.setVisible(
+        ed.dc.isVisible() && ed.hc.currentHealthpoints() != ed.hc.maximalHealthpoints());
     updatePosition(ed.pb, ed.pc);
 
     // set value to health percent
@@ -91,6 +92,7 @@ public final class HealthBarSystem extends System {
     return new EnemyData(
         entity.fetch(HealthComponent.class).orElseThrow(),
         entity.fetch(PositionComponent.class).orElseThrow(),
+        entity.fetch(DrawComponent.class).orElseThrow(),
         healthBarMapping.get(entity.id()));
   }
 
@@ -123,5 +125,6 @@ public final class HealthBarSystem extends System {
     pb.setPosition(screenPosition.x, screenPosition.y);
   }
 
-  private record EnemyData(HealthComponent hc, PositionComponent pc, ProgressBar pb) {}
+  private record EnemyData(
+      HealthComponent hc, PositionComponent pc, DrawComponent dc, ProgressBar pb) {}
 }

--- a/dungeon/src/contrib/systems/HealthBarSystem.java
+++ b/dungeon/src/contrib/systems/HealthBarSystem.java
@@ -73,9 +73,7 @@ public final class HealthBarSystem extends System {
 
   @Override
   public void execute() {
-    filteredEntityStream(DrawComponent.class, HealthComponent.class, PositionComponent.class)
-        .map(this::buildDataObject)
-        .forEach(this::update);
+    filteredEntityStream().map(this::buildDataObject).forEach(this::update);
   }
 
   private void update(final EnemyData ed) {

--- a/dungeon/src/contrib/systems/HealthBarSystem.java
+++ b/dungeon/src/contrib/systems/HealthBarSystem.java
@@ -47,7 +47,7 @@ public final class HealthBarSystem extends System {
 
   /** Create a new HealthBarSystem. */
   public HealthBarSystem() {
-    super(HealthComponent.class, PositionComponent.class);
+    super(DrawComponent.class, HealthComponent.class, PositionComponent.class);
     this.onEntityAdd =
         (x) -> {
           LOGGER.log(CustomLogLevel.TRACE, "HealthBarSystem got send a new Entity");
@@ -126,5 +126,5 @@ public final class HealthBarSystem extends System {
   }
 
   private record EnemyData(
-      HealthComponent hc, PositionComponent pc, DrawComponent dc, ProgressBar pb) {}
+      DrawComponent dc, HealthComponent hc, PositionComponent pc, ProgressBar pb) {}
 }

--- a/dungeon/src/contrib/systems/HealthBarSystem.java
+++ b/dungeon/src/contrib/systems/HealthBarSystem.java
@@ -73,7 +73,9 @@ public final class HealthBarSystem extends System {
 
   @Override
   public void execute() {
-    filteredEntityStream().map(this::buildDataObject).forEach(this::update);
+    filteredEntityStream(DrawComponent.class, HealthComponent.class, PositionComponent.class)
+        .map(this::buildDataObject)
+        .forEach(this::update);
   }
 
   private void update(final EnemyData ed) {


### PR DESCRIPTION
Ich habe das System so angepasst, dass die HealthBar nur sichtbar ist, wenn das Entity auch sichtbar ist. Zusätzlich habe ich den überflüssigen `remove`-Aufruf entfernt, der ausgeführt wurde, wenn die HP 0 oder weniger sind, da bereits oben `this.onEntityRemove = (x) -> healthBarMapping.remove(x.id()).remove();` gesetzt wird, sodass es schon gelöscht wird wenn das Entity gelöscht wird.

- **HealthBarSystem.java**:
  - Hinzufügen einer Abfrage, um die Sichtbarkeit der HealthBar nur dann zu setzen, wenn die Entität sichtbar ist und Gesundheitspunkte verloren hat.
  - Entfernen des überflüssigen `remove`-Aufrufs.
  - Hinzufügen des `DrawComponent` zu `EnemyData` für die Sichtbarkeitsprüfung.
