### PR TITLE
Blockly: change fieball block to require ammunition

### DIFF
--- a/blockly/frontend/src/blocks/dungeon.ts
+++ b/blockly/frontend/src/blocks/dungeon.ts
@@ -500,19 +500,12 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
     output: "Skill",
   },
   {
-    type: "fireball_direction",
-    message0: "Feuerball %1",
+    type: "fireball",
+    message0: "Feuerball",
     previousStatement: null,
     nextStatement: null,
     colour: 0,
     tooltip: "Feuerball in Richtung schießen",
-    args0: [
-      {
-        type: "input_value",
-        name: "DIRECTION",
-        check: "Direction",
-      },
-    ]
   },
   {
     type: "pickup",

--- a/blockly/frontend/src/generators/java/skills.ts
+++ b/blockly/frontend/src/generators/java/skills.ts
@@ -5,12 +5,8 @@ export function interact(_block: Blockly.Block, _generator: Blockly.Generator) {
   return "interagieren();";
 }
 
-export function fireball_direction(
-  block: Blockly.Block,
-  generator: Blockly.Generator
-) {
-  const dir = generator.valueToCode(block, "DIRECTION", Order.NONE);
-  return "feuerball(" + dir + ");";
+export function fireball(_block: Blockly.Block, _generator: Blockly.Generator) {
+  return "feuerball();";
 }
 
 export function wait(_block: Blockly.Block, _generator: Blockly.Generator) {

--- a/blockly/frontend/src/toolbox.ts
+++ b/blockly/frontend/src/toolbox.ts
@@ -207,7 +207,7 @@ export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
         }, */
         {
           kind: "block",
-          type: "fireball_direction",
+          type: "fireball",
         },
         {
           kind: "block",

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -93,16 +93,9 @@ public class Client {
           if (DRAW_CHECKER_PATTERN)
             CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
           Server.instance().interruptExecution = true;
-          if (Game.hero().isPresent()) {
-            AmmunitionComponent ac =
-                Game.hero()
-                    .get()
-                    .fetch(AmmunitionComponent.class)
-                    .orElseThrow(
-                        () ->
-                            MissingComponentException.build(
-                                Game.hero().get(), AmmunitionComponent.class));
-            ac.setCurrentAmmunition(0);
+          Game.hero()
+              .flatMap(e -> e.fetch(AmmunitionComponent.class))
+              .map(ac -> ac.setCurrentAmmunition(0));
           }
         });
   }

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -14,6 +14,7 @@ import core.game.ECSManagment;
 import core.systems.LevelSystem;
 import core.systems.PlayerSystem;
 import core.utils.Tuple;
+import core.utils.components.MissingComponentException;
 import core.utils.components.path.SimpleIPath;
 import entities.HeroTankControlledFactory;
 import java.io.IOException;
@@ -92,6 +93,17 @@ public class Client {
           if (DRAW_CHECKER_PATTERN)
             CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
           Server.instance().interruptExecution = true;
+          if (Game.hero().isPresent()) {
+            AmmunitionComponent ac =
+                Game.hero()
+                    .get()
+                    .fetch(AmmunitionComponent.class)
+                    .orElseThrow(
+                        () ->
+                            MissingComponentException.build(
+                                Game.hero().get(), AmmunitionComponent.class));
+            ac.setCurrentAmmunition(0);
+          }
         });
   }
 

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -14,7 +14,6 @@ import core.game.ECSManagment;
 import core.systems.LevelSystem;
 import core.systems.PlayerSystem;
 import core.utils.Tuple;
-import core.utils.components.MissingComponentException;
 import core.utils.components.path.SimpleIPath;
 import entities.HeroTankControlledFactory;
 import java.io.IOException;
@@ -95,8 +94,7 @@ public class Client {
           Server.instance().interruptExecution = true;
           Game.hero()
               .flatMap(e -> e.fetch(AmmunitionComponent.class))
-              .map(ac -> ac.setCurrentAmmunition(0));
-          }
+              .map(AmmunitionComponent::resetCurrentAmmunition);
         });
   }
 

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -1,6 +1,7 @@
 package client;
 
 import com.sun.net.httpserver.HttpServer;
