### PR TITLE
Blockly: Disable Keyboard and Mouse

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -70,9 +70,7 @@ public class Client {
           Crafting.loadRecipes();
 
           if (KEYBOARD_DEACTIVATION) {
-            PlayerSystem playerSystem =
-                (PlayerSystem) ECSManagment.systems().get(PlayerSystem.class);
-            Game.remove(playerSystem.getClass());
+            Game.remove(PlayerSystem.class);
           }
 
           LevelSystem levelSystem = (LevelSystem) ECSManagment.systems().get(LevelSystem.class);

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -10,9 +10,9 @@ import contrib.systems.*;
 import contrib.utils.components.Debugger;
 import core.Entity;
 import core.Game;
-import core.components.PlayerComponent;
 import core.game.ECSManagment;
 import core.systems.LevelSystem;
+import core.systems.PlayerSystem;
 import core.utils.Tuple;
 import core.utils.components.path.SimpleIPath;
 import java.io.IOException;
@@ -25,6 +25,7 @@ import server.Server;
  * have any effect
  */
 public class Client {
+  private static final boolean KEYBOARD_DEACTIVATION = true;
   private static HttpServer httpServer;
 
   /**
@@ -67,6 +68,13 @@ public class Client {
           startServer();
 
           Crafting.loadRecipes();
+
+          if (KEYBOARD_DEACTIVATION) {
+            PlayerSystem playerSystem =
+                (PlayerSystem) ECSManagment.systems().get(PlayerSystem.class);
+            Game.remove(playerSystem.getClass());
+          }
+
           LevelSystem levelSystem = (LevelSystem) ECSManagment.systems().get(LevelSystem.class);
           levelSystem.onEndTile(DevDungeonLoader::loadNextLevel);
           DevDungeonLoader.afterAllLevels(Client::startRoomBasedLevel);
@@ -105,17 +113,6 @@ public class Client {
     Entity hero;
     try {
       hero = (EntityFactory.newHero());
-      hero.fetch(PlayerComponent.class)
-          .flatMap(
-              fetch ->
-                  fetch.registerCallback(
-                      KeyboardConfig.TOGGLE_BLOCKLY_HUD.value(),
-                      (e) ->
-                          Server.instance()
-                              .variableHUD
-                              .visible(!Server.instance().variableHUD.visible()),
-                      false,
-                      true));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Ich habe das `PlayerSystem` innerhalb der `onSetup()` in der `client.java` entfernt, um alle Steuerungen über Maus und Tastatur zu deaktivieren.
Zusätzlich habe ich auf Wunsch von @Flamtky den Keybind des BlocklyHUDs in der `createHero()`  entfernt, da es nicht mehr verwendet wird. 

closes #1747 