### PR TITLE
Blockly: Toggle VariableHUD on Keystroke

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -9,6 +9,7 @@ import contrib.systems.*;
 import contrib.utils.components.Debugger;
 import core.Entity;
 import core.Game;
+import core.components.PlayerComponent;
 import core.game.ECSManagment;
 import core.level.TileLevel;
 import core.level.elements.ILevel;
@@ -92,8 +93,9 @@ public class Client {
     Game.userOnLevelLoad(
         (firstLoad) -> {
           VariableHUD variableHUD = Server.instance().variableHUD;
-          if (variableHUD == null) { // should only be on first level load
-            variableHUD = new VariableHUD(Game.stage());
+          if (variableHUD == null
+              && Game.stage().isPresent()) { // should only be on first level load
+            variableHUD = new VariableHUD(Game.stage().get());
             Server.instance().variableHUD = variableHUD;
           }
 
@@ -184,6 +186,17 @@ public class Client {
     Entity hero;
     try {
       hero = (EntityFactory.newHero());
+      hero.fetch(PlayerComponent.class)
+          .flatMap(
+              fetch ->
+                  fetch.registerCallback(
+                      KeyboardConfig.TOGGLE_BLOCKLY_HUD.value(),
+                      (e) ->
+                          Server.instance()
+                              .variableHUD
+                              .visible(!Server.instance().variableHUD.visible()),
+                      false,
+                      true));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/blockly/src/client/KeyboardConfig.java
+++ b/blockly/src/client/KeyboardConfig.java
@@ -1,0 +1,11 @@
+package client;
+
+/** Keyboard-configuration for blockly-package. */
+@core.configuration.ConfigMap(path = {"keyboard"})
+public class KeyboardConfig {
+  /** Toggle the visibility of the blockly hud. */
+  public static final core.configuration.ConfigKey<Integer> TOGGLE_BLOCKLY_HUD =
+      new core.configuration.ConfigKey<>(
+          new String[] {"blockly", "toggle_blockly_hud"},
+          new core.configuration.values.ConfigIntValue(com.badlogic.gdx.Input.Keys.B));
+}

--- a/blockly/src/entities/VariableHUD.java
+++ b/blockly/src/entities/VariableHUD.java
@@ -19,7 +19,6 @@ import core.utils.components.path.IPath;
 import core.utils.components.path.SimpleIPath;
 import entities.utility.HUDVariable;
 import java.util.ArrayList;
-import java.util.Optional;
 import java.util.Random;
 import java.util.TreeSet;
 
@@ -29,8 +28,7 @@ import java.util.TreeSet;
  * were created in blockly.
  */
 public class VariableHUD extends BlocklyHUD {
-
-  private Stage stage;
+  private Table hudContainer;
   // General numbers used for table creation and scaling
   private final int xTiles = 28;
   private int yTiles = 16;
@@ -65,32 +63,35 @@ public class VariableHUD extends BlocklyHUD {
    * Initialize the variable and array HUD. It will add 4 tables to the stage. The variable tiles
    * table, the variable labels table, the array tiles table and the array labels table.
    *
-   * @param stage The variable HUD will be added to the given stage if it is not empty.
+   * @param stage The variable HUD will be added to the given stage.
    */
-  public VariableHUD(Optional<Stage> stage) {
-    if (stage.isEmpty()) {
-      return;
-    }
-    this.stage = stage.get();
+  public VariableHUD(Stage stage) {
+    this.hudContainer = new Table();
+    this.hudContainer.setFillParent(true);
+    stage.addActor(hudContainer);
+
+    // Initial size
+    this.hudContainer.setHeight(stage.getHeight());
+    this.hudContainer.setWidth(stage.getWidth());
 
     this.textureWall = createTexture(LevelElement.WALL, DesignLabel.FOREST);
     this.textureFloor = createTexture(LevelElement.FLOOR, DesignLabel.FOREST);
 
     this.varTable = createVariableTable(textureWall, textureFloor);
-    this.stage.addActor(varTable);
+    this.hudContainer.addActor(varTable);
 
     this.varLabels = createVariableLabels();
-    this.stage.addActor(varLabels);
+    this.hudContainer.addActor(varLabels);
 
     this.arrayTable = createArrayTable(textureWall, textureFloor);
-    this.stage.addActor(arrayTable);
+    this.hudContainer.addActor(arrayTable);
 
     this.arrayLabels = createArrayLabels();
     updateArrayLabelCells(false);
-    this.stage.addActor(arrayLabels);
+    this.hudContainer.addActor(arrayLabels);
 
     this.monsterTable = createMonsterTable();
-    this.stage.addActor(monsterTable);
+    this.hudContainer.addActor(monsterTable);
 
     loadMonsterTextures();
   }
@@ -121,7 +122,7 @@ public class VariableHUD extends BlocklyHUD {
    * @return Returns the widht for one tile.
    */
   private float getWidth() {
-    return this.stage.getWidth() / xTiles;
+    return this.hudContainer.getWidth() / xTiles;
   }
 
   /**
@@ -130,8 +131,8 @@ public class VariableHUD extends BlocklyHUD {
    * @return Returns the height for one tile.
    */
   private float getHeight() {
-    yTiles = (int) (this.stage.getHeight() / getWidth());
-    return this.stage.getHeight() / (float) yTiles;
+    yTiles = (int) (this.hudContainer.getHeight() / getWidth());
+    return this.hudContainer.getHeight() / (float) yTiles;
   }
 
   /**
@@ -286,7 +287,7 @@ public class VariableHUD extends BlocklyHUD {
   private void updateMonsterTable() {
     monsterTable.remove();
     monsterTable = createMonsterTable();
-    this.stage.addActor(monsterTable);
+    this.hudContainer.addActor(monsterTable);
   }
 
   /**
@@ -671,9 +672,9 @@ public class VariableHUD extends BlocklyHUD {
       // Create new table first
       Table newTable = createArrayTable(this.textureWall, this.textureFloor);
       // Remove old table
-      this.stage.getActors().removeValue(arrayTable, true);
+      this.hudContainer.getChildren().removeValue(arrayTable, true);
       // Set new table
-      this.stage.addActor(newTable);
+      this.hudContainer.addActor(newTable);
       arrayTable = newTable;
       return;
     }
@@ -700,9 +701,9 @@ public class VariableHUD extends BlocklyHUD {
       // Create new table first
       Table newTable = createArrayLabels();
       // Remove old table
-      this.stage.getActors().removeValue(arrayLabels, true);
+      this.hudContainer.getChildren().removeValue(arrayLabels, true);
       // Set new table
-      this.stage.addActor(newTable);
+      this.hudContainer.addActor(newTable);
       arrayLabels = newTable;
       updateArrayLabelCells(false);
       return;
@@ -729,6 +730,25 @@ public class VariableHUD extends BlocklyHUD {
         label.setFontScale(varNameScaling * scaling);
       }
     }
+  }
+
+  /**
+   * Set the visibility of the variable HUD. If the visibility is set to false, the HUD will not be
+   * displayed.
+   *
+   * @param visible True if the HUD should be visible, false otherwise.
+   */
+  public void visible(boolean visible) {
+    hudContainer.setVisible(visible);
+  }
+
+  /**
+   * Check if the variable HUD is currently visible.
+   *
+   * @return Returns true if the HUD is visible, false otherwise.
+   */
+  public boolean visible() {
+    return hudContainer.isVisible();
   }
 
   /**


### PR DESCRIPTION
Ich habe eine Funktion eingebaut mit dem man das `VariableHUD` unsichtbar und wieder sichbar machen kann per Tastendruck.
Die Tastenbelegung ist: **B**

Änderungen:
1. Der Ctor Parameter für das `VariableHUD` ist nicht mehr Optional, da das HUD die Stage braucht.
2. Das `VariableHUD` speichert nicht mehr die Stage, sondern ein `Table`. Hier dient `Table` als Gruppe von Objekten im UI, es wird `Table` statt `Group` verwendet um dynamisch die Größe zu ändern per `table.setFillParent(true)` . Groups bzw. Tables haben das Field `visible` um die Actors (UI-Elemente) auszublenden. Dieses Field ist per Getter und Setter im `VariableHUD` veränderbar.
3. Es wurde ein neue `KeyboardConfig` für Blockly erstellt. Diese hat den neuen Keybind für das Togglen des `VariableHUD`. Die Logik dafür ist im `Client` per `PlayerComponent` umgesetzt wurden.

closes #1697