### PR TITLE
Blockly: Implement Block Limiting and Toolbox Type Enhancement

### DIFF
--- a/blockly/frontend/src/config.ts
+++ b/blockly/frontend/src/config.ts
@@ -6,6 +6,9 @@ interface Config {
   HIDE_GENERATED_CODE: boolean;
   HIDE_RESPONSE_INFO: boolean;
   ARRAY_MAX_VALUE: number;
+  LIMITS: {
+    [key: string]: number;
+  };
 }
 
 export const config: Config = {
@@ -16,4 +19,7 @@ export const config: Config = {
   HIDE_GENERATED_CODE: false,
   HIDE_RESPONSE_INFO: true,
   ARRAY_MAX_VALUE: 10,
+  LIMITS: {
+    //"fireball_.*": 1, // max 1 fireball
+  }
 };

--- a/blockly/frontend/src/index.ts
+++ b/blockly/frontend/src/index.ts
@@ -90,7 +90,6 @@ if (workspace) {
   });
 
   // Limits
-  // Update counts of each blockType
   workspace.addChangeListener((e: Blockly.Events.Abstract) => {
     let update = false;
     if (e.type == Blockly.Events.BLOCK_CREATE) {
@@ -98,7 +97,7 @@ if (workspace) {
       if (newBlockId === undefined) return;
       const newBlock = workspace.getBlockById(newBlockId);
       if (newBlock === null) return;
-      LimitUtils.registerBlockAdded(newBlock);
+      LimitUtils.registerBlockAdded(newBlock as unknown as Blockly.serialization.blocks.State);
       update = true;
     } else if (e.type == Blockly.Events.BLOCK_DELETE) {
       const oldBlockState = (e as Blockly.Events.BlockDelete).oldJson;
@@ -109,6 +108,7 @@ if (workspace) {
     // disable block if limit is reached
     if (update) {
       LimitUtils.refreshToolbox(workspace);
+      workspace.getToolbox()?.refreshSelection();
     }
   });
 }

--- a/blockly/frontend/src/index.ts
+++ b/blockly/frontend/src/index.ts
@@ -98,17 +98,17 @@ if (workspace) {
       if (newBlockId === undefined) return;
       const newBlock = workspace.getBlockById(newBlockId);
       if (newBlock === null) return;
-      LimitUtils.onNewBlock(newBlock);
+      LimitUtils.registerBlockAdded(newBlock);
       update = true;
     } else if (e.type == Blockly.Events.BLOCK_DELETE) {
       const oldBlockState = (e as Blockly.Events.BlockDelete).oldJson;
       if (oldBlockState === undefined) return;
-      LimitUtils.onDeleteBlock(oldBlockState);
+      LimitUtils.registerBlockRemoved(oldBlockState);
       update = true;
     }
     // disable block if limit is reached
     if (update) {
-      LimitUtils.updateToolbox(workspace);
+      LimitUtils.refreshToolbox(workspace);
     }
   });
 }

--- a/blockly/frontend/src/limits.ts
+++ b/blockly/frontend/src/limits.ts
@@ -1,69 +1,92 @@
 import * as Blockly from "blockly";
-import {config} from "./config.ts";
-import {toolbox} from "./toolbox.ts";
+import {config} from "./config";
+import {toolbox} from "./toolbox";
 
-const counts: Record<string, number> = {};
+const blockCounts: Record<string, number> = {};
 
