### PR TITLE
[Blockly] add Item blocks

### DIFF
--- a/blockly/frontend/src/blocks/dungeon.ts
+++ b/blockly/frontend/src/blocks/dungeon.ts
@@ -507,6 +507,14 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
     ]
   },
   {
+    type: "pickup",
+    message0: "Aufheben",
+    previousStatement: null,
+    nextStatement: null,
+    colour: 0,
+    tooltip: "Sammel den Gegenstand unter dir auf.",
+  },
+  {
     type: "wait",
     message0: "warte",
     previousStatement: null,

--- a/blockly/frontend/src/blocks/dungeon.ts
+++ b/blockly/frontend/src/blocks/dungeon.ts
@@ -508,7 +508,7 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
   },
   {
     type: "pickup",
-    message0: "Aufheben",
+    message0: "aufheben",
     previousStatement: null,
     nextStatement: null,
     colour: 0,

--- a/blockly/frontend/src/blocks/dungeon.ts
+++ b/blockly/frontend/src/blocks/dungeon.ts
@@ -515,6 +515,21 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
     tooltip: "Sammel den Gegenstand unter dir auf.",
   },
   {
+    type: "drop_item",
+    message0: "fallen lassen %1",
+    previousStatement: null,
+    nextStatement: null,
+    colour: 0,
+    tooltip: "Gegenstand auf den Boden werfen.",
+    args0: [
+      {
+        type: "input_value",
+        name: "ITEM",
+        check: "Item",
+      },
+    ]
+  },
+  {
     type: "wait",
     message0: "warte",
     previousStatement: null,
@@ -545,7 +560,14 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
     nextStatement: null,
     colour: 0,
     tooltip: "Nur einmal feste ziehen!",
-   },
+  },
+  {
+    type: "item_breadcrumbs",
+    message0: "Brotkrumen",
+    output: "Item",
+    colour: 230
+  },
+
   //  ---------------------- Functions ----------------------
   {
     type: "func_def",

--- a/blockly/frontend/src/generators/java.ts
+++ b/blockly/frontend/src/generators/java.ts
@@ -8,6 +8,7 @@ import * as skills from "./java/skills.ts";
 import * as arrays from "./java/arrays.ts";
 import * as functions from "./java/functions.ts";
 import * as directions from "./java/directions.ts";
+import * as directions from "./java/items.ts";
 
 class JavaGenerator extends Blockly.Generator {
   public variables: Map<string, number|string>;

--- a/blockly/frontend/src/generators/java.ts
+++ b/blockly/frontend/src/generators/java.ts
@@ -8,7 +8,7 @@ import * as skills from "./java/skills.ts";
 import * as arrays from "./java/arrays.ts";
 import * as functions from "./java/functions.ts";
 import * as directions from "./java/directions.ts";
-import * as directions from "./java/items.ts";
+import * as items from "./java/items.ts";
 
 class JavaGenerator extends Blockly.Generator {
   public variables: Map<string, number|string>;
@@ -51,7 +51,8 @@ Object.assign(
   skills,
   arrays,
   functions,
-  directions
+  directions,
+  items
 );
 
 export const Order = {

--- a/blockly/frontend/src/generators/java/items.ts
+++ b/blockly/frontend/src/generators/java/items.ts
@@ -1,0 +1,10 @@
+import * as Blockly from "blockly";
+import {Order} from "../java.ts";
+
+export function item_breadcrumbs(
+  _block: Blockly.Block,
+  _generator: Blockly.Generator
+) {
+  return ["\"Brotkrumen\"", Order.ATOMIC];
+}
+

--- a/blockly/frontend/src/generators/java/skills.ts
+++ b/blockly/frontend/src/generators/java/skills.ts
@@ -33,3 +33,11 @@ export function pickup(_block: Blockly.Block, _generator: Blockly.Generator) {
   return "aufsammeln();";
 }
 
+export function drop_item(
+  block: Blockly.Block,
+  generator: Blockly.Generator
+) {
+  const item = generator.valueToCode(block, "ITEM", Order.NONE);
+  return "fallen_lassen(" + item + ");";
+}
+

--- a/blockly/frontend/src/generators/java/skills.ts
+++ b/blockly/frontend/src/generators/java/skills.ts
@@ -29,3 +29,7 @@ export function pull(_block: Blockly.Block, _generator: Blockly.Generator) {
   return "ziehen();";
 }
 
+export function pickup(_block: Blockly.Block, _generator: Blockly.Generator) {
+  return "aufsammeln();";
+}
+

--- a/blockly/frontend/src/toolbox.ts
+++ b/blockly/frontend/src/toolbox.ts
@@ -73,6 +73,10 @@ export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
           kind: "block",
           type: "direction_right",
         },
+        {
+          kind: "block",
+          type: "item_breadcrumbs",
+        },
       ],
     },
     {
@@ -220,6 +224,10 @@ export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
         {
           kind: "block",
           type: "pull",
+        },
+        {
+          kind: "block",
+          type: "drop_item",
         },
       ],
     },

