### PR TITLE
[Blockly] add pull feature

### DIFF
--- a/blockly/frontend/src/blocks/dungeon.ts
+++ b/blockly/frontend/src/blocks/dungeon.ts
@@ -521,7 +521,7 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
     nextStatement: null,
     colour: 0,
     tooltip: "Nur einmal feste drücken!",
-    },
+  },
   {
     type: "pull",
     message0: "ziehen",
@@ -529,7 +529,7 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
     nextStatement: null,
     colour: 0,
     tooltip: "Nur einmal feste ziehen!",
-    },
+   },
   //  ---------------------- Functions ----------------------
   {
     type: "func_def",

--- a/blockly/frontend/src/blocks/dungeon.ts
+++ b/blockly/frontend/src/blocks/dungeon.ts
@@ -522,6 +522,14 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
     colour: 0,
     tooltip: "Nur einmal feste drücken!",
     },
+  {
+    type: "pull",
+    message0: "ziehen",
+    previousStatement: null,
+    nextStatement: null,
+    colour: 0,
+    tooltip: "Nur einmal feste ziehen!",
+    },
   //  ---------------------- Functions ----------------------
   {
     type: "func_def",

--- a/blockly/frontend/src/generators/java/skills.ts
+++ b/blockly/frontend/src/generators/java/skills.ts
@@ -25,3 +25,8 @@ export function push(_block: Blockly.Block, _generator: Blockly.Generator) {
   return "schieben();";
 }
 
+export function pull(_block: Blockly.Block, _generator: Blockly.Generator) {
+  return "ziehen();";
+}
+
+

--- a/blockly/frontend/src/generators/java/skills.ts
+++ b/blockly/frontend/src/generators/java/skills.ts
@@ -29,4 +29,3 @@ export function pull(_block: Blockly.Block, _generator: Blockly.Generator) {
   return "ziehen();";
 }
 
-

--- a/blockly/frontend/src/toolbox.ts
+++ b/blockly/frontend/src/toolbox.ts
@@ -209,6 +209,9 @@ export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
           kind: "block",
           type: "push",
         },
+          kind: "block",
+          type: "pull",
+        },
       ],
     },
     {

--- a/blockly/frontend/src/toolbox.ts
+++ b/blockly/frontend/src/toolbox.ts
@@ -209,6 +209,7 @@ export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
           kind: "block",
           type: "push",
         },
+        {
           kind: "block",
           type: "pull",
         },

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -1462,8 +1462,21 @@ public class Server {
         pushable.get().add(new BlockComponent());
 
         // turn hero back after movement
-        // TODO: WHY DOES THIS NOT WORK FOR THE DRAWING?
         pc.viewDirection(viewDirection);
+        int x =
+            viewDirection == PositionComponent.Direction.LEFT
+                ? -1
+                : viewDirection == PositionComponent.Direction.RIGHT ? 1 : 0;
+        int y =
+            viewDirection == PositionComponent.Direction.UP
+                ? 1
+                : viewDirection == PositionComponent.Direction.DOWN ? -1 : 0;
+        hero.fetch(VelocityComponent.class)
+            .ifPresent(
+                vc -> {
+                  vc.currentXVelocity(x);
+                  vc.currentYVelocity(y);
+                });
         waitDelta();
       }
     }

--- a/game/src/core/components/PositionComponent.java
+++ b/game/src/core/components/PositionComponent.java
@@ -163,5 +163,19 @@ public final class PositionComponent implements Component {
     LEFT,
     /** Direction right. */
     RIGHT;
+
+    /**
+     * Returns the opposite direction.
+     *
+     * @return the opposite Direction
+     */
+    public Direction opposite() {
+      return switch (this) {
+        case UP -> DOWN;
+        case DOWN -> UP;
+        case LEFT -> RIGHT;
+        case RIGHT -> LEFT;
+      };
+    }
   }
 }


### PR DESCRIPTION
Neben den in #1805 eingefügten "Schieben" fügt dieser PR das "Ziehen" hinzu.  

Konzeptuell ist das Ganze identisch, nur wird nicht nach vorne geguckt, sondern nach hinten.  

Ich habe noch ein Problem mit der Animation.  
Da der Held sich beim Ziehen nach hinten bewegt, wechselt das VelocitySystem die Animation entsprechend. Es sieht eher so aus, als würde der Held den Stein hinter sich herziehen (naja, damit kann man erstmal leben):  
Dabei ändert das VS aber auch die Blickrichtung des Helden (Rückwärtsgehen geht ja nicht).  
Das führt dazu, dass jedes Mal, wenn der Held einmal am Stein zieht, er danach nicht mehr den Stein anschaut. Ich müsste ihn in Blockly erst einmal umdrehen … doof.  

Daher dachte ich, ein einfaches  
```java
        pc.viewDirection(viewDirection);
        waitDelta();
```  
am Ende der Aktion sollte reichen, um den Helden umzudrehen.  
Tut es auch … so halb …  
Die Blickrichtung wird zwar richtig geändert, aber die Animation wird nicht geupdated. Das heißt, optisch schaue ich vom Stein weg, während ich im Code den Stein anschaue.  

Nach meinem Verständnis müsste eigentlich das VS erkennen, dass ich mich nicht bewege, und daher die Idle-Animation setzen. Dabei wird über die Blickrichtung des Helden "geswitcht" …  

Wo ist mein Gedankenknick?  