-export function onNewBlock(block: Blockly.Block) {
-  const blockType = block.type;
-  if (blockType in counts) {
-    counts[blockType]++;
-  } else {
-    counts[blockType] = 1;
+/**
+ * Increases the count for a newly added block type.
+ * @param block - The Blockly block that was added.
+ */
+export function registerBlockAdded(block: Blockly.Block): void {
+  const type = block.type;
+  blockCounts[type] = (blockCounts[type] ?? 0) + 1;
+}
+
+/**
+ * Decreases the count for a removed block type.
+ * @param block - The Blockly block state that was removed.
+ */
+export function registerBlockRemoved(block: Blockly.serialization.blocks.State): void {
+  const type = block.type;
+  if (type in blockCounts) {
+    blockCounts[type]--;
   }
 }
 
-export function onDeleteBlock(block: Blockly.serialization.blocks.State) {
-  const blockType = block.type;
-  if (blockType in counts) {
-    counts[blockType]--;
-  }
+/**
+ * Retrieves a list of limit rules that have been reached based on the current block counts.
+ * @returns An array of objects containing the rule name and its corresponding regex.
+ */
+function getReachedLimitRules(): { rule: string; regex: RegExp }[] {
+  return Object.keys(config.LIMITS).map(rule => ({
+    rule,
+    regex: new RegExp(`^${rule}$`)
+  }));
 }
 
-function getAllReachedLimitRules() {
-  const rules: string[] = [];
-  for (const key in config.LIMITS) {
-    const regex = new RegExp(`^${key}$`);
-    for (const blockType in counts) {
-      if (regex.test(blockType) && counts[blockType] >= config.LIMITS[key]) {
-        rules.push(key);
-      }
+/**
+ * Extracts all block items from the toolbox, including nested categories.
+ * @param items - The toolbox item information array.
+ * @returns An array of block information objects.
+ */
+function extractBlockItems(items: Blockly.utils.toolbox.ToolboxItemInfo[]): Blockly.utils.toolbox.BlockInfo[] {
+  const result: Blockly.utils.toolbox.BlockInfo[] = [];
+  const stack: Blockly.utils.toolbox.ToolboxItemInfo[] = [...items];
+
+  while (stack.length) {
+    const item = stack.pop()! as Blockly.utils.toolbox.StaticCategoryInfo;
+    if (item.kind === "block") {
+      result.push(item);
+    } else if (item.kind === "category" && item.contents) {
+      stack.push(...item.contents);
     }
   }
-  return rules;
+
+  return result;
 }
 
+/**
+ * Updates the enabled state of each block item based on the reached limit rules.
+ * @param blocks - The array of block information objects to update.
+ */
+function applyDisablingToBlocks(blocks: Blockly.utils.toolbox.BlockInfo[]): void {
+  const compiledRules = getReachedLimitRules().filter(({rule, regex}) =>
+    Object.entries(blockCounts).some(
+      ([type, count]) => regex.test(type) && count >= config.LIMITS[rule]
+    )
+  );
 
-export function updateToolbox(workspace: Blockly.WorkspaceSvg) {
-  const allReachedLimitRules = getAllReachedLimitRules();
-
-  // get alls blocks in toolbox
-  const blocks: Blockly.utils.toolbox.BlockInfo[] = [];
-  // checking every category/subcategory etc.
-  const queue: Blockly.utils.toolbox.ToolboxItemInfo[] = Array.from((toolbox as Blockly.utils.toolbox.ToolboxInfo).contents);
-  while (queue.length > 0) {
-    const item = queue.shift() as Blockly.utils.toolbox.StaticCategoryInfo;
-    if (item === undefined) continue;
-    if (item.kind === "category") {
-      queue.push(...(item.contents));
-    } else if (item.kind === "block") {
-      blocks.push(item);
-    }
-  }
-
-  // disable blocks if limit is reached
-  for (const item of blocks) {
-    item.enabled = true;
-    delete item.disabledReasons
-    for (const rule of allReachedLimitRules) {
-      const regex = new RegExp(`^${rule}$`);
-      item.enabled = !regex.test(item.type!);
-      if (!item.enabled) {
-        item.disabledReasons = [`Limit ${rule} reached`];
+  for (const blockItem of blocks) {
+    blockItem.enabled = true;
+    delete blockItem.disabledReasons;
+    for (const {rule, regex} of compiledRules) {
+      if (regex.test(blockItem.type!)) {
+        blockItem.enabled = false;
+        blockItem.disabledReasons = [`Limit ${rule} reached`];
         break;
       }
     }
   }
+}
 
+/**
+ * Refreshes the toolbox in the given workspace based on the current block counts and reached limits.
+ * @param workspace - The Blockly workspace where the toolbox should be updated.
+ */
+export function refreshToolbox(workspace: Blockly.WorkspaceSvg): void {
+  const toolboxInfo = toolbox as Blockly.utils.toolbox.ToolboxInfo;
+  const blockItems = extractBlockItems(toolboxInfo.contents);
+  applyDisablingToBlocks(blockItems);
   workspace.updateToolbox(toolbox);
 }

--- a/blockly/frontend/src/limits.ts
+++ b/blockly/frontend/src/limits.ts
@@ -11,7 +11,6 @@ const blockCounts: Record<string, number> = {};
 function addBlock(block: Blockly.serialization.blocks.State): void {
   const type = block.type;
   blockCounts[type] = (blockCounts[type] ?? 0) + 1;
-  console.debug(`Added block of type: '${type}' -> ${blockCounts[type]}`);
 }
 
 function removeBlock(block: Blockly.serialization.blocks.State): void {
@@ -19,7 +18,6 @@ function removeBlock(block: Blockly.serialization.blocks.State): void {
   if (type in blockCounts) {
     blockCounts[type]--;
   }
-  console.debug(`Removed block of type: '${type}' -> ${blockCounts[type]}`);
 }
 
 /**

--- a/blockly/frontend/src/limits.ts
+++ b/blockly/frontend/src/limits.ts
@@ -1,0 +1,69 @@
+import * as Blockly from "blockly";
+import {config} from "./config.ts";
+import {toolbox} from "./toolbox.ts";
+
+const counts: Record<string, number> = {};
+
+export function onNewBlock(block: Blockly.Block) {
+  const blockType = block.type;
+  if (blockType in counts) {
+    counts[blockType]++;
+  } else {
+    counts[blockType] = 1;
+  }
+}
+
+export function onDeleteBlock(block: Blockly.serialization.blocks.State) {
+  const blockType = block.type;
+  if (blockType in counts) {
+    counts[blockType]--;
+  }
+}
+
+function getAllReachedLimitRules() {
+  const rules: string[] = [];
+  for (const key in config.LIMITS) {
+    const regex = new RegExp(`^${key}$`);
+    for (const blockType in counts) {
+      if (regex.test(blockType) && counts[blockType] >= config.LIMITS[key]) {
+        rules.push(key);
+      }
+    }
+  }
+  return rules;
+}
+
+
+export function updateToolbox(workspace: Blockly.WorkspaceSvg) {
+  const allReachedLimitRules = getAllReachedLimitRules();
+
+  // get alls blocks in toolbox
+  const blocks: Blockly.utils.toolbox.BlockInfo[] = [];
+  // checking every category/subcategory etc.
+  const queue: Blockly.utils.toolbox.ToolboxItemInfo[] = Array.from((toolbox as Blockly.utils.toolbox.ToolboxInfo).contents);
+  while (queue.length > 0) {
+    const item = queue.shift() as Blockly.utils.toolbox.StaticCategoryInfo;
+    if (item === undefined) continue;
+    if (item.kind === "category") {
+      queue.push(...(item.contents));
+    } else if (item.kind === "block") {
+      blocks.push(item);
+    }
+  }
+
+  // disable blocks if limit is reached
+  for (const item of blocks) {
+    item.enabled = true;
+    delete item.disabledReasons
+    for (const rule of allReachedLimitRules) {
+      const regex = new RegExp(`^${rule}$`);
+      item.enabled = !regex.test(item.type!);
+      if (!item.enabled) {
+        item.disabledReasons = [`Limit ${rule} reached`];
+        break;
+      }
+    }
+  }
+
+  workspace.updateToolbox(toolbox);
+}

--- a/blockly/frontend/src/toolbox.ts
+++ b/blockly/frontend/src/toolbox.ts
@@ -1,4 +1,6 @@
-export const toolbox = {
+import * as Blockly from "blockly";
+
+export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
   kind: "categoryToolbox",
   contents: [
     {
@@ -56,7 +58,7 @@ export const toolbox = {
         {
           kind: "button",
           text: "Variable erstellen",
-          callbackKey: "createVariable",
+          callbackkey: "createVariable",
         },
         {
 


### PR DESCRIPTION
Dieser PR führt eine neue Logik ein, mit der man bestimmte Blöcke limitieren kann. Über die `config.ts` lässt sich ein Regex angeben, dem ein Limit zugeordnet wird. So können beispielsweise alle Blöcke, die mit `fireball_*` beginnen (Alle Fireball Skills), beschränkt werden.

Funktionsweise der Block-Limitierung:
1. Wird ein Block ins Workspace gezogen, wird er erfasst.
2. Erreicht die Anzahl der erfassten Blöcke das definierte Limit, werden die entsprechenden Blöcke in der Toolbox deaktiviert und können nicht mehr platziert werden.
3. Wird ein Block gelöscht, wird das Limit automatisch wieder freigegeben.
4. Auch Sub-Blöcke (Input oder Folgeblock eines anderen Blocks) werden erkannt und berücksichtigt.

Zusätzlich wurde in `toolbox.ts` der Typ der Toolbox um `ToolboxDefinition` ergänzt.