### PR TITLE
Core: add direction of view

### DIFF
--- a/game/src/core/components/PositionComponent.java
+++ b/game/src/core/components/PositionComponent.java
@@ -3,6 +3,7 @@ package core.components;
 import core.Component;
 import core.level.Tile;
 import core.utils.Point;
+import core.utils.components.position.Direction;
 import dsl.annotation.DSLType;
 
 /**
@@ -10,8 +11,8 @@ import dsl.annotation.DSLType;
  *
  * <p>Various systems access the position of an entity through this component, e.g., the {@link
  * core.systems.DrawSystem} uses the position to draw an entity in the right place, and the {@link
- * core.systems.VelocitySystem} updates the position values based on the velocity and the previous
- * position of an entity.
+ * core.systems.VelocitySystem} updates the position and direction of view values based on the
+ * velocity and the previous position of an entity.
  *
  * <p>If the position is the {@link #ILLEGAL_POSITION}, the {@link core.systems.PositionSystem} will
  * change the position to a random position of an accessible tile in the current level.
@@ -21,6 +22,10 @@ import dsl.annotation.DSLType;
  * <p>Use {@link #position(Point)} to set the position to the given position.
  *
  * <p>Use {@link #position()} to get a copy of the position.
+ *
+ * <p>Use {@link #direction_of_view} to get the direction the entity is currently looking in.
+ *
+ * <p>Use {@link #direction_of_view(Direction)} to set the direction the entity should look towards.
  *
  * @see core.systems.PositionSystem
  * @see Point
@@ -32,6 +37,7 @@ public final class PositionComponent implements Component {
   public static final Point ILLEGAL_POSITION = new Point(Integer.MIN_VALUE, Integer.MIN_VALUE);
 
   private Point position;
+  private Direction direction_of_view;
 
   /**
    * Create a new PositionComponent with given position.
@@ -39,9 +45,39 @@ public final class PositionComponent implements Component {
    * <p>Sets the position to the given point.
    *
    * @param position The position in the level.
+   * @param direction_of_view Direction the entity is looking to.
+   */
+  public PositionComponent(final Point position, final Direction direction_of_view) {
+    this.position = position;
+    this.direction_of_view = direction_of_view;
+  }
+
+  /**
+   * Create a new PositionComponent with given position.
+   *
+   * <p>Sets the position to the given point.
+   *
+   * <p>The Entity will look down.
+   *
+   * @param position The position in the level.
    */
   public PositionComponent(final Point position) {
-    this.position = position;
+    this(position, Direction.DOWN);
+  }
+
+  /**
+   * Create a new PositionComponent with given position.
+   *
+   * <p>Sets the position to the given point.
+   *
+   * <p>The Entity will look down.
+   *
+   * @param x x-position
+   * @param y y-position
+   * @param direction_of_view Direction the entity is looking to.
+   */
+  public PositionComponent(float x, float y, final Direction direction_of_view) {
+    this(new Point(x, y), direction_of_view);
   }
 
   /**
@@ -49,11 +85,13 @@ public final class PositionComponent implements Component {
    *
    * <p>Sets the position to a point with the given x and y positions.
    *
+   * <p>The Entity will look down.
+   *
    * @param x x-position
    * @param y y-position
    */
   public PositionComponent(float x, float y) {
-    this(new Point(x, y));
+    this(new Point(x, y), Direction.DOWN);
   }
 
   /**
@@ -93,5 +131,23 @@ public final class PositionComponent implements Component {
    */
   public void position(final Tile tile) {
     position(tile.position());
+  }
+
+  /**
+   * Get the direction of view
+   *
+   * @return current direction of view
+   */
+  public Direction direction_of_view() {
+    return direction_of_view;
+  }
+
+  /**
+   * Set directon of view
+   *
+   * @param direction new direction of view
+   */
+  public void direction_of_view(final Direction direction) {
+    this.direction_of_view = direction;
   }
 }

--- a/game/src/core/components/PositionComponent.java
+++ b/game/src/core/components/PositionComponent.java
@@ -3,7 +3,6 @@ package core.components;
 import core.Component;
 import core.level.Tile;
 import core.utils.Point;