--- a/blockly/frontend/src/toolbox.ts
+++ b/blockly/frontend/src/toolbox.ts
@@ -211,6 +211,10 @@ export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
         },
         {
           kind: "block",
+          type: "pickup",
+        },
+        {
+          kind: "block",
           type: "push",
         },
         {

--- a/blockly/src/components/BlocklyItemComponent.java
+++ b/blockly/src/components/BlocklyItemComponent.java
@@ -1,0 +1,14 @@
+package components;
+
+import core.Component;
+
+/**
+ * Marks an entity as an Item in the Blockly world.
+ *
+ * <p>Items in Blockly differ from {@link contrib.item.Item Dungeon items} in that they are not
+ * designed for an inventory system. Blockly items exist only in the game world, not in the
+ * inventory.
+ *
+ * <p>This component is used to mark entities as collectible for the "pick up" block.
+ */
+public final class BlocklyItemComponent implements Component {}

--- a/blockly/src/entities/MiscFactory.java
+++ b/blockly/src/entities/MiscFactory.java
@@ -114,24 +114,24 @@ public class MiscFactory {
   /**
    * Creates a breadcrumb entity at the given position.
    *
-   * <p>The breadcrumb is a temporary item that can be picked up and removed upon interaction.
-   * It can be used for marking paths.
+   * <p>The breadcrumb is a temporary item that can be picked up and removed upon interaction. It
+   * can be used for marking paths.
    *
    * @param position The initial position of the breadcrumb.
    * @return A new breadcrumb entity.
    */
-  public static Entity breadcrumb (Point position){
+  public static Entity breadcrumb(Point position) {
     Entity breadcrumb = new Entity("breadcrumb");
     breadcrumb.add(new PositionComponent(position.toCoordinate().toCenteredPoint()));
     breadcrumb.add(new DrawComponent(Animation.fromSingleImage(BREADCRUMB_PATH)));
     breadcrumb.add(new ItemComponent(null));
     breadcrumb.add(
-            new InteractionComponent(
-                    0,
-                    false,
-                    (entity, entity2) -> {
-                      Game.remove(breadcrumb);
-                    }));
+        new InteractionComponent(
+            0,
+            false,
+            (entity, entity2) -> {
+              Game.remove(breadcrumb);
+            }));
     return breadcrumb;
   }
 }

--- a/blockly/src/entities/MiscFactory.java
+++ b/blockly/src/entities/MiscFactory.java
@@ -1,10 +1,10 @@
 package entities;
 
 import components.BlockComponent;
+import components.BlocklyItemComponent;
 import components.PushableComponent;
 import contrib.components.CollideComponent;
 import contrib.components.InteractionComponent;
-import contrib.components.ItemComponent;
 import contrib.components.LeverComponent;
 import contrib.hud.DialogUtils;
 import contrib.utils.ICommand;
@@ -124,7 +124,7 @@ public class MiscFactory {
     Entity breadcrumb = new Entity("breadcrumb");
     breadcrumb.add(new PositionComponent(position.toCoordinate().toCenteredPoint()));
     breadcrumb.add(new DrawComponent(Animation.fromSingleImage(BREADCRUMB_PATH)));
-    breadcrumb.add(new ItemComponent(null));
+    breadcrumb.add(new BlocklyItemComponent());
     breadcrumb.add(
         new InteractionComponent(
             0,

--- a/blockly/src/entities/MiscFactory.java
+++ b/blockly/src/entities/MiscFactory.java
@@ -96,19 +96,18 @@ public class MiscFactory {
    * @return A new book pickup entity with interaction behavior.
    */
   public static Entity bookPickup(Point position, String title, String pickupText) {
-      Entity pickup = new Entity("Book Pickup");
-      pickup.add(new PositionComponent(position.toCoordinate().toCenteredPoint()));
-      pickup.add(new DrawComponent(Animation.fromSingleImage(PICKUP_BOCK_PATH)));
-      pickup.add(
-              new InteractionComponent(
-                      1,
-                      false,
-                      (entity, entity2) -> {
-                          DialogUtils.showTextPopup(pickupText, title);
-                          Game.remove(pickup);
-                      }));
-      return pickup;
-
+    Entity pickup = new Entity("Book Pickup");
+    pickup.add(new PositionComponent(position.toCoordinate().toCenteredPoint()));
+    pickup.add(new DrawComponent(Animation.fromSingleImage(PICKUP_BOCK_PATH)));
+    pickup.add(
+        new InteractionComponent(
+            1,
+            false,
+            (entity, entity2) -> {
+              DialogUtils.showTextPopup(pickupText, title);
+              Game.remove(pickup);
+            }));
+    return pickup;
   }
 
   /**

--- a/blockly/src/entities/MiscFactory.java
+++ b/blockly/src/entities/MiscFactory.java
@@ -4,6 +4,7 @@ import components.BlockComponent;
 import components.PushableComponent;
 import contrib.components.CollideComponent;
 import contrib.components.InteractionComponent;
+import contrib.components.ItemComponent;
 import contrib.components.LeverComponent;
 import contrib.hud.DialogUtils;
 import contrib.utils.ICommand;
@@ -30,6 +31,7 @@ public class MiscFactory {
       new SimpleIPath("objects/pressureplate/off/pressureplate_0.png");
 
   private static final IPath PICKUP_BOCK_PATH = new SimpleIPath("items/book/spell_book.png");
+  private static final IPath BREADCRUMB_PATH = new SimpleIPath("items/resource/leaf.png");
   private static final float STONE_SPEED = 7.5f;
 
   /**
@@ -94,17 +96,42 @@ public class MiscFactory {
    * @return A new book pickup entity with interaction behavior.
    */
   public static Entity bookPickup(Point position, String title, String pickupText) {
-    Entity pickup = new Entity("Book Pickup");
-    pickup.add(new PositionComponent(position.toCoordinate().toCenteredPoint()));
-    pickup.add(new DrawComponent(Animation.fromSingleImage(PICKUP_BOCK_PATH)));
-    pickup.add(
-        new InteractionComponent(
-            1,
-            false,
-            (entity, entity2) -> {
-              DialogUtils.showTextPopup(pickupText, title);
-              Game.remove(pickup);
-            }));
-    return pickup;
+      Entity pickup = new Entity("Book Pickup");
+      pickup.add(new PositionComponent(position.toCoordinate().toCenteredPoint()));
+      pickup.add(new DrawComponent(Animation.fromSingleImage(PICKUP_BOCK_PATH)));
+      pickup.add(
+              new InteractionComponent(
+                      1,
+                      false,
+                      (entity, entity2) -> {
+                          DialogUtils.showTextPopup(pickupText, title);
+                          Game.remove(pickup);
+                      }));
+      return pickup;
+
+  }
+
+  /**
+   * Creates a breadcrumb entity at the given position.
+   *
+   * <p>The breadcrumb is a temporary item that can be picked up and removed upon interaction.
+   * It can be used for marking paths.
+   *
+   * @param position The initial position of the breadcrumb.
+   * @return A new breadcrumb entity.
+   */
+  public static Entity breadcrumb (Point position){
+    Entity breadcrumb = new Entity("breadcrumb");
+    breadcrumb.add(new PositionComponent(position.toCoordinate().toCenteredPoint()));
+    breadcrumb.add(new DrawComponent(Animation.fromSingleImage(BREADCRUMB_PATH)));
+    breadcrumb.add(new ItemComponent(null));
+    breadcrumb.add(
+            new InteractionComponent(
+                    0,
+                    false,
+                    (entity, entity2) -> {
+                      Game.remove(breadcrumb);
+                    }));
+    return breadcrumb;
   }
 }

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -9,6 +9,7 @@ import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import components.BlockComponent;
+import components.BlocklyItemComponent;
 import components.PushableComponent;
 import contrib.components.CollideComponent;
 import contrib.components.InteractionComponent;
@@ -1371,7 +1372,7 @@ public class Server {
    */
   public void pickup() {
     Game.entityAtTile(Game.tileAT(EntityUtils.getHeroCoordinate()))
-        .filter(e -> e.isPresent(ItemComponent.class))
+        .filter(e -> e.isPresent(BlocklyItemComponent.class))
         .forEach(
             item ->
                 item.fetch(InteractionComponent.class)

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -27,6 +27,7 @@ import core.level.utils.LevelUtils;
 import core.utils.MissingHeroException;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
+import entities.MiscFactory;
 import entities.VariableHUD;
 import java.io.IOException;
 import java.io.InputStream;
@@ -120,7 +121,8 @@ public class Server {
     "schieben",
     "ziehen",
     "geheZumAusgang",
-    "aufsammeln"
+    "aufsammeln",
+    "fallen_lassen",
   };
   private final Stack<String> currently_repeating_scope = new Stack<>();
 
@@ -1135,6 +1137,16 @@ public class Server {
       case "aufsammeln" -> {
         pickup();
       }
+      case "fallen_lassen" -> {
+        String firstArg;
+        if (args[0] instanceof String) {
+          firstArg = (String) args[0];
+        } else {
+          setError("Unexpected type for item " + args[0]);
+          return;
+        }
+        dropItem(firstArg);
+      }
       case "geheZumAusgang" -> {
         moveToExit();
       }
@@ -1364,6 +1376,17 @@ public class Server {
             item ->
                 item.fetch(InteractionComponent.class)
                     .ifPresent(ic -> ic.triggerInteraction(item, hero)));
+  }
+
+  /**
+   * Drop an Blockly-Item at the heros position.
+   *
+   * @param item Name of the item to drop
+   */
+  public void dropItem(String item) {
+    if (item.equals("Brotkrumen")) {
+      Game.add(MiscFactory.breadcrumb(getHeroPosition().position()));
+    }
   }
 
   /** Moves the Hero to the Exit Block of the current Level. */

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -12,6 +12,7 @@ import components.BlockComponent;
 import components.PushableComponent;
 import contrib.components.CollideComponent;
 import contrib.components.InteractionComponent;
+import contrib.components.ItemComponent;
 import contrib.utils.EntityUtils;
 import contrib.utils.components.Debugger;
 import contrib.utils.components.skill.FireballSkill;
@@ -111,7 +112,15 @@ public class Server {
 
   private boolean clearHUD = false;
   private final String[] reservedFunctions = {
-    "gehe", "feuerball", "naheWand", "warte", "benutzen", "schieben", "ziehen", "geheZumAusgang"
+    "gehe",
+    "feuerball",
+    "naheWand",
+    "warte",
+    "benutzen",
+    "schieben",
+    "ziehen",
+    "geheZumAusgang",
+    "aufsammeln"
   };
   private final Stack<String> currently_repeating_scope = new Stack<>();
 
@@ -1123,6 +1132,9 @@ public class Server {
       case "ziehen" -> {
         pull();
       }
+      case "aufsammeln" -> {
+        pickup();
+      }
       case "geheZumAusgang" -> {
         moveToExit();
       }
@@ -1339,6 +1351,19 @@ public class Server {
                     .ifPresent(
                         interactionComponent ->
                             interactionComponent.triggerInteraction(entity, hero)));
+  }
+
+  /**
+   * Triggers the interaction (normally a pickup action) for each Entity with an {@link
+   * ItemComponent} at the same tile as the hero.
+   */
+  public void pickup() {
+    Game.entityAtTile(Game.tileAT(EntityUtils.getHeroCoordinate()))
+        .filter(e -> e.isPresent(ItemComponent.class))
+        .forEach(
+            item ->
+                item.fetch(InteractionComponent.class)
+                    .ifPresent(ic -> ic.triggerInteraction(item, hero)));
   }
 
   /** Moves the Hero to the Exit Block of the current Level. */


### PR DESCRIPTION
fixes #1777  

- Fügt die Blöcke `aufsammeln` und `fallen lassen %1` mit dem möglichen Parameter `Brotkrumen` hinzu.  
- `aufsammeln` löst `onInteraction` für alle Entitäten mit `BlocklyItemComponent` aus, die sich auf dem gleichen Tile wie der Held befinden.  
- `fallen lassen` erzeugt eine neue Item-Entität auf dem Feld des Helden. Da Blockly kein Inventar benötigt, gibt es keinen Check, ob genug Items vorhanden sind (und das ist aktuell auch nicht vorgesehen).  
- `MiscFactory#breadcrumb` erstellt ein Item, das später in Rätseln als Wegmarkierung genutzt wird (z. B. Hänsel und Gretel).  
- Fügt `BlocklyItemComponent` als Marker-Komponente hinzu.  

---  

**Konzeptioneller Hinweis:**  

Im `Dungeon.contrib` haben wir ein recht ausgeklügeltes Item-System mit Enums, Buildern, Crafting etc.  
Warum verwende ich das nicht?  

Dungeon-Items sind für ein Inventar-System konzipiert. Sie haben getrennte Texturen für "In-World" und "Im-Inventar", und das Aufheben prüft, ob genügend Platz vorhanden ist.  

Für Blockly wäre das Overkill. Im aktuellen Konzept gibt es keine Items, die so funktionieren.