### PR TITLE
Blockly: add use block

### DIFF
--- a/blockly/frontend/src/blocks/dungeon.ts
+++ b/blockly/frontend/src/blocks/dungeon.ts
@@ -506,6 +506,14 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
     colour: 0,
     tooltip: "Warte für einen kurzen Moment.",
   },
+  {
+    type: "use",
+    message0: "benutzen",
+    previousStatement: null,
+    nextStatement: null,
+    colour: 0,
+    tooltip: "Benutze den Gegenstand vor dir.",
+  },
   //  ---------------------- Functions ----------------------
   {
     type: "func_def",

--- a/blockly/frontend/src/generators/java/skills.ts
+++ b/blockly/frontend/src/generators/java/skills.ts
@@ -17,3 +17,7 @@ export function wait(_block: Blockly.Block, _generator: Blockly.Generator) {
   return "warte();";
 }
 
+export function use(_block: Blockly.Block, _generator: Blockly.Generator) {
+  return "benutzen();";
+}
+

--- a/blockly/frontend/src/toolbox.ts
+++ b/blockly/frontend/src/toolbox.ts
@@ -201,6 +201,10 @@ export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
           kind: "block",
           type: "wait",
         },
+        {
+          kind: "block",
+          type: "use",
+        },
       ],
     },
     {

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -8,6 +8,7 @@ import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import contrib.components.CollideComponent;
+import contrib.components.InteractionComponent;
 import contrib.utils.EntityUtils;
 import contrib.utils.components.Debugger;
 import contrib.utils.components.skill.FireballSkill;
@@ -105,7 +106,7 @@ public class Server {
   public String errorMsg = "";
 
   private boolean clearHUD = false;
-  private final String[] reservedFunctions = {"gehe", "feuerball", "naheWand", "warte"};
+  private final String[] reservedFunctions = {"gehe", "feuerball", "naheWand", "warte", "benutzen"};
   private final Stack<String> currently_repeating_scope = new Stack<>();
 
   /**
@@ -1107,6 +1108,9 @@ public class Server {
       case "warte" -> {
         waitDelta();
       }
+      case "benutzen" -> {
+        interact();
+      }
       default -> System.out.println("Unknown action: " + action);
     }
   }
@@ -1266,5 +1270,21 @@ public class Server {
             1);
     fireball.execute(hero);
     waitDelta();
+  }
+
+  /** Triggers each interactable in front of the hero. */
+  public void interact() {
+    PositionComponent pc =
+        hero.fetch(PositionComponent.class)
+            .orElseThrow(() -> MissingComponentException.build(hero, PositionComponent.class));
+    Tile inFront = Game.tileAT(pc.position(), pc.viewDirection());
+    Game.entityAtTile(inFront)
+        .forEach(
+            entity ->
+                entity
+                    .fetch(InteractionComponent.class)
+                    .ifPresent(
+                        interactionComponent ->
+                            interactionComponent.triggerInteraction(entity, hero)));
   }
 }

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -394,6 +394,35 @@ public final class Game {
   }
 
   /**
+   * Get the next tile in the given direction from the specified coordinate.
+   *
+   * @param coordinate The starting coordinate
+   * @param direction The direction in which to find the next tile
+   * @return The tile that is the next tile from the given coordinate in the specified direction.
+   */
+  public static Tile tileAT(final Coordinate coordinate, PositionComponent.Direction direction) {
+    Coordinate c = new Coordinate(coordinate);
+    switch (direction) {
+      case UP -> c.y += 1;
+      case LEFT -> c.x -= 1;
+      case DOWN -> c.y -= 1;
+      case RIGHT -> c.x += 1;
+    }
+    return tileAT(c);
+  }
+
+  /**
+   * Get the next tile in the given direction from the specified point.
+   *
+   * @param point The starting point
+   * @param direction The direction in which to find the next tile
+   * @return The tile that is the next tile from the given point in the specified direction.
+   */
+  public static Tile tileAT(final Point point, PositionComponent.Direction direction) {
+    return tileAT(point.toCoordinate(), direction);
+  }
+
+  /**
    * Get a random tile in the level.
    *
    * @return a random Tile in the Level


### PR DESCRIPTION
Fixes #1779 

Fügt den block `benutzen` ein.

Der Block führt für jede Entität die sich auf dem Tile vor dem Helden (Blickrichtung wird beachtet) und die ein `InteractionComponent` hat, die Interaktion aus.

Ich habs mit Items und Schatztruhen erfolgreich getestet.


Außerdem habe ich in `core` noch zwei Helper-Funktionen eingebaut, um das Tile in einer bestimmten Richtung vom übergebenen Punkt zu bekommen. 