### PR TITLE
[Blockly] fix bug where player was centered on the wrong coordinate 

### DIFF
--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -1268,7 +1268,8 @@ public class Server {
     for (EntityComponents ec : entityComponents) {
       ec.vc.currentXVelocity(0);
       ec.vc.currentYVelocity(0);
-      ec.pc.position(ec.targetPosition.toCenteredPoint()); // snap to grid
+      // check the position-tile via new request in case a new level was loaded
+      ec.pc.position(Game.tileAT(ec.pc.position()).coordinate().toCenteredPoint()); // snap to grid
     }
   }
 

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -1269,7 +1269,8 @@ public class Server {
       ec.vc.currentXVelocity(0);
       ec.vc.currentYVelocity(0);
       // check the position-tile via new request in case a new level was loaded
-      ec.pc.position(Game.tileAT(ec.pc.position()).coordinate().toCenteredPoint()); // snap to grid
+      Tile endTile = Game.tileAT(ec.pc.position());
+      if (endTile != null) ec.pc.position(endTile); // snap to grid
     }
   }
 


### PR DESCRIPTION
fixes #1815

Der Bug wurde verursacht, da der `move`-Command die Entitäten am Ende immer zentriert. 
Problem: Es wurden die Coordinaten des Target-Tiles (also wohin der Spieler sich bewegt wird) zum zentrieren verwendet. Das klappt im selben Level ohne Probleme da `targetTile == Game.tileAt(playerPosition)` ABER wenn ein neues Level geladen wird, passt das nicht mehr.

- Ersetzt `currentTile` in der Abfrage mit `Game.tileAt(entityPosition)` 