### PR TITLE
Dungeon: allow to shuffle quiz answers

### DIFF
--- a/dungeon/src/task/tasktype/Quiz.java
+++ b/dungeon/src/task/tasktype/Quiz.java
@@ -3,10 +3,7 @@ package task.tasktype;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import dsl.annotation.DSLType;
 import dsl.annotation.DSLTypeMember;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import task.Task;
 import task.TaskContent;
 import task.game.hud.QuizUI;
@@ -118,6 +115,22 @@ public abstract class Quiz extends Task {
       }
     }
     return added;
+  }
+
+  /**
+   * Shuffle the order of the answers.
+   *
+   * <p>Shuffles the order of the answers in the content list. The correct answer will be shuffled
+   * with the other answers. The indices of the correct answers will be updated accordingly.
+   */
+  public void shuffleAnswers() {
+    List<TaskContent> answers = new ArrayList<>(content);
+    TaskContent correctAnswer = contentByIndex(correctAnswerIndices.iterator().next());
+    Collections.shuffle(answers);
+    content.clear();
+    answers.forEach(this::addContent);
+    correctAnswerIndices.clear();
+    correctAnswerIndices.add(answers.indexOf(correctAnswer));
   }
 
   /**


### PR DESCRIPTION
Ich habe eine Methode hinzugefügt, die die Reihenfolge der Antwortmöglichkeiten in einem Quiz zufällig verändert. Dadurch kann man nicht einfach die gleiche Position anklicken, sondern muss sich den Inhalt merken. Die Indizes der korrekten Antworten werden entsprechend angepasst.

- **Quiz.java**:
  - Hinzufügen der Methode `shuffleAnswers`, um die Reihenfolge der Antworten zufällig zu verändern und die Indizes der korrekten Antworten zu aktualisieren.

Diese Änderungen wurden vorgenommen, um sicherzustellen, dass die Teilnehmer eines Quizzes sich die Inhalte der Antworten merken müssen, anstatt einfach eine feste Position anzuklicken. Jedoch muss die neue Methode vorher aufgerufen werden, falls man die Reihenfolge zufällig verändern will.