### PR TITLE
Blockly: Add new linter rule to enforce newline at end of files

### DIFF
--- a/blockly/frontend/eslint.config.js
+++ b/blockly/frontend/eslint.config.js
@@ -18,6 +18,8 @@ export default [
                     argsIgnorePattern: '^_',
                 },
             ],
+            // Enforce newline at the end of files
+            'eol-last': ['error', 'always'],
         },
     },
 ];


### PR DESCRIPTION
Ich habe eine neue Linter-Regel `eol-last` hinzugefügt, um sicherzustellen, dass jede `.ts` und `.js` Datei mit einer neuen Zeile endet.  

- `.eslint.config.js`: Regel `eol-last` hinzugefügt.