### PR TITLE
Blockly: Fix toggle Blockly HUD

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -39,7 +39,6 @@ public class Client {
   private static int currentLevel = 0;
   private static HttpServer httpServer;
   private static boolean blocklyHUDEnabled = false;
-  private static boolean firstTimeBlocklyHUD = true;
   private static Entity hudEntity;
 
   /**
@@ -62,7 +61,11 @@ public class Client {
 
     onFrame(debugger);
 
-    toggleBlocklyHUD();
+    Game.userOnLevelLoad(
+        (firstLoad) -> {
+          toggleBlocklyHUD();
+          Game.userOnLevelLoad((firstLoad1) -> {});
+        });
 
     // build and start game
     Game.run();
@@ -93,17 +96,6 @@ public class Client {
   }
 
   public static void toggleBlocklyHUD() {
-    if (firstTimeBlocklyHUD) {
-      firstTimeBlocklyHUD = false;
-      if (blocklyHUDEnabled) {
-        Game.userOnLevelLoad(
-            (firstLoad) -> {
-              toggleBlocklyHUD();
-              Game.userOnLevelLoad((firstLoad1) -> {});
-            });
-      }
-      return;
-    }
     if (blocklyHUDEnabled) {
       VariableHUD variableHUD = new VariableHUD(Game.stage().orElseThrow());
       Server.instance().variableHUD = variableHUD;

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -95,6 +95,10 @@ public class Client {
         });
   }
 
+  /**
+   * Toggle the visibility of the blockly hud. If the hud is enabled, the hud will be disabled and
+   * vice versa.
+   */
   public static void toggleBlocklyHUD() {
     if (blocklyHUDEnabled) {
       VariableHUD variableHUD = new VariableHUD(Game.stage().orElseThrow());

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -99,7 +99,7 @@ public class Client {
    * Toggle the visibility of the blockly hud. If the hud is enabled, the hud will be disabled and
    * vice versa.
    */
-  public static void toggleBlocklyHUD() {
+  private static void toggleBlocklyHUD() {
     if (blocklyHUDEnabled) {
       VariableHUD variableHUD = new VariableHUD(Game.stage().orElseThrow());
       Server.instance().variableHUD = variableHUD;

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -110,7 +110,7 @@ public class Client {
         hudEntity = null;
       }
       if (Server.instance().variableHUD != null) {
-        Server.instance().variableHUD.destroy();
+        Server.instance().variableHUD.dispose();
         Server.instance().variableHUD = null;
       }
     }

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -95,6 +95,13 @@ public class Client {
   public static void toggleBlocklyHUD() {
     if (firstTimeBlocklyHUD) {
       firstTimeBlocklyHUD = false;
+      if (blocklyHUDEnabled) {
+        Game.userOnLevelLoad(
+            (firstLoad) -> {
+              toggleBlocklyHUD();
+              Game.userOnLevelLoad((firstLoad1) -> {});
+            });
+      }
       return;
     }
     if (blocklyHUDEnabled) {

--- a/blockly/src/entities/VariableHUD.java
+++ b/blockly/src/entities/VariableHUD.java
@@ -96,6 +96,27 @@ public class VariableHUD extends BlocklyHUD {
     loadMonsterTextures();
   }
 
+  public void destroy() {
+    if (monsterTable != null) {
+      monsterTable.remove();
+    }
+    if (arrayLabels != null) {
+      arrayLabels.remove();
+    }
+    if (arrayTable != null) {
+      arrayTable.remove();
+    }
+    if (varLabels != null) {
+      varLabels.remove();
+    }
+    if (varTable != null) {
+      varTable.remove();
+    }
+    if (hudContainer != null) {
+      hudContainer.remove();
+    }
+  }
+
   /** Load all textures for the monsters. This will be called initially once. */
   private void loadMonsterTextures() {
     monsterTextures = new ArrayList<>();

--- a/blockly/src/entities/VariableHUD.java
+++ b/blockly/src/entities/VariableHUD.java
@@ -96,7 +96,11 @@ public class VariableHUD extends BlocklyHUD {
     loadMonsterTextures();
   }
 
-  public void destroy() {
+  /**
+   * Dispose the variable HUD. This will remove all tables and labels from the stage in reverse
+   * order of creation.
+   */
+  public void dispose() {
     if (monsterTable != null) {
       monsterTable.remove();
     }

--- a/blockly/src/entities/VariableHUD.java
+++ b/blockly/src/entities/VariableHUD.java
@@ -101,24 +101,12 @@ public class VariableHUD extends BlocklyHUD {
    * order of creation.
    */
   public void dispose() {
-    if (monsterTable != null) {
-      monsterTable.remove();
-    }
-    if (arrayLabels != null) {
-      arrayLabels.remove();
-    }
-    if (arrayTable != null) {
-      arrayTable.remove();
-    }
-    if (varLabels != null) {
-      varLabels.remove();
-    }
-    if (varTable != null) {
-      varTable.remove();
-    }
-    if (hudContainer != null) {
-      hudContainer.remove();
-    }
+    monsterTable.remove();
+    arrayLabels.remove();
+    arrayTable.remove();
+    varLabels.remove();
+    varTable.remove();
+    hudContainer.remove();
   }
 
   /** Load all textures for the monsters. This will be called initially once. */


### PR DESCRIPTION
fixes #1697 

see https://github.com/Dungeon-CampusMinden/Dungeon/pull/1703#issuecomment-2658746446

Dieser Pull Request führt mehrere Änderungen an den Klassen `Client` und `VariableHUD` ein, um die Funktionalität des Blockly HUD zu verbessern. Zu den wichtigsten Änderungen gehören das Hinzufügen eines Umschaltmechanismus für das Blockly HUD, das Refactoring der Initialisierung und das Hinzufügen einer Dispose-Methode für das HUD.

Das HUD ist jetzt standardmäßig ausgestellt.