-import core.utils.components.position.Direction;
 import dsl.annotation.DSLType;
 
 /**
@@ -23,9 +22,9 @@ import dsl.annotation.DSLType;
  *
  * <p>Use {@link #position()} to get a copy of the position.
  *
- * <p>Use {@link #direction_of_view} to get the direction the entity is currently looking in.
+ * <p>Use {@link #viewDirection} to get the direction the entity is currently looking in.
  *
- * <p>Use {@link #direction_of_view(Direction)} to set the direction the entity should look towards.
+ * <p>Use {@link #viewDirection(Direction)} to set the direction the entity should look towards.
  *
  * @see core.systems.PositionSystem
  * @see Point
@@ -37,7 +36,7 @@ public final class PositionComponent implements Component {
   public static final Point ILLEGAL_POSITION = new Point(Integer.MIN_VALUE, Integer.MIN_VALUE);
 
   private Point position;
-  private Direction direction_of_view;
+  private Direction viewDirection;
 
   /**
    * Create a new PositionComponent with given position.
@@ -45,11 +44,11 @@ public final class PositionComponent implements Component {
    * <p>Sets the position to the given point.
    *
    * @param position The position in the level.
-   * @param direction_of_view Direction the entity is looking to.
+   * @param viewDirection Direction the entity is looking to.
    */