+import components.AmmunitionComponent;
 import contrib.crafting.Crafting;
 import contrib.hud.DialogUtils;
 import contrib.level.DevDungeonLoader;
@@ -117,6 +118,7 @@ public class Client {
     Entity hero;
     try {
       hero = HeroTankControlledFactory.newTankControlledHero();
+      hero.add(new AmmunitionComponent());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/blockly/src/components/AmmunitionComponent.java
+++ b/blockly/src/components/AmmunitionComponent.java
@@ -56,8 +56,10 @@ public final class AmmunitionComponent implements Component {
    * Set the desired amount of ammunition.
    *
    * @param ammunitionAmount New amount of current ammunition
+   * @return the new ammunition value
    */
-  public void setCurrentAmmunition(int ammunitionAmount) {
-    this.currentAmmunition = ammunitionAmount;
+  public int setCurrentAmmunition(int ammunitionAmount) {
+    currentAmmunition = ammunitionAmount;
+    return currentAmmunition;
   }
 }

--- a/blockly/src/components/AmmunitionComponent.java
+++ b/blockly/src/components/AmmunitionComponent.java
@@ -1,0 +1,63 @@
+package components;
+
+import core.Component;
+
+/**
+ * Allow an associated entity to collect and spend ammunition.
+ *
+ * <p>If an entity has this component, it can use skills that require ammunition.
+ */
+public final class AmmunitionComponent implements Component {
+  private int currentAmmunition;
+
+  /**
+   * Create a new AmmunitionComponent.
+   *
+   * @param currentAmmunition Current amount of ammunition
+   */
+  public AmmunitionComponent(int currentAmmunition) {
+    this.currentAmmunition = currentAmmunition;
+  }
+
+  /** Create a AmmunitionComponent with default values. */
+  public AmmunitionComponent() {
+    this.currentAmmunition = 2;
+  }
+
+  /** Pick up one Ammunition. */
+  public void collectAmmo() {
+    currentAmmunition++;
+  }
+
+  /** Spend one Ammunition. */
+  public void spendAmmo() {
+    currentAmmunition--;
+  }
+
+  /**
+   * Check for remaining ammunition.
+   *
+   * @return True if there is any ammunition left
+   */
+  public boolean checkAmmunition() {
+    return currentAmmunition > 0;
+  }
+
+  /**
+   * Get the current amount of ammunition.
+   *
+   * @return Current amount of ammunition
+   */
+  public int getCurrentAmmunition() {
+    return currentAmmunition;
+  }
+
+  /**
+   * Set the desired amount of ammunition.
+   *
+   * @param ammunitionAmount New amount of current ammunition
+   */
+  public void setCurrentAmmunition(int ammunitionAmount) {
+    this.currentAmmunition = ammunitionAmount;
+  }
+}

--- a/blockly/src/components/AmmunitionComponent.java
+++ b/blockly/src/components/AmmunitionComponent.java
@@ -31,7 +31,7 @@ public final class AmmunitionComponent implements Component {
 
   /** Spend one Ammunition. */
   public void spendAmmo() {
-    currentAmmunition--;
+    currentAmmunition = Math.max(0, currentAmmunition - 1);
   }
 
   /**

--- a/blockly/src/components/AmmunitionComponent.java
+++ b/blockly/src/components/AmmunitionComponent.java
@@ -44,6 +44,15 @@ public final class AmmunitionComponent implements Component {
   }
 
   /**
+   * Reset the current amount of ammunition to zero.
+   *
+   * @return the new ammunition value (0)
+   */
+  public int resetCurrentAmmunition() {
+    return setCurrentAmmunition(0);
+  }
+
+  /**
    * Get the current amount of ammunition.
    *
    * @return Current amount of ammunition

--- a/blockly/src/components/AmmunitionComponent.java
+++ b/blockly/src/components/AmmunitionComponent.java
@@ -21,7 +21,7 @@ public final class AmmunitionComponent implements Component {
 
   /** Create a AmmunitionComponent with default values. */
   public AmmunitionComponent() {
-    this.currentAmmunition = 2;
+    this.currentAmmunition = 0;
   }
 
   /** Pick up one Ammunition. */

--- a/blockly/src/components/AmmunitionComponent.java
+++ b/blockly/src/components/AmmunitionComponent.java
@@ -5,7 +5,7 @@ import core.Component;
 /**
  * Allow an associated entity to collect and spend ammunition.
  *
- * <p>If an entity has this component, it can use skills that require ammunition.
+ * <p>Use this component to store and manage ammunition, represented by a simple integer counter.
  */
 public final class AmmunitionComponent implements Component {
   private int currentAmmunition;

--- a/blockly/src/entities/MiscFactory.java
+++ b/blockly/src/entities/MiscFactory.java
@@ -137,6 +137,15 @@ public class MiscFactory {
     return breadcrumb;
   }
 
+  /**
+   * Creates a fireballScroll at the given position.
+   *
+   * <p>The fireballScroll is a temporary item that can be picked up to increase the current
+   * ammunition.
+   *
+   * @param position The initial position of the fireballScroll.
+   * @return A new fireballScroll entity.
+   */
   public static Entity fireballScroll(Point position) {
     Entity fireballScroll = new Entity("fireballScroll");
     fireballScroll.add(new PositionComponent(position.toCoordinate().toCenteredPoint()));

--- a/blockly/src/entities/MiscFactory.java
+++ b/blockly/src/entities/MiscFactory.java
@@ -1,5 +1,6 @@
 package entities;
 
+import components.AmmunitionComponent;
 import components.BlockComponent;
 import components.BlocklyItemComponent;
 import components.PushableComponent;
@@ -16,6 +17,7 @@ import core.components.VelocityComponent;
 import core.level.Tile;
 import core.utils.Point;
 import core.utils.TriConsumer;
+import core.utils.components.MissingComponentException;
 import core.utils.components.draw.Animation;
 import core.utils.components.path.IPath;
 import core.utils.components.path.SimpleIPath;
@@ -32,6 +34,7 @@ public class MiscFactory {
 
   private static final IPath PICKUP_BOCK_PATH = new SimpleIPath("items/book/spell_book.png");
   private static final IPath BREADCRUMB_PATH = new SimpleIPath("items/resource/leaf.png");
+  private static final IPath SCROLL_PATH = new SimpleIPath("items/book/magic_scroll.png");
   private static final float STONE_SPEED = 7.5f;
 
   /**
@@ -132,5 +135,26 @@ public class MiscFactory {
               Game.remove(breadcrumb);
             }));
     return breadcrumb;
+  }
+
+  public static Entity fireballScroll(Point position) {
+    Entity fireballScroll = new Entity("fireballScroll");
+    fireballScroll.add(new PositionComponent(position.toCoordinate().toCenteredPoint()));
+    fireballScroll.add(new DrawComponent(Animation.fromSingleImage(SCROLL_PATH)));
+    fireballScroll.add(new BlocklyItemComponent());
+    fireballScroll.add(
+        new InteractionComponent(
+            0,
+            false,
+            (entity, hero) -> {
+              AmmunitionComponent heroAC =
+                  hero.fetch(AmmunitionComponent.class)
+                      .orElseThrow(
+                          () -> MissingComponentException.build(hero, AmmunitionComponent.class));
+              heroAC.collectAmmo();
+
+              Game.remove(fireballScroll);
+            }));
+    return fireballScroll;
   }
 }


### PR DESCRIPTION
Ich habe den bisher existierenden Feuerball-Block abgeändert, sodass dieser immer in die Blickrichtung des Helden schießt. Außerdem muss eine `fireballScroll` aufgesammelt werden, damit der Held Munition für einen Feuerball hat.

Für die Munition habe ich das `AmmunitionComponent()` erstellt und dem Helden in der  `createHero()` zugewiesen.
Die Munition wird in der `onLevelLoad()` zurückgesetzt und somit nicht ins nächste Level übernommen.
Aktuell ist noch kein UI-Element vorhanden, und dafür bräuchten wir dementsprechend ein separates Issue.

closes #1759 , abgesehen von dem UI-Element