### PR TITLE
Dungeon: Balanced Hero and Monster Stats

### DIFF
--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -46,7 +46,7 @@ public final class HeroFactory {
   private static final IPath HERO_FILE_PATH = new SimpleIPath("character/wizard");
   private static final Vector2 SPEED_HERO = new Vector2(7.5f, 7.5f);
   private static final int FIREBALL_COOL_DOWN = 500;
-  private static final int HERO_HP = 100;
+  private static final int HERO_HP = 25;
   private static Skill HERO_SKILL =
       new Skill(new FireballSkill(SkillTools::cursorPositionAsPoint), FIREBALL_COOL_DOWN);
 

--- a/dungeon/src/contrib/entities/MonsterFactory.java
+++ b/dungeon/src/contrib/entities/MonsterFactory.java
@@ -42,7 +42,7 @@ public final class MonsterFactory {
   };
 
   private static final int MIN_MONSTER_HEALTH = 10;
-  private static final int MAX_MONSTER_HEALTH = 50;
+  private static final int MAX_MONSTER_HEALTH = 20;
   private static final float MIN_MONSTER_SPEED = 5.0f;
   private static final float MAX_MONSTER_SPEED = 8.5f;
   private static final DamageType MONSTER_COLLIDE_DAMAGE_TYPE = DamageType.PHYSICAL;

--- a/dungeon/src/contrib/utils/components/skill/FireballSkill.java
+++ b/dungeon/src/contrib/utils/components/skill/FireballSkill.java
@@ -25,7 +25,7 @@ public final class FireballSkill extends DamageProjectile {
   private static final IPath PROJECTILE_TEXTURES = new SimpleIPath("skills/fireball");
   private static final IPath PROJECTILE_SOUND = new SimpleIPath("sounds/fireball.wav");
   private static final float DEFAULT_PROJECTILE_SPEED = 15.0f;
-  private static final int DEFAULT_DAMAGE_AMOUNT = 5;
+  private static final int DEFAULT_DAMAGE_AMOUNT = 2;
   private static final float DEFAULT_PROJECTILE_RANGE = 7f;
   private static final DamageType DAMAGE_TYPE = DamageType.FIRE;
   private static final Point HIT_BOX_SIZE = new Point(1, 1);


### PR DESCRIPTION
Als letzte Vorbereitung vor dem Mergen des DevDungeon habe ich die Werte für HP und Schaden angepasst:

- HeroFactory.java:
  - HERO_HP von 100 auf 25 reduziert

- MonsterFactory.java:
  - MAX_MONSTER_HEALTH von 50 auf 20 reduziert

- FireballSkill.java:
  - DEFAULT_DAMAGE_AMOUNT von 5 auf 2 reduziert (dieser Wert wird für Monster Feuerbälle verwendet)

Monster und Held verursachen jetzt gleich viel Schaden und die Monster haben nun maximal weniger HP als der Held. Dies dient als Grundlage für den DevDungeon und als gute Vorlage für andere Spiele.