-  public PositionComponent(final Point position, final Direction direction_of_view) {
+  public PositionComponent(final Point position, final Direction viewDirection) {
     this.position = position;
-    this.direction_of_view = direction_of_view;
+    this.viewDirection = viewDirection;
   }
 
   /**
@@ -74,10 +73,10 @@ public final class PositionComponent implements Component {
    *
    * @param x x-position
    * @param y y-position
-   * @param direction_of_view Direction the entity is looking to.
+   * @param viewDirection Direction the entity is looking to.
    */
-  public PositionComponent(float x, float y, final Direction direction_of_view) {
-    this(new Point(x, y), direction_of_view);
+  public PositionComponent(float x, float y, final Direction viewDirection) {
+    this(new Point(x, y), viewDirection);
   }
 
   /**
@@ -138,8 +137,8 @@ public final class PositionComponent implements Component {
    *
    * @return current direction of view
    */
-  public Direction direction_of_view() {
-    return direction_of_view;
+  public Direction viewDirection() {
+    return viewDirection;
   }
 
   /**
@@ -147,7 +146,19 @@ public final class PositionComponent implements Component {
    *
    * @param direction new direction of view
    */
-  public void direction_of_view(final Direction direction) {
-    this.direction_of_view = direction;
+  public void viewDirection(final Direction direction) {
+    this.viewDirection = direction;
+  }
+
+  /** Represents the possible directions an entity can face. */
+  public enum Direction {
+    /** Direction up (away from camera). */
+    UP,
+    /** Direction down (facing camera). */
+    DOWN,
+    /** Direction left. */
+    LEFT,
+    /** Direction right. */
+    RIGHT;
   }
 }

--- a/game/src/core/components/PositionComponent.java
+++ b/game/src/core/components/PositionComponent.java
@@ -99,9 +99,12 @@ public final class PositionComponent implements Component {
    * <p>Sets the position of this entity to {@link #ILLEGAL_POSITION}. Keep in mind that if the
    * associated entity is processed by the {@link core.systems.PositionSystem}, {@link
    * #ILLEGAL_POSITION} will be replaced with a random accessible position.
+   *
+   * <p>The Entity will look down.
    */
   public PositionComponent() {
     position = ILLEGAL_POSITION;
+    viewDirection = Direction.DOWN;
   }
 
   /**

--- a/game/src/core/components/PositionComponent.java
+++ b/game/src/core/components/PositionComponent.java
@@ -134,7 +134,7 @@ public final class PositionComponent implements Component {
   }
 
   /**
-   * Get the direction of view
+   * Get the direction of view.
    *
    * @return current direction of view
    */
@@ -143,7 +143,7 @@ public final class PositionComponent implements Component {
   }
 
   /**
-   * Set directon of view
+   * Set direction of view.
    *
    * @param direction new direction of view
    */

--- a/game/src/core/systems/VelocitySystem.java
+++ b/game/src/core/systems/VelocitySystem.java
@@ -14,6 +14,7 @@ import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import core.utils.components.draw.CoreAnimationPriorities;
 import core.utils.components.draw.CoreAnimations;
+import core.utils.components.position.Direction;
 
 /**
  * The VelocitySystem controls the movement of the entities in the game.
@@ -133,10 +134,20 @@ public final class VelocitySystem extends System {
     // move
     if (x != 0 || y != 0) {
       vsd.dc.deQueueByPriority(CoreAnimationPriorities.RUN.priority());
-      if (x > 0) vsd.dc.queueAnimation(CoreAnimations.RUN_RIGHT, CoreAnimations.RUN);
-      else if (x < 0) vsd.dc.queueAnimation(CoreAnimations.RUN_LEFT, CoreAnimations.RUN);
-      else if (y > 0) vsd.dc.queueAnimation(CoreAnimations.RUN_UP, CoreAnimations.RUN);
-      else if (y < 0) vsd.dc.queueAnimation(CoreAnimations.RUN_DOWN, CoreAnimations.RUN);
+      if (x > 0) {
+        vsd.dc.queueAnimation(CoreAnimations.RUN_RIGHT, CoreAnimations.RUN);
+        vsd.pc.direction_of_view(Direction.RIGHT);
+      } else if (x < 0) {
+        vsd.dc.queueAnimation(CoreAnimations.RUN_LEFT, CoreAnimations.RUN);
+        vsd.pc.direction_of_view(Direction.LEFT);
+      } else if (y > 0) {
+        vsd.dc.queueAnimation(CoreAnimations.RUN_UP, CoreAnimations.RUN);
+        vsd.pc.direction_of_view(Direction.UP);
+      } else if (y < 0) {
+        vsd.dc.queueAnimation(CoreAnimations.RUN_DOWN, CoreAnimations.RUN);
+        vsd.pc.direction_of_view(Direction.DOWN);
+      }
+
       vsd.vc.previousXVelocity(x);
       vsd.vc.previousYVelocity(y);
 
@@ -145,38 +156,40 @@ public final class VelocitySystem extends System {
     // idle
     else {
       // each drawComponent has an idle animation, so no check is needed
-      if (vsd.vc.previousXVelocity() < 0)
-        vsd.dc.queueAnimation(
-            DEFAULT_FRAME_TIME,
-            CoreAnimations.IDLE_LEFT,
-            CoreAnimations.IDLE,
-            CoreAnimations.IDLE_RIGHT,
-            CoreAnimations.IDLE_DOWN,
-            CoreAnimations.IDLE_UP);
-      else if (vsd.vc.previousXVelocity() > 0)
-        vsd.dc.queueAnimation(
-            DEFAULT_FRAME_TIME,
-            CoreAnimations.IDLE_RIGHT,
-            CoreAnimations.IDLE,
-            CoreAnimations.IDLE_LEFT,
-            CoreAnimations.IDLE_DOWN,
-            CoreAnimations.IDLE_UP);
-      else if (vsd.vc.previousYVelocity() > 0)
-        vsd.dc.queueAnimation(
-            DEFAULT_FRAME_TIME,
-            CoreAnimations.IDLE_UP,
-            CoreAnimations.IDLE,
-            CoreAnimations.IDLE_DOWN,
-            CoreAnimations.IDLE_LEFT,
-            CoreAnimations.IDLE_RIGHT);
-      else
-        vsd.dc.queueAnimation(
-            DEFAULT_FRAME_TIME,
-            CoreAnimations.IDLE_DOWN,
-            CoreAnimations.IDLE,
-            CoreAnimations.IDLE_UP,
-            CoreAnimations.IDLE_LEFT,
-            CoreAnimations.IDLE_RIGHT);
+      switch (vsd.pc.direction_of_view()) {
+        case UP ->
+            vsd.dc.queueAnimation(
+                DEFAULT_FRAME_TIME,
+                CoreAnimations.IDLE_UP,
+                CoreAnimations.IDLE,
+                CoreAnimations.IDLE_DOWN,
+                CoreAnimations.IDLE_LEFT,
+                CoreAnimations.IDLE_RIGHT);
+        case LEFT ->
+            vsd.dc.queueAnimation(
+                DEFAULT_FRAME_TIME,
+                CoreAnimations.IDLE_LEFT,
+                CoreAnimations.IDLE,
+                CoreAnimations.IDLE_RIGHT,
+                CoreAnimations.IDLE_DOWN,
+                CoreAnimations.IDLE_UP);
+        case DOWN ->
+            vsd.dc.queueAnimation(
+                DEFAULT_FRAME_TIME,
+                CoreAnimations.IDLE_DOWN,
+                CoreAnimations.IDLE,
+                CoreAnimations.IDLE_UP,
+                CoreAnimations.IDLE_LEFT,
+                CoreAnimations.IDLE_RIGHT);
+        case RIGHT ->
+            vsd.dc.queueAnimation(
+                DEFAULT_FRAME_TIME,
+                CoreAnimations.IDLE_RIGHT,
+                CoreAnimations.IDLE,
+                CoreAnimations.IDLE_LEFT,
+                CoreAnimations.IDLE_DOWN,
+                CoreAnimations.IDLE_UP);
+      }
     }
   }
 

--- a/game/src/core/systems/VelocitySystem.java
+++ b/game/src/core/systems/VelocitySystem.java
@@ -14,7 +14,6 @@ import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import core.utils.components.draw.CoreAnimationPriorities;
 import core.utils.components.draw.CoreAnimations;
-import core.utils.components.position.Direction;
 
 /**
  * The VelocitySystem controls the movement of the entities in the game.
@@ -136,16 +135,16 @@ public final class VelocitySystem extends System {
       vsd.dc.deQueueByPriority(CoreAnimationPriorities.RUN.priority());
       if (x > 0) {
         vsd.dc.queueAnimation(CoreAnimations.RUN_RIGHT, CoreAnimations.RUN);
-        vsd.pc.direction_of_view(Direction.RIGHT);
+        vsd.pc.viewDirection(PositionComponent.Direction.RIGHT);
       } else if (x < 0) {
         vsd.dc.queueAnimation(CoreAnimations.RUN_LEFT, CoreAnimations.RUN);
-        vsd.pc.direction_of_view(Direction.LEFT);
+        vsd.pc.viewDirection(PositionComponent.Direction.LEFT);
       } else if (y > 0) {
         vsd.dc.queueAnimation(CoreAnimations.RUN_UP, CoreAnimations.RUN);
-        vsd.pc.direction_of_view(Direction.UP);
+        vsd.pc.viewDirection(PositionComponent.Direction.UP);
       } else if (y < 0) {
         vsd.dc.queueAnimation(CoreAnimations.RUN_DOWN, CoreAnimations.RUN);
-        vsd.pc.direction_of_view(Direction.DOWN);
+        vsd.pc.viewDirection(PositionComponent.Direction.DOWN);
       }
 
       vsd.vc.previousXVelocity(x);
@@ -156,7 +155,7 @@ public final class VelocitySystem extends System {
     // idle
     else {
       // each drawComponent has an idle animation, so no check is needed
-      switch (vsd.pc.direction_of_view()) {
+      switch (vsd.pc.viewDirection()) {
         case UP ->
             vsd.dc.queueAnimation(
                 DEFAULT_FRAME_TIME,

--- a/game/src/core/utils/components/position/Direction.java
+++ b/game/src/core/utils/components/position/Direction.java
@@ -2,8 +2,12 @@ package core.utils.components.position;
 
 /** Represents the possible directions an entity can face or move in. */
 public enum Direction {
+  /** Direction up (away from camera). */
   UP,
+  /** Direction down (facing camera). */
   DOWN,
+  /** Direction left. */
   LEFT,
+  /** Direction right. */
   RIGHT;
 }

--- a/game/src/core/utils/components/position/Direction.java
+++ b/game/src/core/utils/components/position/Direction.java
@@ -1,0 +1,9 @@
+package core.utils.components.position;
+
+/** Represents the possible directions an entity can face or move in. */
+public enum Direction {
+  UP,
+  DOWN,
+  LEFT,
+  RIGHT;
+}

--- a/game/src/core/utils/components/position/Direction.java
+++ b/game/src/core/utils/components/position/Direction.java
@@ -1,1 +1,0 @@
-package core.utils.components.position;

--- a/game/src/core/utils/components/position/Direction.java
+++ b/game/src/core/utils/components/position/Direction.java
@@ -1,13 +1,1 @@
 package core.utils.components.position;
-
-/** Represents the possible directions an entity can face or move in. */
-public enum Direction {
-  /** Direction up (away from camera). */
-  UP,
-  /** Direction down (facing camera). */
-  DOWN,
-  /** Direction left. */
-  LEFT,
-  /** Direction right. */
-  RIGHT;
-}


### PR DESCRIPTION
DIeser PR führt die Blickrichtung (`direction_of_view`) im `PositionComponent` hinzu.  
Für Entitäten mit `PositionComponent` und `VelocityComponent` aktualisiert das `VelocitySystem` die Blickrichtung entsprechend der Bewegung.  

Das Feature wird für #1756 #1772  #1760 etc. benötigt

- Außerdem wurde ein Check im `VelocitySystem` vereinfacht: Anstelle der alten Bewegungsgeschwindigkeit als Indikator der Blickrichtung wird jetzt die Blickrichtung verwendet.  

### Warum im `PositionComponent`:  

Passt am besten da rein, jede Entität, die irgendwo steht, ist in irgendeine Blickrichtung ausgerichtet.  

Alternativen:  
- Im `VelocityComponent` wäre die Blickrichtung für unbewegliche Entitäten verwehrt geblieben.  
- Eigenes `DirectionComponent` wäre m.M.n. Overkill. Es gibt kein `DirectionSystem` und die `direction_of_view` ist eher eine Hilfsvariable für andere Systeme.