### PR TITLE
Blockly: Fix memory leak in VariableHUD

### DIFF
--- a/blockly/src/entities/VariableHUD.java
+++ b/blockly/src/entities/VariableHUD.java
@@ -189,11 +189,15 @@ public class VariableHUD extends BlocklyHUD {
     table.bottom();
     table.setFillParent(true);
 
-    createVarRow(table, textureWall);
+    for (int i = 0; i < xTiles; i++) {
+      createVarRow(table, textureWall);
+    }
     table.row();
 
-    for (int i = 0; i < varTiles - 1; i++) {
-      createVarRow(table, textureFloor);
+    for (int j = 0; j < varTiles - 1; j++) {
+      for (int i = 0; i < xTiles; i++) {
+        createVarRow(table, textureFloor);
+      }
       table.row();
     }
     return table;

--- a/blockly/src/entities/VariableHUD.java
+++ b/blockly/src/entities/VariableHUD.java
@@ -28,6 +28,9 @@ import java.util.TreeSet;
  * were created in blockly.
  */
 public class VariableHUD extends BlocklyHUD {
+  // Default label style
+  private static final Label.LabelStyle default_labelStyle = new Label.LabelStyle(new BitmapFont(), Color.WHITE);
+
   private Table hudContainer;
   // General numbers used for table creation and scaling
   private final int xTiles = 28;
@@ -227,7 +230,7 @@ public class VariableHUD extends BlocklyHUD {
 
     for (int j = 0; j < 2; j++) {
       for (int i = 0; i < xTiles / 2; i++) {
-        Label label = new Label("", new Label.LabelStyle(new BitmapFont(), Color.WHITE));
+        Label label = new Label("", default_labelStyle);
         if (j == 0) {
           label.setFontScale(varNameScaling);
         } else {
@@ -401,7 +404,7 @@ public class VariableHUD extends BlocklyHUD {
     float scaling = getFontScaling();
 
     for (int i = 0; i < 2; i++) {
-      Label arrayLabel = new Label("", new Label.LabelStyle(new BitmapFont(), Color.WHITE));
+      Label arrayLabel = new Label("", default_labelStyle);
       arrayLabel.setAlignment(Align.center);
       arrayLabel.setFontScale(varNameScaling * scaling);
 
@@ -429,11 +432,11 @@ public class VariableHUD extends BlocklyHUD {
     float paddingLeft = getWidth() * (xTiles - 4);
     float scaling = getFontScaling();
     for (int i = 0; i < 2; i++) {
-      Label labelValue = new Label("", new Label.LabelStyle(new BitmapFont(), Color.WHITE));
+      Label labelValue = new Label("", default_labelStyle);
       labelValue.setFontScale(valueScaling * scaling);
       labelValue.setAlignment(Align.center);
 
-      Label labelIndex = new Label("", new Label.LabelStyle(new BitmapFont(), Color.WHITE));
+      Label labelIndex = new Label("", default_labelStyle);
       labelIndex.setFontScale(indexScaling * scaling);
       labelIndex.setAlignment(Align.center);
 

--- a/blockly/src/entities/VariableHUD.java
+++ b/blockly/src/entities/VariableHUD.java
@@ -188,15 +188,11 @@ public class VariableHUD extends BlocklyHUD {
     table.bottom();
     table.setFillParent(true);
 
-    for (int i = 0; i < xTiles; i++) {
-      createVarRow(table, textureWall);
-    }
+    createVarRow(table, textureWall);
     table.row();
 
-    for (int j = 0; j < varTiles - 1; j++) {
-      for (int i = 0; i < xTiles; i++) {
-        createVarRow(table, textureFloor);
-      }
+    for (int i = 0; i < varTiles - 1; i++) {
+      createVarRow(table, textureFloor);
       table.row();
     }
     return table;

--- a/blockly/src/entities/VariableHUD.java
+++ b/blockly/src/entities/VariableHUD.java
@@ -29,7 +29,8 @@ import java.util.TreeSet;
  */
 public class VariableHUD extends BlocklyHUD {
   // Default label style
-  private static final Label.LabelStyle default_labelStyle = new Label.LabelStyle(new BitmapFont(), Color.WHITE);
+  private static final Label.LabelStyle default_labelStyle =
+      new Label.LabelStyle(new BitmapFont(), Color.WHITE);
 
   private Table hudContainer;
   // General numbers used for table creation and scaling


### PR DESCRIPTION
Ich habe den Memory Leak im `VariableHUD` behoben. Das Problem lag darin, dass bei jeder Erstellung des HUDs mehrfach identische `BitmapFont` Instanzen (sowie die dazugehörige `LabelStyle`) neu erstellt wurden, anstatt diese als statischen Wert zu einmalig zu speichern. Das HUD verbraucht jetzt nur noch circa 10MB Speicher, statt 100-300MB

Änderungen:
1. `BitmapFont` und `LabelStyle` werden nun als statische Instanzen genutzt, um mehrfaches Allozieren von Memory zu verhindern.

closes #1706