### PR TITLE
[Blockly] cleanup fireball ammunition

### DIFF
--- a/blockly/src/components/AmmunitionComponent.java
+++ b/blockly/src/components/AmmunitionComponent.java
@@ -24,9 +24,14 @@ public final class AmmunitionComponent implements Component {
     this.currentAmmunition = 0;
   }
 
-  /** Pick up one Ammunition. */
-  public void collectAmmo() {
+  /**
+   * Pick up one Ammunition.
+   *
+   * @return current ammunition amount after increase.
+   */
+  public int collectAmmo() {
     currentAmmunition++;
+    return currentAmmunition;
   }
 
   /** Spend one Ammunition. */
@@ -49,7 +54,7 @@ public final class AmmunitionComponent implements Component {
    * @return the new ammunition value (0)
    */
   public int resetCurrentAmmunition() {
-    return setCurrentAmmunition(0);
+    return currentAmmunition(0);
   }
 
   /**
@@ -57,7 +62,7 @@ public final class AmmunitionComponent implements Component {
    *
    * @return Current amount of ammunition
    */
-  public int getCurrentAmmunition() {
+  public int currentAmmunition() {
     return currentAmmunition;
   }
 
@@ -67,7 +72,7 @@ public final class AmmunitionComponent implements Component {
    * @param ammunitionAmount New amount of current ammunition
    * @return the new ammunition value
    */
-  public int setCurrentAmmunition(int ammunitionAmount) {
+  public int currentAmmunition(int ammunitionAmount) {
     currentAmmunition = ammunitionAmount;
     return currentAmmunition;
   }

--- a/blockly/src/entities/MiscFactory.java
+++ b/blockly/src/entities/MiscFactory.java
@@ -156,7 +156,6 @@ public class MiscFactory {
             false,
             (entity, hero) -> {
               hero.fetch(AmmunitionComponent.class).map(AmmunitionComponent::collectAmmo);
-
               Game.remove(fireballScroll);
             }));
     return fireballScroll;

--- a/blockly/src/entities/MiscFactory.java
+++ b/blockly/src/entities/MiscFactory.java
@@ -17,7 +17,6 @@ import core.components.VelocityComponent;
 import core.level.Tile;
 import core.utils.Point;
 import core.utils.TriConsumer;
-import core.utils.components.MissingComponentException;
 import core.utils.components.draw.Animation;
 import core.utils.components.path.IPath;
 import core.utils.components.path.SimpleIPath;
@@ -104,7 +103,7 @@ public class MiscFactory {
     pickup.add(new DrawComponent(Animation.fromSingleImage(PICKUP_BOCK_PATH)));
     pickup.add(
         new InteractionComponent(
-            1,
+            0,
             false,
             (entity, entity2) -> {
               DialogUtils.showTextPopup(pickupText, title);
@@ -156,11 +155,7 @@ public class MiscFactory {
             0,
             false,
             (entity, hero) -> {
-              AmmunitionComponent heroAC =
-                  hero.fetch(AmmunitionComponent.class)
-                      .orElseThrow(
-                          () -> MissingComponentException.build(hero, AmmunitionComponent.class));
-              heroAC.collectAmmo();
+              hero.fetch(AmmunitionComponent.class).map(AmmunitionComponent::collectAmmo);
 
               Game.remove(fireballScroll);
             }));

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -1369,27 +1369,25 @@ public class Server {
         hero.fetch(AmmunitionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(hero, AmmunitionComponent.class));
 
-    if (heroAC.checkAmmunition()) {
-      utils.Direction viewDirection =
-          convertPosCompDirectionToUtilsDirection(EntityUtils.getViewDirection(hero));
-      Skill fireball =
-          new Skill(
-              new FireballSkill(
-                  () -> {
-                    CollideComponent collider =
-                        hero.fetch(CollideComponent.class)
-                            .orElseThrow(
-                                () ->
-                                    MissingComponentException.build(hero, CollideComponent.class));
+    if (!heroAC.checkAmmunition()) return;
+    utils.Direction viewDirection =
+        convertPosCompDirectionToUtilsDirection(EntityUtils.getViewDirection(hero));
+    Skill fireball =
+        new Skill(
+            new FireballSkill(
+                () -> {
+                  CollideComponent collider =
+                      hero.fetch(CollideComponent.class)
+                          .orElseThrow(
+                              () -> MissingComponentException.build(hero, CollideComponent.class));
 
-                    Point start = collider.center(hero);
-                    return start.add(new Point(viewDirection.x(), viewDirection.y()));
-                  }),
-              1);
-      fireball.execute(hero);
-      heroAC.spendAmmo();
-      waitDelta();
-    }
+                  Point start = collider.center(hero);
+                  return start.add(new Point(viewDirection.x(), viewDirection.y()));
+                }),
+            1);
+    fireball.execute(hero);
+    heroAC.spendAmmo();
+    waitDelta();
   }
 
   /** Triggers each interactable in front of the hero. */


### PR DESCRIPTION
In #1828 ist noch etwas Kleinkram durchgerutscht, dieser PR fixt das.  
Außerdem setze ich den Interaktionsradius des Buches auf 0. Dadurch kann es via Blockly nicht mit "benutzen", sondern nur mit "aufheben" aufgesammelt werden. Habe ich mir von den Schriftrollen abgeguckt. ^^  

----  

Thema: [[Diskussion](https://github.com/Dungeon-CampusMinden/Dungeon/pull/1828#discussion_r2012734534)](https://github.com/Dungeon-CampusMinden/Dungeon/pull/1828#discussion_r2012734534)  

**tldr:**  

```java
Game.hero()
    .flatMap(e -> e.fetch(AmmunitionComponent.class))
    .map(AmmunitionComponent::resetCurrentAmmunition);
```

soll aus `Client` raus in ein eigenes System.  

Warum ich dagegen bin:  
Die Entscheidung, dass ich beim Start eines neuen Levels keine Munition mehr habe, ist eine Entscheidung auf Gamedesign-Ebene.  
Mit einem System würden wir das stärker vorgeben.  

Unser Framework hat aber genau für diese Situation – "Ich möchte etwas in MEINEM Spiel machen, wenn ein neues Level geladen wird" – ein Konzept: die `onLevelLoad`-Methode.  

**tldr:** Gehört da hin.