### PR TITLE
Blockly: Fix HUD scaling on maximize

### DIFF
--- a/blockly/src/entities/VariableHUD.java
+++ b/blockly/src/entities/VariableHUD.java
@@ -29,6 +29,8 @@ import java.util.TreeSet;
  */
 public class VariableHUD extends BlocklyHUD {
   private Table hudContainer;
+  private Stage stage;
+
   // General numbers used for table creation and scaling
   private final int xTiles = 28;
   private int yTiles = 16;
@@ -66,13 +68,15 @@ public class VariableHUD extends BlocklyHUD {
    * @param stage The variable HUD will be added to the given stage.
    */
   public VariableHUD(Stage stage) {
+    this.stage = stage;
+
     this.hudContainer = new Table();
     this.hudContainer.setFillParent(true);
-    stage.addActor(hudContainer);
+    this.stage.addActor(hudContainer);
 
     // Initial size
-    this.hudContainer.setHeight(stage.getHeight());
-    this.hudContainer.setWidth(stage.getWidth());
+    this.hudContainer.setHeight(this.stage.getHeight());
+    this.hudContainer.setWidth(this.stage.getWidth());
 
     this.textureWall = createTexture(LevelElement.WALL, DesignLabel.FOREST);
     this.textureFloor = createTexture(LevelElement.FLOOR, DesignLabel.FOREST);
@@ -637,6 +641,8 @@ public class VariableHUD extends BlocklyHUD {
    */
   @Override
   public void updateActors() {
+    this.hudContainer.setHeight(this.stage.getHeight());
+    this.hudContainer.setWidth(this.stage.getWidth());
     // yTiles might change after the first call of getHeight(). Save current value here to track if
     // array tables must be
     // adjusted

--- a/blockly/src/entities/VariableHUD.java
+++ b/blockly/src/entities/VariableHUD.java
@@ -189,17 +189,15 @@ public class VariableHUD extends BlocklyHUD {
     table.bottom();
     table.setFillParent(true);
 
-    for (int i = 0; i < xTiles; i++) {
-      createVarRow(table, textureWall);
-    }
+    createVarRow(table, textureWall);
+
     table.row();
 
-    for (int j = 0; j < varTiles - 1; j++) {
-      for (int i = 0; i < xTiles; i++) {
-        createVarRow(table, textureFloor);
-      }
+    for (int i = 0; i < varTiles - 1; i++) {
+      createVarRow(table, textureFloor);
       table.row();
     }
+
     return table;
   }
 


### PR DESCRIPTION
Es wurde behoben, dass das HUD beim Maximieren des Spiels nicht korrekt neu skaliert wurde. Der Fehler lag darin, dass der `hudContainer` nicht an die neue Größe der `stage ` angepasst wurde. Mit dieser Änderung wird der Container nun mit der Stage skaliert, sodass das HUD ordnungsgemäß dargestellt wird.

Zusätzlich habe ich die Anzahl der im HUD erstellten Images korrigiert: Statt fälschlicherweise 2000 werden nun nur noch 84 Bilder erzeugt. 

Änderungen:
1. `hudContainer` wird dynamisch auf die aktuelle Stage-Größe angepasst.
2. Reduzierung der im HUD erstellten Images von ~2000 auf 84.
3. Konsistente Skalierung des HUDs durch Anpassung des Containers an die Stage.

fixes #1708