### PR TITLE
Blockly: Better Grid Visibility with Checker Pattern

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -20,13 +20,16 @@ import java.util.logging.Level;
 import level.MazeLevel;
 import server.Server;
 import systems.BlockSystem;
+import utils.CheckPatternPainter;
 
 /**
  * This Class must be run to start the dungeon application. Otherwise, the blockly frontend won't
  * have any effect
  */
 public class Client {
-  private static final boolean KEYBOARD_DEACTIVATION = true;
+  private static final boolean KEYBOARD_DEACTIVATION = false;
+  private static final boolean DRAW_CHECKER_PATTERN = true;
+
   private static HttpServer httpServer;
 
   /**
@@ -85,6 +88,8 @@ public class Client {
   private static void onLevelLoad() {
     Game.userOnLevelLoad(
         (firstLoad) -> {
+          if (DRAW_CHECKER_PATTERN)
+            CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
           Server.instance().interruptExecution = true;
         });
   }

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -27,7 +27,7 @@ import utils.CheckPatternPainter;
  * have any effect
  */
 public class Client {
-  private static final boolean KEYBOARD_DEACTIVATION = false;
+  private static final boolean KEYBOARD_DEACTIVATION = true;
   private static final boolean DRAW_CHECKER_PATTERN = true;
 
   private static HttpServer httpServer;

--- a/blockly/src/utils/CheckPatternPainter.java
+++ b/blockly/src/utils/CheckPatternPainter.java
@@ -1,0 +1,56 @@
+package utils;
+
+import core.level.Tile;
+import core.level.utils.LevelElement;
+
+/**
+ * A utility class to paint a checker pattern on tiles in a level layout.
+ *
+ * <p>This class provides a method to apply a checker pattern to tiles that are marked with specific
+ * level elements. The pattern is applied by alternating colors based on the tile's position in the
+ * layout.
+ *
+ * @see #paintCheckerPattern(Tile[][])
+ */
+public class CheckPatternPainter {
+
+  /**
+   * The color used for the checker pattern. This color is applied to the tiles that are marked with
+   * the specified level elements.
+   *
+   * @see #LEVEL_ELEMENTS_TO_PAINT
+   */
+  private static final int CHECKER_PATTERN_COLOR = 0xffffffcc; // slightly darker
+
+  /** The level elements that will be painted with the checker pattern. */
+  private static final LevelElement[] LEVEL_ELEMENTS_TO_PAINT = {
+    LevelElement.FLOOR,
+  };
+
+  /**
+   * Paints a checker pattern on the given layout of tiles. The pattern is applied to the tiles that
+   * are marked with the specified level elements.
+   *
+   * @param layout The 2D array of tiles to paint.
+   */
+  public static void paintCheckerPattern(Tile[][] layout) {
+    for (int i = 0; i < layout.length; i++) {
+      for (int j = 0; j < layout[i].length; j++) {
+        if ((i + j) % 2 == 0) {
+          if (isLevelElementToPaint(layout[i][j].levelElement())) {
+            layout[i][j].tintColor(CHECKER_PATTERN_COLOR);
+          }
+        }
+      }
+    }
+  }
+
+  private static boolean isLevelElementToPaint(LevelElement element) {
+    for (LevelElement levelElement : LEVEL_ELEMENTS_TO_PAINT) {
+      if (levelElement == element) {
+        return true;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
Ich habe das Grid besser sichtbar gemacht, indem ein Checkpattern vom Level generiert und etwas dunkler eingefärbt wird.

- `CheckPatternPainter.java`: Neue Utility-Klasse mit Fields für Einstellungen wie Farbe (aktuell etwas dunkler) und betroffene Level-Elemente (aktuell nur FLOOR) sowie der Methode `paintCheckerPattern`, die das Checkpattern einzeichnet.
- `Client.java`: Beim Laden eines jeden Levels wird nun die Methode `paintCheckerPattern` aufgerufen. `DRAW_CHECKER_PATTERN ` als schnell Möglichkeit das Einzeichnen auszuschalten

closes #1790