### PR TITLE
Fix Blockly-Doc: Start game before Server

### DIFF
--- a/blockly/doc/installation.md
+++ b/blockly/doc/installation.md
@@ -37,7 +37,13 @@ npm install
 
 ## Schritt 4: Starten der Applikation
 
-Starten Sie den Vite.js-Entwicklungsserver, um "Blocky" lokal auszuführen:
+Starten Sie das Blockly-Dungeon mit:
+
+```bash
+gradlew runBlockly
+```
+
+Starten Sie dann den Vite.js-Entwicklungsserver, um "Blocky" lokal auszuführen:
 
 ```bash
 npm run dev


### PR DESCRIPTION
In der Blockly Anleitung fehlter der Hinweis, dass man das Spiel vorher starten muss. 