### PR TITLE
Add randomTile(LevelElement elementType) method to Game class

### DIFF
--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -403,6 +403,16 @@ public final class Game {
   }
 
   /**
+   * Get a random tile of the given type in the level.
+   *
+   * @param elementType The type of tile to retrieve.
+   * @return A random tile of the specified type in the level.
+   */
+  public static Optional<Tile> randomTile(LevelElement elementType) {
+    return currentLevel().randomTile(elementType);
+  }
+
+  /**
    * Get the neighbors of the given Tile.
    *
    * <p>Neighbors are the tiles directly above, below, left, and right of the given Tile.

--- a/game/test/core/GameTest.java
+++ b/game/test/core/GameTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import core.level.elements.ILevel;
+import core.level.utils.LevelElement;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -70,6 +71,16 @@ public class GameTest {
   public void find_nonExisting() {
     DummyComponent dc = new DummyComponent();
     assertTrue(Game.find(dc).isEmpty());
+  }
+
+  /** Test for the new randomTile(LevelElement elementType) method in Game class. */
+  @Test
+  public void testRandomTileWithElementType() {
+    ILevel level = Mockito.mock(ILevel.class);
+    Game.currentLevel(level);
+    LevelElement elementType = LevelElement.FLOOR;
+    Game.randomTile(elementType);
+    Mockito.verify(level).randomTile(elementType);
   }
 
   private static class DummyComponent implements Component {}


### PR DESCRIPTION
Fixes #1625

Add a new method `randomTile(LevelElement elementType)` to the `Game` class.

* **Game.java**
  - Add a new method `randomTile(LevelElement elementType)` that calls `currentLevel().randomTile(elementType)`.
  - Update the Javadoc for the new method to explain its purpose.

* **GameTest.java**
  - Add a new test method to verify the functionality of `Game.randomTile(LevelElement elementType)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Dungeon-CampusMinden/Dungeon/pull/1668?shareId=89dcbdd5-d9df-4ac9-95e1-a55b93256442).