### PR TITLE
Dungeon: improve handling of tiles in game API

### DIFF
--- a/devDungeon/src/level/utils/DungeonSaver.java
+++ b/devDungeon/src/level/utils/DungeonSaver.java
@@ -9,6 +9,7 @@ import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import level.DevDungeonLevel;
 
 /**
@@ -31,7 +32,15 @@ public class DungeonSaver {
   public static void saveCurrentDungeon() {
     String designLabel;
     if (Game.currentLevel().endTile() == null) {
-      designLabel = Game.currentLevel().randomTile(LevelElement.FLOOR).designLabel().name();
+      designLabel =
+          Game.currentLevel()
+              .randomTile(LevelElement.FLOOR)
+              .orElseThrow(
+                  () ->
+                      new NoSuchElementException(
+                          "There is no floor tile in the level; cannot place the missing exit and cannot save the dungeon"))
+              .designLabel()
+              .name();
     } else {
       designLabel = Game.currentLevel().endTile().designLabel().name();
     }

--- a/devDungeon/src/systems/FallingSystem.java
+++ b/devDungeon/src/systems/FallingSystem.java
@@ -81,8 +81,8 @@ public class FallingSystem extends System {
   }
 
   private Tile getSafeTile(Point heroCoords) {
-    return Game.accessibleTilesInRange(heroCoords, 5)
-        .getFirst()
+    return Game.accessibleTilesInRange(heroCoords, 5).stream()
+        .findFirst()
         .orElse(
             Game.randomTile(LevelElement.FLOOR)
                 .orElseThrow(() -> new NoSuchElementException("No Floor Tile in the level.")));

--- a/devDungeon/src/systems/FallingSystem.java
+++ b/devDungeon/src/systems/FallingSystem.java
@@ -76,10 +76,8 @@ public class FallingSystem extends System {
   private void teleportPlayerIfPossible() {
     Point heroCoords = EntityUtils.getHeroPosition();
     if (heroCoords != null) {
-      Tile tile =
-          getSafeTile(heroCoords)
-              .orElseThrow(() -> new NoSuchElementException(("No safe place to port.")));
-      Debugger.TELEPORT(tile);
+      getSafeTile(heroCoords)
+          .ifPresentOrElse(Debugger::TELEPORT, () -> LOGGER.warning("No safe place to port."));
     }
   }
 

--- a/devDungeon/src/systems/FallingSystem.java
+++ b/devDungeon/src/systems/FallingSystem.java
@@ -12,7 +12,6 @@ import core.components.PositionComponent;
 import core.level.Tile;
 import core.level.elements.tile.PitTile;
 import core.level.utils.LevelElement;
-import core.level.utils.LevelUtils;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import java.util.NoSuchElementException;
@@ -82,7 +81,8 @@ public class FallingSystem extends System {
   }
 
   private Tile getSafeTile(Point heroCoords) {
-    return LevelUtils.accessibleTilesInRange(heroCoords, 5).getFirst()
+    return Game.accessibleTilesInRange(heroCoords, 5)
+        .getFirst()
         .orElse(
             Game.randomTile(LevelElement.FLOOR)
                 .orElseThrow(() -> new NoSuchElementException("No Floor Tile in the level.")));

--- a/devDungeon/src/systems/FallingSystem.java
+++ b/devDungeon/src/systems/FallingSystem.java
@@ -14,9 +14,8 @@ import core.level.elements.tile.PitTile;
 import core.level.utils.LevelElement;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
-import utils.EntityUtils;
-
 import java.util.NoSuchElementException;
+import utils.EntityUtils;
 
 /**
  * The FallingSystem is responsible for handling entities that fall into {@link PitTile}s. Falling
@@ -79,23 +78,21 @@ public class FallingSystem extends System {
       try {
         Tile tile = getSafeTile(heroCoords);
         Debugger.TELEPORT(tile);
-      }
-      catch (NoSuchElementException e) {
+      } catch (NoSuchElementException e) {
         LOGGER.warning(e.getMessage());
       }
-      }
     }
+  }
 
-  private Tile getSafeTile(Point heroCoords) throws NoSuchElementException{
+  private Tile getSafeTile(Point heroCoords) throws NoSuchElementException {
     Tile tile;
     try {
-      tile=Game.accessibleTilesInRange(heroCoords, 5).getFirst();
-    }
-    catch (NoSuchElementException e){
-      tile=Game.randomTile(LevelElement.FLOOR)
-                    .orElseThrow(() -> new NoSuchElementException("No safe Tile found."));
+      tile = Game.accessibleTilesInRange(heroCoords, 5).getFirst();
+    } catch (NoSuchElementException e) {
+      tile =
+          Game.randomTile(LevelElement.FLOOR)
+              .orElseThrow(() -> new NoSuchElementException("No safe Tile found."));
     }
     return tile;
-
   }
 }

--- a/devDungeon/src/systems/FallingSystem.java
+++ b/devDungeon/src/systems/FallingSystem.java
@@ -14,8 +14,9 @@ import core.level.elements.tile.PitTile;
 import core.level.utils.LevelElement;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
-import java.util.NoSuchElementException;
 import utils.EntityUtils;
+
+import java.util.NoSuchElementException;
 
 /**
  * The FallingSystem is responsible for handling entities that fall into {@link PitTile}s. Falling
@@ -75,16 +76,26 @@ public class FallingSystem extends System {
   private void teleportPlayerIfPossible() {
     Point heroCoords = EntityUtils.getHeroPosition();
     if (heroCoords != null) {
-      Tile tile = getSafeTile(heroCoords);
-      Debugger.TELEPORT(tile);
+      try {
+        Tile tile = getSafeTile(heroCoords);
+        Debugger.TELEPORT(tile);
+      }
+      catch (NoSuchElementException e) {
+        LOGGER.warning(e.getMessage());
+      }
+      }
     }
-  }
 
-  private Tile getSafeTile(Point heroCoords) {
-    return Game.accessibleTilesInRange(heroCoords, 5).stream()
-        .findFirst()
-        .orElse(
-            Game.randomTile(LevelElement.FLOOR)
-                .orElseThrow(() -> new NoSuchElementException("No Floor Tile in the level.")));
+  private Tile getSafeTile(Point heroCoords) throws NoSuchElementException{
+    Tile tile;
+    try {
+      tile=Game.accessibleTilesInRange(heroCoords, 5).getFirst();
+    }
+    catch (NoSuchElementException e){
+      tile=Game.randomTile(LevelElement.FLOOR)
+                    .orElseThrow(() -> new NoSuchElementException("No safe Tile found."));
+    }
+    return tile;
+
   }
 }

--- a/devDungeon/src/systems/FallingSystem.java
+++ b/devDungeon/src/systems/FallingSystem.java
@@ -15,6 +15,7 @@ import core.level.utils.LevelElement;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import utils.EntityUtils;
 
 /**
@@ -75,24 +76,18 @@ public class FallingSystem extends System {
   private void teleportPlayerIfPossible() {
     Point heroCoords = EntityUtils.getHeroPosition();
     if (heroCoords != null) {
-      try {
-        Tile tile = getSafeTile(heroCoords);
-        Debugger.TELEPORT(tile);
-      } catch (NoSuchElementException e) {
-        LOGGER.warning(e.getMessage());
-      }
+      Tile tile =
+          getSafeTile(heroCoords)
+              .orElseThrow(() -> new NoSuchElementException(("No safe place to port.")));
+      Debugger.TELEPORT(tile);
     }
   }
 
-  private Tile getSafeTile(Point heroCoords) throws NoSuchElementException {
-    Tile tile;
+  private Optional<Tile> getSafeTile(Point heroCoords) throws NoSuchElementException {
     try {
-      tile = Game.accessibleTilesInRange(heroCoords, 5).getFirst();
+      return Optional.of(Game.accessibleTilesInRange(heroCoords, 5).getFirst());
     } catch (NoSuchElementException e) {
-      tile =
-          Game.randomTile(LevelElement.FLOOR)
-              .orElseThrow(() -> new NoSuchElementException("No safe Tile found."));
+      return Game.randomTile(LevelElement.FLOOR);
     }
-    return tile;
   }
 }

--- a/devDungeon/src/systems/FallingSystem.java
+++ b/devDungeon/src/systems/FallingSystem.java
@@ -82,12 +82,10 @@ public class FallingSystem extends System {
   }
 
   private Tile getSafeTile(Point heroCoords) {
-    Tile tile;
-    try {
-      tile = LevelUtils.accessibleTilesInRange(heroCoords, 5).getFirst();
-    } catch (NoSuchElementException e) {
-      tile = Game.randomTile(LevelElement.FLOOR);
-    }
-    return tile;
+    return LevelUtils.accessibleTilesInRange(heroCoords, 5).stream()
+        .findFirst()
+        .orElse(
+            Game.randomTile(LevelElement.FLOOR)
+                .orElseThrow(() -> new NoSuchElementException("No Floor Tile in the level.")));
   }
 }

--- a/devDungeon/src/systems/FallingSystem.java
+++ b/devDungeon/src/systems/FallingSystem.java
@@ -82,8 +82,7 @@ public class FallingSystem extends System {
   }
 
   private Tile getSafeTile(Point heroCoords) {
-    return LevelUtils.accessibleTilesInRange(heroCoords, 5).stream()
-        .findFirst()
+    return LevelUtils.accessibleTilesInRange(heroCoords, 5).getFirst()
         .orElse(
             Game.randomTile(LevelElement.FLOOR)
                 .orElseThrow(() -> new NoSuchElementException("No Floor Tile in the level.")));

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -53,7 +53,6 @@ import java.util.stream.Stream;
 public final class Game {
 
   private static final Logger LOGGER = Logger.getLogger(Game.class.getSimpleName());
-  private static final Random RANDOM = new Random();
 
   /** Starts the dungeon and requires a {@link Game}. */
   public static void run() {
@@ -401,6 +400,18 @@ public final class Game {
    */
   public static Tile randomTile() {
     return currentLevel().randomTile();
+  }
+
+  /**
+   * Get the neighbors of the given Tile.
+   *
+   * <p>Neighbors are the tiles directly above, below, left, and right of the given Tile.
+   *
+   * @param tile Tile to get the neighbors for
+   * @return Set with the neighbor tiles.
+   */
+  public static Set<Tile> neighbours(final Tile tile) {
+    return LevelUtils.neighbours(tile);
   }
 
   /**

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -547,6 +547,16 @@ public final class Game {
   }
 
   /**
+   * Checks if the given Tile is accessible and no entity is placed on that tile.
+   *
+   * @param tile Tile to check.
+   * @return True if the Tile is free, false if not
+   */
+  public static boolean isFreeTile(Tile tile) {
+    return LevelUtils.isFreeTile(tile);
+  }
+
+  /**
    * Get all accessible tiles within a specified range around a given center point.
    *
    * <p>The range is determined by the provided radius.

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -534,22 +534,22 @@ public final class Game {
    */
   public static Optional<Tile> freeTile() {
     // Direction vectors for moving up, down, left, and right
-    int[] dRow = {-1, 1, 0, 0};
-    int[] dCol = {0, 0, -1, 1};
+    int[] deltaRow = {-1, 1, 0, 0};
+    int[] deltaCol = {0, 0, -1, 1};
 
     Tile[][] layout = currentLevel().layout();
     int startRow = RANDOM.nextInt(layout[0].length);
     int startCol = RANDOM.nextInt(layout.length);
-    int rows = layout.length;
-    int cols = layout[0].length;
-    boolean[][] visited = new boolean[rows][cols];
+    int rowsSize = layout.length;
+    int colsSize = layout[0].length;
+    boolean[][] queued = new boolean[rowsSize][colsSize];
 
     // Queue to hold the cells to be explored in the form of (row, col)
     Queue<Tuple<Integer, Integer>> queue = new LinkedList<>();
 
     // Start BFS from the given start position
     queue.add(new Tuple<>(startRow, startCol));
-    visited[startRow][startCol] = true;
+    queued[startRow][startCol] = true;
 
     while (!queue.isEmpty()) {
       // Dequeue the front cell
@@ -557,23 +557,21 @@ public final class Game {
       int row = cell.a();
       int col = cell.b();
 
-      if (isFreeTile(layout[row][col])) {
-        return Optional.of(layout[row][col]);
-      }
+      if (isFreeTile(layout[row][col])) return Optional.of(layout[row][col]);
 
       // Explore all 4 possible directions
       for (int i = 0; i < 4; i++) {
-        int newRow = row + dRow[i];
-        int newCol = col + dCol[i];
+        int newRow = row + deltaRow[i];
+        int newCol = col + deltaCol[i];
 
         // Check if the new cell is within bounds and not yet visited
         if (newRow >= 0
-            && newRow < rows
+            && newRow < rowsSize
             && newCol >= 0
-            && newCol < cols
-            && !visited[newRow][newCol]) {
+            && newCol < colsSize
+            && !queued[newRow][newCol]) {
           queue.add(new Tuple<>(newRow, newCol));
-          visited[newRow][newCol] = true;
+          queued[newRow][newCol] = true;
         }
       }
     }

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -534,12 +534,14 @@ public final class Game {
    */
   public static Optional<Tile> freeTile() {
     // Direction vectors for moving up, down, left, and right
-    int[] deltaRow = {-1, 1, 0, 0};
-    int[] deltaCol = {0, 0, -1, 1};
+    Tuple<Integer, Integer>[] deltaVectors =
+        new Tuple[] {
+          new Tuple<>(-1, 0), new Tuple<>(1, 0), new Tuple<>(0, -1), new Tuple<>(0, 1),
+        };
 
     Tile[][] layout = currentLevel().layout();
-    int startRow = RANDOM.nextInt(layout[0].length);
-    int startCol = RANDOM.nextInt(layout.length);
+    int startRow = RANDOM.nextInt(layout.length);
+    int startCol = RANDOM.nextInt(layout[0].length);
     int rowsSize = layout.length;
     int colsSize = layout[0].length;
     boolean[][] queued = new boolean[rowsSize][colsSize];
@@ -561,8 +563,8 @@ public final class Game {
 
       // Explore all 4 possible directions
       for (int i = 0; i < 4; i++) {
-        int newRow = row + deltaRow[i];
-        int newCol = col + deltaCol[i];
+        int newRow = row + deltaVectors[i].a();
+        int newCol = col + deltaVectors[i].b();
 
         // Check if the new cell is within bounds and not yet visited
         if (newRow >= 0

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -529,6 +529,17 @@ public final class Game {
   }
 
   /**
+   * Get a position of a random free tile from the current level. A free tile is a tile that is of
+   * type FLOOR and is not occupied by any entity and is accessible.
+   *
+   * @return An Optional containing the postion of a random free tile if available, otherwise an
+   *     empty Optional.
+   */
+  public static Optional<Point> freePosition() {
+    return freeTile().map(tile -> tile.position());
+  }
+
+  /**
    * Starts the indexed A* pathfinding algorithm a returns a path
    *
    * <p>Throws an IllegalArgumentException if start or end is non-accessible.

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -12,6 +12,7 @@ import core.level.elements.ILevel;
 import core.level.utils.Coordinate;
 import core.level.utils.LevelElement;
 import core.level.utils.LevelSize;
+import core.level.utils.LevelUtils;
 import core.systems.LevelSystem;
 import core.utils.IVoidFunction;
 import core.utils.Point;
@@ -537,6 +538,21 @@ public final class Game {
    */
   public static Optional<Point> freePosition() {
     return freeTile().map(tile -> tile.position());
+  }
+
+  /**
+   * Get all accessible tiles within a specified range around a given center point.
+   *
+   * <p>The range is determined by the provided radius.
+   *
+   * <p>The tile at the given point will be part of the list as well, if it is accessible.
+   *
+   * @param center The center point around which the tiles are considered.
+   * @param radius The radius within which the accessible tiles should be located.
+   * @return List of accessible tiles in the given radius around the center point.
+   */
+  public static List<Tile> accessibleTilesInRange(final Point center, float radius) {
+    return LevelUtils.accessibleTilesInRange(center, radius);
   }
 
   /**

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -21,6 +21,7 @@ import core.utils.components.path.IPath;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -491,15 +492,26 @@ public final class Game {
   }
 
   /**
+   * Get all tiles from the current level that satisfy the provided predicate.
+   *
+   * @param filterRule A predicate that determines which tiles to include.
+   * @return A Set containing all tiles in the current level that satisfy the predicate.
+   */
+  public static Set<Tile> allTiles(Predicate<Tile> filterRule) {
+    return Arrays.stream(currentLevel().layout()) // Stream the layout (2D array)
+        .flatMap(Arrays::stream) // Flatten it into a stream of individual elements
+        .filter(filterRule) // Apply the predicate to filter the tiles
+        .collect(Collectors.toSet()); // Collect the elements into a Set
+  }
+
+  /**
    * Get all tiles of the specified type from the current level.
    *
    * @param elementTyp Type of the tiles to retrieve.
    * @return A Set containing all tiles of the specified type in the current level.
    */
   public static Set<Tile> allTiles(final LevelElement elementTyp) {
-    Set<Tile> tiles = allTiles();
-    tiles.removeIf(tile -> tile.levelElement() != elementTyp);
-    return tiles;
+    return allTiles(tile -> tile.levelElement() == elementTyp);
   }
 
   /**
@@ -509,10 +521,8 @@ public final class Game {
    * @return A Set containing all free tiles in the current level.
    */
   public static Set<Tile> allFreeTiles() {
-    Set<Tile> tiles = allTiles();
     // Remove the tile if an entity is on it or it is not accessible.
-    tiles.removeIf(t -> entityAtTile(t).count() > 0 || !t.isAccessible());
-    return tiles;
+    return allTiles(tile -> tile.isAccessible() && entityAtTile(tile).count() == 0);
   }
 
   /**

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -484,7 +484,6 @@ public final class Game {
    * @return A Set containing all tiles in the current level.
    */
   public static Set<Tile> allTiles() {
-
     return Arrays.stream(currentLevel().layout()) // Stream the layout (2D array)
         .flatMap(Arrays::stream) // Flatten it into a stream of individual elements
         .collect(Collectors.toSet()); // Collect the elements into a Set

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -16,7 +16,6 @@ import core.level.utils.LevelUtils;
 import core.systems.LevelSystem;
 import core.utils.IVoidFunction;
 import core.utils.Point;
-import core.utils.Tuple;
 import core.utils.components.MissingComponentException;
 import core.utils.components.path.IPath;
 import java.io.IOException;
@@ -523,7 +522,7 @@ public final class Game {
    * @return A Set containing all free tiles in the current level.
    */
   public static Set<Tile> allFreeTiles() {
-    return allTiles(Game::isFreeTile);
+    return allTiles(LevelUtils::isFreeTile);
   }
 
   /**
@@ -533,61 +532,7 @@ public final class Game {
    * @return An Optional containing a random free tile if available, otherwise an empty Optional.
    */
   public static Optional<Tile> freeTile() {
-    // Direction vectors for moving up, down, left, and right
-    Tuple<Integer, Integer>[] deltaVectors =
-        new Tuple[] {
-          new Tuple<>(-1, 0), new Tuple<>(1, 0), new Tuple<>(0, -1), new Tuple<>(0, 1),
-        };
-
-    Tile[][] layout = currentLevel().layout();
-    int startRow = RANDOM.nextInt(layout.length);
-    int startCol = RANDOM.nextInt(layout[0].length);
-    int rowsSize = layout.length;
-    int colsSize = layout[0].length;
-    boolean[][] queued = new boolean[rowsSize][colsSize];
-
-    // Queue to hold the cells to be explored in the form of (row, col)
-    Queue<Tuple<Integer, Integer>> queue = new LinkedList<>();
-
-    // Start BFS from the given start position
-    queue.add(new Tuple<>(startRow, startCol));
-    queued[startRow][startCol] = true;
-
-    while (!queue.isEmpty()) {
-      // Dequeue the front cell
-      Tuple<Integer, Integer> cell = queue.poll();
-      int row = cell.a();
-      int col = cell.b();
-
-      if (isFreeTile(layout[row][col])) return Optional.of(layout[row][col]);
-
-      // Explore all 4 possible directions
-      for (int i = 0; i < 4; i++) {
-        int newRow = row + deltaVectors[i].a();
-        int newCol = col + deltaVectors[i].b();
-
-        // Check if the new cell is within bounds and not yet visited
-        if (newRow >= 0
-            && newRow < rowsSize
-            && newCol >= 0
-            && newCol < colsSize
-            && !queued[newRow][newCol]) {
-          queue.add(new Tuple<>(newRow, newCol));
-          queued[newRow][newCol] = true;
-        }
-      }
-    }
-    return Optional.empty();
-  }
-
-  /**
-   * Checks if the given Tile is accessible and no entity is placed on that tile.
-   *
-   * @param tile Tile to check.
-   * @return True if the Tile is free, false if not
-   */
-  public static boolean isFreeTile(Tile tile) {
-    return tile.isAccessible() && entityAtTile(tile).findAny().isEmpty();
+    return LevelUtils.freeTile();
   }
 
   /**

--- a/game/src/core/game/GameLoop.java
+++ b/game/src/core/game/GameLoop.java
@@ -170,6 +170,10 @@ public final class GameLoop extends ScreenAdapter {
   /**
    * Called once at the beginning of the game.
    *
+   * <p>Will execute {@link LevelSystem#execute()} once to load the first level before the actual
+   * game loop starts. This ensures the first level is set at the start of the game loop, even if
+   * the {@link LevelSystem} is not executed as the first system in the game loop..
+   *
    * <p>Will perform some setup.
    */
   private void setup() {
@@ -177,7 +181,6 @@ public final class GameLoop extends ScreenAdapter {
     createSystems();
     setupStage();
     PreRunConfiguration.userOnSetup().execute();
-    // load the first level
     Game.systems().get(LevelSystem.class).execute();
   }
 

--- a/game/src/core/game/GameLoop.java
+++ b/game/src/core/game/GameLoop.java
@@ -177,6 +177,8 @@ public final class GameLoop extends ScreenAdapter {
     createSystems();
     setupStage();
     PreRunConfiguration.userOnSetup().execute();
+    // load the first level
+    Game.systems().get(LevelSystem.class).execute();
   }
 
   /**

--- a/game/src/core/level/elements/ILevel.java
+++ b/game/src/core/level/elements/ILevel.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Random;
+import java.util.function.Function;
 
 /**
  * Defines the API for Levels in the dungeon.
@@ -276,36 +277,21 @@ public interface ILevel extends IndexedGraph<Tile> {
    * @return A random tile of the specified type, or empty if the list for that type is empty.
    */
   default Optional<Tile> randomTile(final LevelElement elementType) {
-    return switch (elementType) {
-      case SKIP ->
-          skipTiles().size() > 0
-              ? Optional.of(skipTiles().get(RANDOM.nextInt(skipTiles().size())))
-              : Optional.empty();
-      case FLOOR ->
-          floorTiles().size() > 0
-              ? Optional.of(floorTiles().get(RANDOM.nextInt(floorTiles().size())))
-              : Optional.empty();
-      case WALL ->
-          wallTiles().size() > 0
-              ? Optional.of(wallTiles().get(RANDOM.nextInt(wallTiles().size())))
-              : Optional.empty();
-      case HOLE ->
-          holeTiles().size() > 0
-              ? Optional.of(holeTiles().get(RANDOM.nextInt(holeTiles().size())))
-              : Optional.empty();
-      case EXIT ->
-          exitTiles().size() > 0
-              ? Optional.of(exitTiles().get(RANDOM.nextInt(exitTiles().size())))
-              : Optional.empty();
-      case DOOR ->
-          doorTiles().size() > 0
-              ? Optional.of(doorTiles().get(RANDOM.nextInt(doorTiles().size())))
-              : Optional.empty();
-      case PIT ->
-          pitTiles().size() > 0
-              ? Optional.of(pitTiles().get(RANDOM.nextInt(pitTiles().size())))
-              : Optional.empty();
-    };
+    Function<List<? extends Tile>, Optional<Tile>> returnVal =
+        (list) ->
+            Optional.ofNullable(list.isEmpty() ? null : list.get(RANDOM.nextInt(list.size())));
+
+    return returnVal.apply(
+        switch (elementType) {
+          case SKIP -> skipTiles();
+          case FLOOR -> floorTiles();
+          case WALL -> wallTiles();
+          case HOLE -> holeTiles();
+          case EXIT -> exitTiles();
+          case DOOR -> doorTiles();
+          case PIT -> pitTiles();
+          default -> throw new NoSuchElementException("No such tile type: '" + elementType + "'");
+        });
   }
 
   /**

--- a/game/src/core/level/elements/ILevel.java
+++ b/game/src/core/level/elements/ILevel.java
@@ -383,6 +383,9 @@ public interface ILevel extends IndexedGraph<Tile> {
   /**
    * Retrieves the layout of the level, represented as a 2D array of tiles.
    *
+   * <p>Note that the layout is stored [y][x], so the first index defines the y-coordinate, and the
+   * second index the x-coordinate.
+   *
    * @return The layout of the level as a 2D array of tiles.
    */
   Tile[][] layout();
@@ -390,15 +393,18 @@ public interface ILevel extends IndexedGraph<Tile> {
   /**
    * Get the size (row x col) of the level as a Tuple.
    *
-   * <p>{@link Tuple#a()} contains the row size (starting at 0).
+   * <p>{@link Tuple#a()} contains the row size (starting at 1).
    *
-   * <p>{@link Tuple#b()} contains the column size (starting at 0).
+   * <p>{@link Tuple#b()} contains the column size (starting at 1).
+   *
+   * <p>Note that the layout is stored [y][x], so the first index defines the y-coordinate, and the
+   * second index the x-coordinate.
    *
    * @return The size of the level as a Tuple.
    */
   default Tuple<Integer, Integer> size() {
     Tile[][] layout = layout();
-    return new Tuple<>(layout.length, layout[0].length);
+    return new Tuple<>(layout[0].length, layout.length);
   }
 
   /**

--- a/game/src/core/level/elements/ILevel.java
+++ b/game/src/core/level/elements/ILevel.java
@@ -16,6 +16,7 @@ import core.level.utils.LevelElement;
 import core.level.utils.TileTextureFactory;
 import core.utils.IVoidFunction;
 import core.utils.Point;
+import core.utils.Tuple;
 import core.utils.components.MissingComponentException;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -385,6 +386,20 @@ public interface ILevel extends IndexedGraph<Tile> {
    * @return The layout of the level as a 2D array of tiles.
    */
   Tile[][] layout();
+
+  /**
+   * Get the size (row x col) of the level as a Tuple.
+   *
+   * <p>{@link Tuple#a()} contains the row size (starting at 0).
+   *
+   * <p>{@link Tuple#b()} contains the column size (starting at 0).
+   *
+   * @return The size of the level as a Tuple.
+   */
+  default Tuple<Integer, Integer> size() {
+    Tile[][] layout = layout();
+    return new Tuple<>(layout.length, layout[0].length);
+  }
 
   /**
    * Retrieves the tile at the specified position within the level.

--- a/game/src/core/level/elements/ILevel.java
+++ b/game/src/core/level/elements/ILevel.java
@@ -18,6 +18,8 @@ import core.utils.IVoidFunction;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Random;
 
 /**
@@ -42,7 +44,10 @@ public interface ILevel extends IndexedGraph<Tile> {
    * it as the start tile for the level.
    */
   default void randomStart() {
-    startTile(randomTile(LevelElement.FLOOR));
+    startTile(
+        randomTile(LevelElement.FLOOR)
+            .orElseThrow(
+                () -> new NoSuchElementException("There is no Floor-Tile to place the Start on.")));
   }
 
   /**
@@ -268,23 +273,38 @@ public interface ILevel extends IndexedGraph<Tile> {
    * specified type is empty, the method returns null.
    *
    * @param elementType Type of the tile to retrieve.
-   * @return A random tile of the specified type, or null if the list for that type is empty.
+   * @return A random tile of the specified type, or empty if the list for that type is empty.
    */
-  default Tile randomTile(final LevelElement elementType) {
+  default Optional<Tile> randomTile(final LevelElement elementType) {
     return switch (elementType) {
       case SKIP ->
-          skipTiles().size() > 0 ? skipTiles().get(RANDOM.nextInt(skipTiles().size())) : null;
+          skipTiles().size() > 0
+              ? Optional.of(skipTiles().get(RANDOM.nextInt(skipTiles().size())))
+              : Optional.empty();
       case FLOOR ->
-          floorTiles().size() > 0 ? floorTiles().get(RANDOM.nextInt(floorTiles().size())) : null;
+          floorTiles().size() > 0
+              ? Optional.of(floorTiles().get(RANDOM.nextInt(floorTiles().size())))
+              : Optional.empty();
       case WALL ->
-          wallTiles().size() > 0 ? wallTiles().get(RANDOM.nextInt(wallTiles().size())) : null;
+          wallTiles().size() > 0
+              ? Optional.of(wallTiles().get(RANDOM.nextInt(wallTiles().size())))
+              : Optional.empty();
       case HOLE ->
-          holeTiles().size() > 0 ? holeTiles().get(RANDOM.nextInt(holeTiles().size())) : null;
+          holeTiles().size() > 0
+              ? Optional.of(holeTiles().get(RANDOM.nextInt(holeTiles().size())))
+              : Optional.empty();
       case EXIT ->
-          exitTiles().size() > 0 ? exitTiles().get(RANDOM.nextInt(exitTiles().size())) : null;
+          exitTiles().size() > 0
+              ? Optional.of(exitTiles().get(RANDOM.nextInt(exitTiles().size())))
+              : Optional.empty();
       case DOOR ->
-          doorTiles().size() > 0 ? doorTiles().get(RANDOM.nextInt(doorTiles().size())) : null;
-      case PIT -> pitTiles().size() > 0 ? pitTiles().get(RANDOM.nextInt(pitTiles().size())) : null;
+          doorTiles().size() > 0
+              ? Optional.of(doorTiles().get(RANDOM.nextInt(doorTiles().size())))
+              : Optional.empty();
+      case PIT ->
+          pitTiles().size() > 0
+              ? Optional.of(pitTiles().get(RANDOM.nextInt(pitTiles().size())))
+              : Optional.empty();
     };
   }
 
@@ -482,7 +502,10 @@ public interface ILevel extends IndexedGraph<Tile> {
    * @return The position of a randomly selected tile of the specified type in the level as a {@link
    *     Point}.
    */
-  default Point randomTilePoint(final LevelElement elementType) {
-    return randomTile(elementType).position();
+  default Optional<Point> randomTilePoint(final LevelElement elementType) {
+    Optional<Tile> t = randomTile(elementType);
+    if (t.isPresent()) {
+      return Optional.of(t.get().position());
+    } else return Optional.empty();
   }
 }

--- a/game/src/core/level/elements/ILevel.java
+++ b/game/src/core/level/elements/ILevel.java
@@ -503,9 +503,6 @@ public interface ILevel extends IndexedGraph<Tile> {
    *     Point}.
    */
   default Optional<Point> randomTilePoint(final LevelElement elementType) {
-    Optional<Tile> t = randomTile(elementType);
-    if (t.isPresent()) {
-      return Optional.of(t.get().position());
-    } else return Optional.empty();
+    return randomTile(elementType).map(Tile::position);
   }
 }

--- a/game/src/core/level/utils/LevelUtils.java
+++ b/game/src/core/level/utils/LevelUtils.java
@@ -311,7 +311,6 @@ public final class LevelUtils {
    * @return An Optional containing a random free tile if available, otherwise an empty Optional.
    */
   public static Optional<Tile> freeTile() {
-
     Tuple<Integer, Integer> levelSize = Game.currentLevel().size();
     int startRow = RANDOM.nextInt(levelSize.a());
     int startCol = RANDOM.nextInt(levelSize.b());
@@ -327,7 +326,9 @@ public final class LevelUtils {
       // Dequeue the front cell
       Tile cell = queue.poll();
 
+      // We have found a free field, abort the search.
       if (isFreeTile(cell)) return Optional.of(cell);
+      
       // Explore all 4 possible directions
       for (Tile tile : neighbours(cell)) {
         Coordinate coordinate = tile.coordinate();

--- a/game/src/core/level/utils/LevelUtils.java
+++ b/game/src/core/level/utils/LevelUtils.java
@@ -312,30 +312,29 @@ public final class LevelUtils {
    */
   public static Optional<Tile> freeTile() {
     Tuple<Integer, Integer> levelSize = Game.currentLevel().size();
-    int startRow = RANDOM.nextInt(levelSize.a());
-    int startCol = RANDOM.nextInt(levelSize.b());
-    boolean[][] queued = new boolean[levelSize.a()][levelSize.b()];
+    int startX = RANDOM.nextInt(0, levelSize.a());
+    int startY = RANDOM.nextInt(0, levelSize.b());
+    boolean[][] queued = new boolean[levelSize.b()][levelSize.a()];
 
     // Queue to hold the cells to be explored in the form of (row, col)
     Queue<Tile> queue = new LinkedList<>();
     // Start BFS from the given start position
-    queue.add(Game.currentLevel().tileAt(new Coordinate(startRow, startCol)));
-    queued[startRow][startCol] = true;
+    queue.add(Game.currentLevel().tileAt(new Coordinate(startX, startY)));
+    queued[startY][startX] = true;
 
     while (!queue.isEmpty()) {
       // Dequeue the front cell
       Tile cell = queue.poll();
-
-      // We have found a free field, abort the search.
+      // We have found a free field, abort the search
       if (isFreeTile(cell)) return Optional.of(cell);
-      
+
       // Explore all 4 possible directions
       for (Tile tile : neighbours(cell)) {
         Coordinate coordinate = tile.coordinate();
         // Check if the new cell is within bounds and not yet visited
-        if (!queued[coordinate.x][coordinate.y]) {
+        if (!queued[coordinate.y][coordinate.x]) {
           queue.add(tile);
-          queued[coordinate.x][coordinate.y] = true;
+          queued[coordinate.y][coordinate.x] = true;
         }
       }
     }
@@ -356,14 +355,14 @@ public final class LevelUtils {
     Tuple<Integer, Integer> levelSize = Game.currentLevel().size();
     Tile[][] layout = Game.currentLevel().layout();
     Coordinate coordinate = tile.coordinate();
-    for (int i = 0; i < 4; i++) {
-      Coordinate newCoordinate = coordinate.add(DELTA_VECTORS[i]);
+    for (Coordinate deltaVector : DELTA_VECTORS) {
+      Coordinate newCoordinate = coordinate.add(deltaVector);
       // Check if the new cell is within bounds and not yet visited
       if (newCoordinate.x >= 0
           && newCoordinate.x < levelSize.a()
           && newCoordinate.y >= 0
           && newCoordinate.y < levelSize.b())
-        returnSet.add(layout[newCoordinate.x][newCoordinate.y]);
+        returnSet.add(layout[newCoordinate.y][newCoordinate.x]);
     }
     return returnSet;
   }
@@ -374,7 +373,7 @@ public final class LevelUtils {
    * @param tile Tile to check.
    * @return True if the Tile is free, false if not
    */
-  public static boolean isFreeTile(Tile tile) {
+  public static boolean isFreeTile(final Tile tile) {
     return tile.isAccessible() && Game.entityAtTile(tile).findAny().isEmpty();
   }
 }

--- a/game/src/core/level/utils/LevelUtils.java
+++ b/game/src/core/level/utils/LevelUtils.java
@@ -325,6 +325,7 @@ public final class LevelUtils {
     while (!queue.isEmpty()) {
       // Dequeue the front cell
       Tile cell = queue.poll();
+
       // We have found a free field, abort the search
       if (isFreeTile(cell)) return Optional.of(cell);
 

--- a/game/src/core/systems/PositionSystem.java
+++ b/game/src/core/systems/PositionSystem.java
@@ -44,21 +44,17 @@ public final class PositionSystem extends System {
    * @param data The PSData object containing entity and position component information.
    */
   private void randomPosition(final PSData data) {
-    // The Level can be null if the LevelSystem has not yet been executed (this may occur during the
-    // initial loop frame of the game).
-    if (Game.currentLevel() != null) {
-      Tile tile =
-          Game.freeTile()
-              .orElseThrow(
-                  () ->
-                      new NoSuchElementException(
-                          "There is no free tile in the level; the entity can't be placed."));
-      Point position = tile.position();
-      // place on center
-      position.x += 0.5f;
-      position.y += 0.5f;
-      data.pc().position(position);
-    }
+    Tile tile =
+        Game.freeTile()
+            .orElseThrow(
+                () ->
+                    new NoSuchElementException(
+                        "There is no free tile in the level; the entity can't be placed."));
+    Point position = tile.position();
+    // place on center
+    position.x += 0.5f;
+    position.y += 0.5f;
+    data.pc().position(position);
   }
 
   private PSData buildDataObject(final Entity e) {

--- a/game/src/core/systems/PositionSystem.java
+++ b/game/src/core/systems/PositionSystem.java
@@ -4,10 +4,10 @@ import core.Entity;
 import core.Game;
 import core.System;
 import core.components.PositionComponent;
-import core.level.utils.Coordinate;
-import core.level.utils.LevelElement;
+import core.level.Tile;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
+import java.util.NoSuchElementException;
 
 /**
  * The {@link PositionSystem} checks if an entity has an illegal position and then changes the
@@ -44,20 +44,20 @@ public final class PositionSystem extends System {
    * @param data The PSData object containing entity and position component information.
    */
   private void randomPosition(final PSData data) {
-    // The Level can be null if the LevelSystem has not yet been executed (this may occur during the initial loop frame of the game).
+    // The Level can be null if the LevelSystem has not yet been executed (this may occur during the
+    // initial loop frame of the game).
     if (Game.currentLevel() != null) {
-      Coordinate randomPosition = Game.randomTile(LevelElement.FLOOR).coordinate();
-      boolean otherEntityIsOnThisCoordinate =
-          filteredEntityStream()
-              .map(this::buildDataObject)
-              .anyMatch(psData -> psData.pc().position().toCoordinate().equals(randomPosition));
-      if (!otherEntityIsOnThisCoordinate) {
-        Point position = randomPosition.toPoint();
-        // place on center
-        position.x += 0.5f;
-        position.y += 0.5f;
-        data.pc().position(position);
-      } else randomPosition(data);
+      Tile tile =
+          Game.freeTile()
+              .orElseThrow(
+                  () ->
+                      new NoSuchElementException(
+                          "There is no free tile in the level; the entity can't be placed."));
+      Point position = tile.position();
+      // place on center
+      position.x += 0.5f;
+      position.y += 0.5f;
+      data.pc().position(position);
     }
   }
 

--- a/game/src/core/systems/PositionSystem.java
+++ b/game/src/core/systems/PositionSystem.java
@@ -4,7 +4,6 @@ import core.Entity;
 import core.Game;
 import core.System;
 import core.components.PositionComponent;
-import core.level.Tile;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import java.util.NoSuchElementException;

--- a/game/src/core/systems/PositionSystem.java
+++ b/game/src/core/systems/PositionSystem.java
@@ -44,13 +44,13 @@ public final class PositionSystem extends System {
    * @param data The PSData object containing entity and position component information.
    */
   private void randomPosition(final PSData data) {
-    Tile tile =
+    Point position =
         Game.freeTile()
             .orElseThrow(
                 () ->
                     new NoSuchElementException(
-                        "There is no free tile in the level; the entity can't be placed."));
-    Point position = tile.position();
+                        "There is no free tile in the level; the entity can't be placed."))
+            .position();
     // place on center
     position.x += 0.5f;
     position.y += 0.5f;

--- a/game/src/core/systems/PositionSystem.java
+++ b/game/src/core/systems/PositionSystem.java
@@ -44,12 +44,11 @@ public final class PositionSystem extends System {
    */
   private void randomPosition(final PSData data) {
     Point position =
-        Game.freeTile()
+        Game.freePosition()
             .orElseThrow(
                 () ->
                     new NoSuchElementException(
-                        "There is no free tile in the level; the entity can't be placed."))
-            .position();
+                        "There is no free tile in the level; the entity can't be placed."));
     // place on center
     position.x += 0.5f;
     position.y += 0.5f;

--- a/game/src/core/systems/PositionSystem.java
+++ b/game/src/core/systems/PositionSystem.java
@@ -44,6 +44,7 @@ public final class PositionSystem extends System {
    * @param data The PSData object containing entity and position component information.
    */
   private void randomPosition(final PSData data) {
+    // The Level can be null if the LevelSystem has not yet been executed (this may occur during the initial loop frame of the game).
     if (Game.currentLevel() != null) {
       Coordinate randomPosition = Game.randomTile(LevelElement.FLOOR).coordinate();
       boolean otherEntityIsOnThisCoordinate =

--- a/game/test/core/level/TileLevelTest.java
+++ b/game/test/core/level/TileLevelTest.java
@@ -15,6 +15,7 @@ import core.utils.Point;
 import core.utils.components.path.SimpleIPath;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -100,10 +101,11 @@ public class TileLevelTest {
         new LevelElement[][] {
           {LevelElement.WALL, LevelElement.WALL}, {LevelElement.WALL, LevelElement.WALL}
         };
-
-    TileLevel level = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
-    assertNull(level.startTile());
-    assertNull(level.endTile());
+    assertThrows(
+        NoSuchElementException.class,
+        () -> {
+          new TileLevel(elementsLayout, DesignLabel.DEFAULT);
+        });
   }
 
   /** WTF? . */
@@ -157,9 +159,10 @@ public class TileLevelTest {
   public void test_nodeCount_NoAccessible() {
     LevelElement[][] elementsLayout =
         new LevelElement[][] {
-          {LevelElement.WALL, LevelElement.WALL, LevelElement.WALL, LevelElement.WALL},
+          {LevelElement.FLOOR, LevelElement.WALL, LevelElement.WALL, LevelElement.WALL},
         };
     TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
+    tileLevel.changeTileElementType(tileLevel.startTile(), LevelElement.WALL);
     assertEquals(0, tileLevel.getNodeCount());
   }
 
@@ -215,10 +218,9 @@ public class TileLevelTest {
   /** WTF? . */
   @Test
   public void test_setRandomEnd_NoFloors() {
+    // given floor is for start
     LevelElement[][] elementsLayout =
-        new LevelElement[][] {
-          {LevelElement.WALL},
-        };
+        new LevelElement[][] {{LevelElement.WALL}, {LevelElement.FLOOR}};
     TileLevel tileLevel = new TileLevel(elementsLayout, DesignLabel.DEFAULT);
     tileLevel.randomEnd();
     assertNull(tileLevel.endTile());
@@ -409,7 +411,7 @@ public class TileLevelTest {
 
     TileLevel tileLevel = new TileLevel(layout, DesignLabel.DEFAULT);
 
-    Point randomWallPoint = tileLevel.randomTilePoint(LevelElement.WALL);
+    Point randomWallPoint = tileLevel.randomTilePoint(LevelElement.WALL).get();
     assertNotNull(randomWallPoint);
     Tile randomWall = tileLevel.tileAt(randomWallPoint.toCoordinate());
     assertNotNull(randomWall);
@@ -446,8 +448,8 @@ public class TileLevelTest {
 
     TileLevel tileLevel = new TileLevel(layout, DesignLabel.DEFAULT);
 
-    Point randomWallPoint = tileLevel.randomTilePoint(LevelElement.WALL);
-    Point randomFloorPoint = tileLevel.randomTilePoint(LevelElement.FLOOR);
+    Point randomWallPoint = tileLevel.randomTilePoint(LevelElement.WALL).get();
+    Point randomFloorPoint = tileLevel.randomTilePoint(LevelElement.FLOOR).get();
     Tile randomWall = tileLevel.tileAt(randomWallPoint.toCoordinate());
     Tile randomFloor = tileLevel.tileAt(randomFloorPoint.toCoordinate());
     assertEquals(LevelElement.WALL, randomWall.levelElement());

--- a/game/test/core/systems/CameraSystemTest.java
+++ b/game/test/core/systems/CameraSystemTest.java
@@ -10,6 +10,7 @@ import core.components.PositionComponent;
 import core.level.Tile;
 import core.level.elements.ILevel;
 import core.utils.Point;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +38,7 @@ public class CameraSystemTest {
     cameraSystem = new CameraSystem();
     Game.add(cameraSystem);
     Mockito.when(startTile.position()).thenReturn(testPoint);
-    Mockito.when(level.randomTilePoint(Mockito.any())).thenReturn(testPoint);
+    Mockito.when(level.randomTilePoint(Mockito.any())).thenReturn(Optional.of(testPoint));
     Mockito.when(level.startTile()).thenReturn(startTile);
     Game.add(new LevelSystem(null, null, () -> {}));
   }

--- a/game/test/core/systems/PositionSystemTest.java
+++ b/game/test/core/systems/PositionSystemTest.java
@@ -14,6 +14,7 @@ import core.level.utils.Coordinate;
 import core.level.utils.DesignLabel;
 import core.level.utils.LevelElement;
 import core.utils.Point;
+import core.utils.Tuple;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,8 +64,15 @@ public class PositionSystemTest {
         new LevelElement[][] {
           {LevelElement.FLOOR, LevelElement.WALL}, {LevelElement.WALL, LevelElement.WALL}
         };
-    Mockito.when(level.layout())
-        .thenReturn(new TileLevel(elementsLayout, DesignLabel.DEFAULT).layout());
+    Tile[][] layout = new TileLevel(elementsLayout, DesignLabel.DEFAULT).layout();
+    Mockito.when(level.layout()).thenReturn(layout);
+    Mockito.when(level.size()).thenReturn(new Tuple<>(2, 2));
+    Mockito.when(level.tileAt(Mockito.any(Coordinate.class)))
+        .thenAnswer(
+            invocation -> {
+              Coordinate c = invocation.getArgument(0);
+              return layout[c.y][c.x];
+            });
     pc.position(PositionComponent.ILLEGAL_POSITION);
     // entities will be placed in the center of a tile, so add the offset for check
     Point offsetPoint = new Point(point.x + 0.5f, point.y + 0.5f);

--- a/game/test/core/systems/PositionSystemTest.java
+++ b/game/test/core/systems/PositionSystemTest.java
@@ -7,11 +7,14 @@ import core.Entity;
 import core.Game;
 import core.components.PositionComponent;
 import core.level.Tile;
+import core.level.TileLevel;
 import core.level.elements.ILevel;
 import core.level.elements.tile.FloorTile;
 import core.level.utils.Coordinate;
+import core.level.utils.DesignLabel;
 import core.level.utils.LevelElement;
 import core.utils.Point;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +24,7 @@ import org.mockito.Mockito;
 public class PositionSystemTest {
 
   private final Tile mock = Mockito.mock(FloorTile.class);
-  private final Point point = new Point(3, 3);
+  private final Point point = new Point(0, 0);
   private final ILevel level = Mockito.mock(ILevel.class);
   private PositionSystem system;
   private Entity entity;
@@ -40,7 +43,7 @@ public class PositionSystemTest {
 
     entity.add(pc);
 
-    Mockito.when(level.randomTile(LevelElement.FLOOR)).thenReturn(mock);
+    Mockito.when(level.randomTile(LevelElement.FLOOR)).thenReturn(Optional.of(mock));
     Mockito.when(mock.position()).thenReturn(point);
     Mockito.when(mock.coordinate()).thenReturn(new Coordinate(3, 3));
   }
@@ -56,6 +59,12 @@ public class PositionSystemTest {
   /** WTF? . */
   @Test
   public void test_illegalPosition() {
+    LevelElement[][] elementsLayout =
+        new LevelElement[][] {
+          {LevelElement.FLOOR, LevelElement.WALL}, {LevelElement.WALL, LevelElement.WALL}
+        };
+    Mockito.when(level.layout())
+        .thenReturn(new TileLevel(elementsLayout, DesignLabel.DEFAULT).layout());
     pc.position(PositionComponent.ILLEGAL_POSITION);
     // entities will be placed in the center of a tile, so add the offset for check
     Point offsetPoint = new Point(point.x + 0.5f, point.y + 0.5f);


### PR DESCRIPTION
Fixes #1575

Konkret wird hier:
- Das erste Level wird nun durch ein `LevelSystem#execute` im Setup geladen. Damit entfällt ein null Check zur Laufzeit
- Das rekursive Verhalten beim Suchen nach freien Tiles entfernt und durch BFS ersetzt
- Einige API-Methoden zum Finden von Tiles hinzugefügt (haben sich aus dem Punkt oben ergeben).
    - `Game#allTiles` gibt alle Tiles als Set zurück
    - `Game#allTiles(LevelElement)` gibt alle Tiles des aktuellen Levels zurück
    - ` Game#allTiles(Predicate<Tile>)` gibt alle Tiles  des aktuellen Levels zurück dessen Predicate Ergebnis True ist. 
    - `Game#freeTile()` gibt ein freies Tile zurück (als Optional)
    - `Game#allFreeTiles()`gibt ein Set alle Freien Tiles zurück  
    - `Game#freePostion()` gibt die Position eines freien Tile zurück (als Optional)
    - `Game#isFreeTile(Tile)` prüft ob das gegeben Tile "frei" ist, das bedeuet accessible und nicht von Entitäten besetzt
    - `Game#accessibleTilesInRange(Position,float)` ruft die analoge Methode in `LevelUtils` auf und ist in Game nur ein alternative Weg zum aufruf. 
- `randomTile(LevelElement)` gibt nun korrekterweise ein `Optional<Tile>` zurück.
  - Dies hatte einige komplexe Stellen im Code, die entsprechend bearbeitet wurden.
- Tests angepasst.

