### PR TITLE
Dungeon: Refactor AIUtils to Simplify Path Check Logic and Fix Index Error

### DIFF
--- a/dungeon/src/contrib/utils/components/ai/AIUtils.java
+++ b/dungeon/src/contrib/utils/components/ai/AIUtils.java
@@ -69,22 +69,7 @@ public final class AIUtils {
    * @return true if the entity is on the end of the path or has left the path, otherwise false.
    */
   public static boolean pathFinishedOrLeft(final Entity entity, final GraphPath<Tile> path) {
-    PositionComponent pc =
-        entity
-            .fetch(PositionComponent.class)
-            .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-    boolean finished = LevelUtils.lastTile(path).equals(Game.tileAT(pc.position()));
-
-    boolean onPath = false;
-    Tile currentTile = Game.tileAT(pc.position());
-    for (Tile tile : path) {
-      if (currentTile == tile) {
-        onPath = true;
-        break;
-      }
-    }
-
-    return !onPath || finished;
+    return pathFinished(entity, path) || pathLeft(entity, path);
   }
 
   /**
@@ -99,7 +84,7 @@ public final class AIUtils {
         entity
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-    return LevelUtils.lastTile(path).equals(Game.tileAT(pc.position()));
+    return path.getCount() == 0 || LevelUtils.lastTile(path).equals(Game.tileAT(pc.position()));
   }
 
   /**


### PR DESCRIPTION
Ich habe AIUtils refactored, sodass `pathFinishedOrLeft` die vorhandenen Methoden verwendet, anstatt die Logik doppelt zu schreiben. Zusätzlich habe ich `pathFinished` gefixt, damit es auch wahr ist, wenn der Pfad leer ist. Zuvor gab es einen Indexfehler, wenn z.B. der Held an einer Position stand wo man nicht hin kann.

### Änderungen
- **AIUtils.java**:
  - Refactoren der Methode `pathFinishedOrLeft`, um die Methoden `pathFinished` und `pathLeft` zu verwenden.
  - Fix für `pathFinished`, damit es auch dann wahr zurückgibt, wenn der Pfad leer ist.
