### PR TITLE
Dungeon: add weighted random selection to ItemGenerator

### DIFF
--- a/dungeon/src/contrib/entities/MiscFactory.java
+++ b/dungeon/src/contrib/entities/MiscFactory.java
@@ -31,6 +31,14 @@ public final class MiscFactory {
   private static final int MIN_AMOUNT_OF_ITEMS_ON_RANDOM = 1;
 
   /**
+   * The {@link ItemGenerator} used to generate random items for chests.
+   *
+   * @see ItemGenerator
+   * @see ItemGenerator#defaultItemGenerator()
+   */
+  public static ItemGenerator randomItemGenerator = ItemGenerator.defaultItemGenerator();
+
+  /**
    * This method is used to create a new chest entity. The chest will be filled with random items.
    *
    * <p>The Entity is not added to the game yet.
@@ -76,7 +84,7 @@ public final class MiscFactory {
 
   private static Set<Item> generateRandomItems(int min, int max) {
     return IntStream.range(0, RANDOM.nextInt(min, max))
-        .mapToObj(i -> ItemGenerator.generateItemData())
+        .mapToObj(i -> randomItemGenerator.generateItemData())
         .collect(Collectors.toSet());
   }
 

--- a/dungeon/src/contrib/entities/MiscFactory.java
+++ b/dungeon/src/contrib/entities/MiscFactory.java
@@ -36,7 +36,7 @@ public final class MiscFactory {
    * @see ItemGenerator
    * @see ItemGenerator#defaultItemGenerator()
    */
-  public static ItemGenerator randomItemGenerator = ItemGenerator.defaultItemGenerator();
+  private static ItemGenerator randomItemGenerator = ItemGenerator.defaultItemGenerator();
 
   /**
    * This method is used to create a new chest entity. The chest will be filled with random items.
@@ -86,6 +86,28 @@ public final class MiscFactory {
     return IntStream.range(0, RANDOM.nextInt(min, max))
         .mapToObj(i -> randomItemGenerator.generateItemData())
         .collect(Collectors.toSet());
+  }
+
+  /**
+   * Sets the ItemGenerator used to generate random items for monsters upon death.
+   *
+   * @param randomItemGenerator The ItemGenerator to use for generating random items.
+   * @see ItemGenerator
+   */
+  public static void randomItemGenerator(ItemGenerator randomItemGenerator) {
+    MiscFactory.randomItemGenerator = randomItemGenerator;
+  }
+
+  /**
+   * Gets the ItemGenerator used to generate random items for randomly filled chests.
+   *
+   * <p>The default ItemGenerator is {@link ItemGenerator#defaultItemGenerator()}.
+   *
+   * @return The current ItemGenerator used for generating random items.
+   * @see ItemGenerator
+   */
+  public static ItemGenerator randomItemGenerator() {
+    return randomItemGenerator;
   }
 
   /**

--- a/dungeon/src/contrib/entities/MonsterFactory.java
+++ b/dungeon/src/contrib/entities/MonsterFactory.java
@@ -50,13 +50,7 @@ public final class MonsterFactory {
   private static final int MONSTER_COLLIDE_COOL_DOWN = 2 * Game.frameRate();
   private static final int MAX_DISTANCE_FOR_DEATH_SOUND = 15;
 
-  /**
-   * The {@link ItemGenerator} used to generate random items for monsters upon death.
-   *
-   * @see ItemGenerator
-   * @see ItemGenerator#defaultItemGenerator()
-   */
-  public static ItemGenerator randomItemGenerator = ItemGenerator.defaultItemGenerator();
+  private static ItemGenerator randomItemGenerator = ItemGenerator.defaultItemGenerator();
 
   /**
    * Get an Entity that can be used as a monster.
@@ -103,6 +97,28 @@ public final class MonsterFactory {
         MONSTER_COLLIDE_DAMAGE,
         MONSTER_COLLIDE_COOL_DOWN,
         randomMonsterIdleSound());
+  }
+
+  /**
+   * Sets the ItemGenerator used to generate random items for monsters upon death.
+   *
+   * @param randomItemGenerator The ItemGenerator to use for generating random items.
+   * @see ItemGenerator
+   */
+  public static void randomItemGenerator(ItemGenerator randomItemGenerator) {
+    MonsterFactory.randomItemGenerator = randomItemGenerator;
+  }
+
+  /**
+   * Gets the ItemGenerator used to generate random items for monsters upon death.
+   *
+   * <p>The default ItemGenerator is {@link ItemGenerator#defaultItemGenerator()}.
+   *
+   * @return The current ItemGenerator used for generating random items.
+   * @see ItemGenerator
+   */
+  public static ItemGenerator randomItemGenerator() {
+    return randomItemGenerator;
   }
 
   private static Sound randomMonsterDeathSound() {

--- a/dungeon/src/contrib/entities/MonsterFactory.java
+++ b/dungeon/src/contrib/entities/MonsterFactory.java
@@ -51,6 +51,14 @@ public final class MonsterFactory {
   private static final int MAX_DISTANCE_FOR_DEATH_SOUND = 15;
 
   /**
+   * The {@link ItemGenerator} used to generate random items for monsters upon death.
+   *
+   * @see ItemGenerator
+   * @see ItemGenerator#defaultItemGenerator()
+   */
+  public static ItemGenerator randomItemGenerator = ItemGenerator.defaultItemGenerator();
+
+  /**
    * Get an Entity that can be used as a monster.
    *
    * <p>The Entity is not added to the game yet.
@@ -165,7 +173,7 @@ public final class MonsterFactory {
     monster.add(ic);
     // rolls a dice for item chance (itemChance == 0  no item, 1.0 always)
     if (RANDOM.nextFloat() < itemChance) {
-      Item item = ItemGenerator.generateItemData();
+      Item item = randomItemGenerator.generateItemData();
       ic.add(item);
     }
     BiConsumer<Entity, Entity> onDeath =

--- a/dungeon/src/contrib/item/HealthPotionType.java
+++ b/dungeon/src/contrib/item/HealthPotionType.java
@@ -53,17 +53,9 @@ public enum HealthPotionType {
    * @return A randomly selected health potion type
    */
   public static HealthPotionType randomType() {
-    HealthPotionType[] types = HealthPotionType.values();
-    float[] chances = {0.75f, 0.20f, 0.05f}; // 75%, 20%, 5%
     float randomValue = Item.RANDOM.nextFloat();
-
-    for (int i = 0; i < chances.length; i++) {
-      if (randomValue < chances[i]) {
-        return types[i];
-      }
-      randomValue -= chances[i];
-    }
-
-    return types[types.length - 1];
+    if (randomValue < 0.75f) return WEAK;
+    if (randomValue < 0.95f) return NORMAL;
+    return GREATER;
   }
 }

--- a/dungeon/src/contrib/item/HealthPotionType.java
+++ b/dungeon/src/contrib/item/HealthPotionType.java
@@ -40,4 +40,30 @@ public enum HealthPotionType {
     String name = this.name();
     return name.substring(0, 1).toUpperCase() + name.substring(1).toLowerCase();
   }
+
+  /**
+   * Generates a random health potion type based on the following weights.
+   *
+   * <ul>
+   *   <li>75%: HealthPotionType.WEAK
+   *   <li>20%: HealthPotionType.NORMAL
+   *   <li>5%: HealthPotionType.GREATER
+   * </ul>
+   *
+   * @return A randomly selected health potion type
+   */
+  public static HealthPotionType randomType() {
+    HealthPotionType[] types = HealthPotionType.values();
+    float[] chances = {0.75f, 0.20f, 0.05f}; // 75%, 20%, 5%
+    float randomValue = Item.RANDOM.nextFloat();
+
+    for (int i = 0; i < chances.length; i++) {
+      if (randomValue < chances[i]) {
+        return types[i];
+      }
+      randomValue -= chances[i];
+    }
+
+    return types[types.length - 1];
+  }
 }

--- a/dungeon/src/contrib/item/Item.java
+++ b/dungeon/src/contrib/item/Item.java
@@ -144,16 +144,16 @@ public class Item implements CraftingIngredient, CraftingResult {
   }
 
   /**
-   * Get all registered items.
+   * Get a copy of the registered items.
    *
-   * <p>This method is used to get all registered items. It returns a map where the keys are the
+   * <p>This method is used a copy of all registered items. It returns a map where the keys are the
    * simple names of the classes (e.g. {@link ItemResourceBerry}), and the values are the
    * corresponding class objects.
    *
-   * @return A map of all registered items.
+   * @return A copy of the registered items.
    */
   public static Map<String, Class<? extends Item>> registeredItems() {
-    return REGISTERED_ITEMS;
+    return new HashMap<>(REGISTERED_ITEMS);
   }
 
   /**

--- a/dungeon/src/contrib/item/Item.java
+++ b/dungeon/src/contrib/item/Item.java
@@ -47,15 +47,15 @@ public class Item implements CraftingIngredient, CraftingResult {
    * <p>The keys in the map are the simple names of the classes (e.g. "ItemBookRed"), and the values
    * are the corresponding class objects.
    */
-  private static final Map<String, Class<? extends Item>> ITEMS = new HashMap<>();
+  private static final Map<String, Class<? extends Item>> REGISTERED_ITEMS = new HashMap<>();
 
   static {
-    ITEMS.put(ItemDefault.class.getSimpleName(), ItemDefault.class);
-    ITEMS.put(ItemPotionHealth.class.getSimpleName(), ItemPotionHealth.class);
-    ITEMS.put(ItemPotionWater.class.getSimpleName(), ItemPotionWater.class);
-    ITEMS.put(ItemResourceBerry.class.getSimpleName(), ItemResourceBerry.class);
-    ITEMS.put(ItemResourceEgg.class.getSimpleName(), ItemResourceEgg.class);
-    ITEMS.put(ItemResourceMushroomRed.class.getSimpleName(), ItemResourceMushroomRed.class);
+    registerItem(ItemDefault.class);
+    registerItem(ItemPotionHealth.class);
+    registerItem(ItemPotionWater.class);
+    registerItem(ItemResourceBerry.class);
+    registerItem(ItemResourceEgg.class);
+    registerItem(ItemResourceMushroomRed.class);
   }
 
   private String displayName;
@@ -132,17 +132,45 @@ public class Item implements CraftingIngredient, CraftingResult {
   }
 
   /**
-   * Get the class name of the specific item.
+   * Register an item. This is used to associate the simple name of the class with the class object
+   * in the {@link #REGISTERED_ITEMS} map.
    *
-   * @param id WTF? .
-   * @return The class name of the specific item.
+   * <p>When a new item is created, it should be registered using this method.
+   *
+   * @param clazz The class of the item to register.
    */
-  public static Class<? extends Item> getItem(final String id) {
-    return ITEMS.get(id);
+  public static void registerItem(final Class<? extends Item> clazz) {
+    REGISTERED_ITEMS.put(clazz.getSimpleName(), clazz);
   }
 
-  protected static boolean isRegistered(final Class<? extends Item> clazz) {
-    return ITEMS.containsValue(clazz);
+  /**
+   * Get all registered items.
+   *
+   * <p>This method is used to get all registered items. It returns a map where the keys are the
+   * simple names of the classes (e.g. {@link ItemResourceBerry}), and the values are the
+   * corresponding class objects.
+   *
+   * @return A map of all registered items.
+   */
+  public static Map<String, Class<? extends Item>> registeredItems() {
+    return REGISTERED_ITEMS;
+  }
+
+  /**
+   * Get an item by its identifier.
+   *
+   * <p>This method is used to get an item by its identifier. The identifier is the simple name of
+   * the class (e.g. "ItemResourceBerry").
+   *
+   * @param id The identifier of the item.
+   * @return The class of the item with the given identifier.
+   */
+  public static Class<? extends Item> getItem(final String id) {
+    return REGISTERED_ITEMS.get(id);
+  }
+
+  private static boolean isRegistered(final Class<? extends Item> clazz) {
+    return REGISTERED_ITEMS.containsValue(clazz);
   }
 
   /**

--- a/dungeon/src/contrib/utils/components/item/ItemGenerator.java
+++ b/dungeon/src/contrib/utils/components/item/ItemGenerator.java
@@ -2,54 +2,122 @@ package contrib.utils.components.item;
 
 import contrib.item.HealthPotionType;
 import contrib.item.Item;
-import contrib.item.concreteItem.*;
-import java.util.Random;
+import contrib.item.concreteItem.ItemDefault;
+import contrib.item.concreteItem.ItemPotionHealth;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
+import java.util.function.Supplier;
 
 /**
- * Generator which creates a random Item based on the Templates provided.
+ * A flexible random item generator that allows for custom weighting of items.
  *
- * <p>USe {@link #generateItemData()} to get a random {@link Item}.
+ * <p>Items can be added to the generator with a specified weight, which will affect the probability
+ * of that item being selected when generating a random item. The weights do not need to sum to 1.
+ *
+ * @see Item
+ * @see contrib.entities.MiscFactory#generateRandomItems(int, int) generateRandomItems
  */
-public final class ItemGenerator {
+public class ItemGenerator {
+  private final Random random;
+  private final Map<Supplier<Item>, Double> weightedItems;
+  private double totalWeight;
 
-  private static final Random RANDOM = new Random();
+  /** Constructs an ItemRandomGenerator with a random seed. */
+  public ItemGenerator() {
+    this.random = new Random();
+    this.weightedItems = new HashMap<>();
+    this.totalWeight = 0.0;
+  }
 
   /**
-   * Generates a new random Item.
+   * Creates a default ItemGenerator with all items added with a weight of 1.
    *
-   * @return A new random Item.
+   * <p>This method is a factory method that creates an instance of ItemGenerator, adds all items to
+   * it with a weight of 1, and then returns the instance. This is useful when you want a simple
+   * ItemGenerator that treats all items equally in terms of their probability of being generated.
+   *
+   * <p>For {@link ItemPotionHealth}, the default health potion is replaced with a random health
+   * potion using {@link HealthPotionType#randomType()}.
+   *
+   * @return An ItemGenerator with all {@link Item#registeredItems()} (except {@link ItemDefault})
+   *     added with a weight of 1.
    */
-  public static Item generateItemData() {
-    return switch (RANDOM.nextInt(9)) {
-      case 0, 1 -> new ItemPotionHealth(getWeightedRandomHealthPotionType());
-      case 2, 3 -> new ItemPotionWater();
-      case 4, 5 -> new ItemResourceBerry();
-      case 6, 7 -> new ItemResourceEgg();
-      default -> new ItemResourceMushroomRed();
+  public static ItemGenerator defaultItemGenerator() {
+    ItemGenerator ig = new ItemGenerator();
+    ig.addAllItems();
+    return ig;
+  }
+
+  /**
+   * Adds an item to the generator with a specified weight.
+   *
+   * @param itemSupplier A supplier that creates an instance of the item
+   * @param weight The weight of the item (higher weight means higher probability)
+   */
+  public void addItem(Supplier<Item> itemSupplier, double weight) {
+    weightedItems.put(itemSupplier, weight);
+    totalWeight += weight;
+  }
+
+  private void addAllItems() {
+    List<Class<? extends Item>> itemClasses = new ArrayList<>(Item.registeredItems().values());
+    itemClasses.remove(ItemDefault.class); // Remove the default item
+
+    // Replace the default health potion with a random health potion
+    itemClasses.remove(ItemPotionHealth.class);
+    addItem(() -> new ItemPotionHealth(HealthPotionType.randomType()), 1.0);
+
+    for (Class<? extends Item> itemClass : itemClasses) {
+      addItem(createItemSupplier(itemClass), 1.0);
+    }
+  }
+
+  /**
+   * Creates a supplier that creates an instance of an item class using reflection.
+   *
+   * @param itemClass The class of the item to create
+   * @return An instance of the item class, or null if an instance could not be created
+   */
+  private Supplier<Item> createItemSupplier(Class<? extends Item> itemClass) {
+    return () -> {
+      try {
+        return itemClass.getDeclaredConstructor().newInstance();
+      } catch (InstantiationException
+          | IllegalAccessException
+          | NoSuchMethodException
+          | InvocationTargetException e) {
+        throw new IllegalStateException(
+            "Could not create an instance of " + itemClass.getSimpleName(), e);
+      }
     };
   }
 
   /**
-   * This method returns a randomly selected potion type based on a weighted system. The weights are
-   * as follows: - 75% WEAK - 20% MEDIUM - 5% GREATER
+   * Generates a random item based on the current weights in the generator.
    *
-   * <p>These weights are based on the likelihood of the player finding a potion of a certain type.
-   *
-   * @return A randomly selected potion type based on the weighted system.
+   * @return A randomly selected item
+   * @throws IllegalStateException if no items have been added to the generator
    */
-  private static HealthPotionType getWeightedRandomHealthPotionType() {
-    HealthPotionType[] types = HealthPotionType.values();
-
-    float[] chances = {0.75f, 0.05f, 0.00f}; /* 75%, 20%, 5% */
-    float random = Item.RANDOM.nextFloat();
-
-    for (int i = 0; i < chances.length; i++) {
-      if (random < chances[i]) {
-        return types[i];
-      }
-      random -= chances[i];
+  public Item generateItemData() {
+    if (weightedItems.isEmpty()) {
+      throw new IllegalStateException("No items added to the generator");
     }
 
-    return types[types.length - 1];
+    double randomValue = random.nextDouble() * totalWeight;
+    for (Map.Entry<Supplier<Item>, Double> entry : weightedItems.entrySet()) {
+      randomValue -= entry.getValue();
+      if (randomValue <= 0) {
+        return entry.getKey().get();
+      }
+    }
+
+    // Fallback, should never be reached
+    return weightedItems.keySet().iterator().next().get();
+  }
+
+  /** Resets the generator, removing all added items and weights. */
+  public void reset() {
+    weightedItems.clear();
+    totalWeight = 0.0;
   }
 }


### PR DESCRIPTION
Ich habe den `ItemGenerator` angepasst, sodass man eigene Logik implementieren kann, da er nicht mehr statisch ist, sondern die Klassen, die ihn verwenden, einfach eine öffentliche statische Instanz davon haben. Der Generator kann jetzt per `addItem` gefüllt werden, standardmäßig ist er jedoch mit allen Items gefüllt. 

Zusätzlich sind alle registrierten Items jetzt per Getter und Setter in `Item` modifizierbar. Und die Methode `getWeightedRandomHealthPotionType` wurde in das Enum `HealthPotionType` verschoben.

- **MiscFactory.java** & **MonsterFactory.java**:
  - Hinzufügen einer statischen Instanz von `ItemGenerator`, um zufällige Items zu generieren.
  
- **HealthPotionType.java**:
  - Hinzufügen einer Methode `randomType`, die eine zufällige `HealthPotionType` basierend auf Gewichtungen erzeugt.
  
- **Item.java**:
  - Neue Methoden zur Registrierung von Items mittels `registerItem` und Abrufen der registrierten Items mittels `registeredItems`.

- **ItemGenerator.java**:
  - Umgestaltung des Generators zur Verwendung von Instanzen und Hinzufügen von Items mit spezifischen Gewichtungen.
  - Einführung einer Methode `defaultItemGenerator`, die alle registrierten Items mit einem Gewicht von 1 hinzufügt.
     - Jedoch wird `ItemDefault` ignoriert und `IteamHealthPotion` verwendet die `randomType` Methode.
  - Erweiterung der Funktionalität zur Erzeugung zufälliger Items basierend auf Gewichtungen.