### PR TITLE
Dungeon: Mouse control for Inventory and Item Usag

### DIFF
--- a/dungeon/src/contrib/configuration/KeyboardConfig.java
+++ b/dungeon/src/contrib/configuration/KeyboardConfig.java
@@ -14,6 +14,15 @@ public class KeyboardConfig {
   public static final ConfigKey<Integer> INVENTORY_OPEN =
       new ConfigKey<>(new String[] {"inventory", "open"}, new ConfigIntValue(Input.Keys.I));
 
+  /**
+   * If Mouse Movement is enabled. This key is used to open and close the inventory.
+   *
+   * @see contrib.entities.HeroFactory#ENABLE_MOUSE_MOVEMENT
+   */
+  public static final ConfigKey<Integer> MOUSE_INVENTORY_TOGGLE =
+      new ConfigKey<>(
+          new String[] {"inventory", "mouse"}, new ConfigIntValue(Input.Buttons.MIDDLE));
+
   /** WTF? . */
   public static final ConfigKey<Integer> CLOSE_UI =
       new ConfigKey<>(new String[] {"ui", "close"}, new ConfigIntValue(Input.Keys.ESCAPE));
@@ -33,6 +42,16 @@ public class KeyboardConfig {
   /** WTF? . */
   public static final ConfigKey<Integer> USE_ITEM =
       new ConfigKey<>(new String[] {"item", "use"}, new ConfigIntValue(Input.Keys.E));
+
+  /**
+   * If Mouse Movement is enabled. This key is used to use an item. Only works if in Hero's
+   * inventory.
+   *
+   * @see contrib.entities.HeroFactory#ENABLE_MOUSE_MOVEMENT
+   * @see contrib.hud.inventory.InventoryGUI#inHeroInventory
+   */
+  public static final ConfigKey<Integer> MOUSE_USE_ITEM =
+      new ConfigKey<>(new String[] {"item", "mouse"}, new ConfigIntValue(Input.Buttons.RIGHT));
 
   /**
    * Quickly transfers an item from one inventory to another. E.g. chest to player or player to

--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -191,26 +191,24 @@ public final class HeroFactory {
           false);
     }
 
+    // UI controls
     pc.registerCallback(
         KeyboardConfig.INVENTORY_OPEN.value(),
-        (e) -> {
-          if (pc.openDialogs()) {
-            return; // do not open inventory if dialogs are open
-          }
-
-          UIComponent uiComponent = e.fetch(UIComponent.class).orElse(null);
-          if (uiComponent != null) {
-            if (uiComponent.dialog() instanceof GUICombination) {
-              InventoryGUI.inHeroInventory = false;
-              e.remove(UIComponent.class);
-            }
-          } else {
-            InventoryGUI.inHeroInventory = true;
-            e.add(new UIComponent(new GUICombination(new InventoryGUI(ic)), true));
-          }
+        (entity) -> {
+          toggleInventory(entity, pc, ic);
         },
         false,
         true);
+
+    if (ENABLE_MOUSE_MOVEMENT) {
+      pc.registerCallback(
+          KeyboardConfig.MOUSE_INVENTORY_TOGGLE.value(),
+          (entity) -> {
+            toggleInventory(entity, pc, ic);
+          },
+          false,
+          true);
+    }
 
     pc.registerCallback(
         KeyboardConfig.CLOSE_UI.value(),
@@ -268,6 +266,23 @@ public final class HeroFactory {
         KeyboardConfig.FIRST_SKILL.value(), heroEntity -> HERO_SKILL.execute(heroEntity));
 
     return hero;
+  }
+
+  private static void toggleInventory(Entity entity, PlayerComponent pc, InventoryComponent ic) {
+    if (pc.openDialogs()) {
+      return;
+    }
+
+    UIComponent uiComponent = entity.fetch(UIComponent.class).orElse(null);
+    if (uiComponent != null) {
+      if (uiComponent.dialog() instanceof GUICombination) {
+        InventoryGUI.inHeroInventory = false;
+        entity.remove(UIComponent.class);
+      }
+    } else {
+      InventoryGUI.inHeroInventory = true;
+      entity.add(new UIComponent(new GUICombination(new InventoryGUI(ic)), true));
+    }
   }
 
   private static void registerMovement(PlayerComponent pc, int key, Vector2 direction) {

--- a/dungeon/src/contrib/hud/inventory/InventoryGUI.java
+++ b/dungeon/src/contrib/hud/inventory/InventoryGUI.java
@@ -373,7 +373,16 @@ public class InventoryGUI extends CombinableGUI {
               @Override
               public boolean touchDown(
                   InputEvent event, float x, float y, int pointer, int button) {
-                if (inHeroInventory) return false;
+                if (inHeroInventory) {
+                  if (KeyboardConfig.MOUSE_USE_ITEM.value() == button) {
+                    // if in hero inventory, allow using items if key is pressed
+                    InventoryGUI.this.useItem(
+                        InventoryGUI.this.inventoryComponent.get(
+                            InventoryGUI.this.getSlotByMousePosition()));
+                    return true;
+                  }
+                  return false;
+                }
 
                 UIComponent uiComponent =
                     Game.hero().flatMap(e -> e.fetch(UIComponent.class)).orElse(null);


### PR DESCRIPTION
In diesem PR wurde die Maussteuerung erweitert:

- Das Inventar kann nun per Mausrad (mittlere Maustaste) geöffnet und geschlossen werden.
- Items können per Rechtsklick direkt im Inventar verwendet werden. Analog zum Verschieben in einem Cauldron oder einer Kiste.
- In der `Herofactory ` wurde die Logik für das Toggle des Inventars in eine eigene Methode refactored, sodass sie nun auch für die Maussteuerung aufgerufen werden kann.
