### PR TITLE
[Blockly] add `aktiv` Block

### DIFF
--- a/blockly/frontend/src/blocks/dungeon.ts
+++ b/blockly/frontend/src/blocks/dungeon.ts
@@ -511,6 +511,20 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
     ],
     colour: 60,
   },
+  {
+    type: "logic_active_direction",
+    message0: "aktiv %1",
+    output: "Boolean",
+    tooltip: "Überprüfe, ob ein aktives Objekt in der Richtung ist",
+    args0: [
+      {
+        type: "input_value",
+        name: "DIRECTION",
+        check: "Direction",
+      },
+    ],
+    colour: 60,
+  },
   // ---------------------- If statement ----------------------
   {
     type: "controls_if",

--- a/blockly/frontend/src/generators/java/condition.ts
+++ b/blockly/frontend/src/generators/java/condition.ts
@@ -93,6 +93,15 @@ export function logic_breadcrumbs_direction(
   return [code, Order.NONE];
 }
 
+export function logic_active_direction(
+  block: Blockly.Block,
+  generator: Blockly.Generator
+) {
+  const dir = generator.valueToCode(block, "DIRECTION", Order.NONE);
+  const code = "active(" + dir + ")";
+  return [code, Order.NONE];
+}
+
 export function controls_if(
   block: Blockly.Block,
   generator: Blockly.Generator

--- a/blockly/frontend/src/generators/java/condition.ts
+++ b/blockly/frontend/src/generators/java/condition.ts
@@ -98,7 +98,7 @@ export function logic_active_direction(
   generator: Blockly.Generator
 ) {
   const dir = generator.valueToCode(block, "DIRECTION", Order.NONE);
-  const code = "active(" + dir + ")";
+  const code = "aktiv(" + dir + ")";
   return [code, Order.NONE];
 }
 

--- a/blockly/frontend/src/toolbox.ts
+++ b/blockly/frontend/src/toolbox.ts
@@ -212,6 +212,10 @@ export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
         },
         {
           kind: "block",
+          type: "logic_active_direction"
+        },
+        {
+          kind: "block",
           type: "controls_if",
         },
         {

--- a/blockly/src/antlr/BlocklyConditionVisitor.java
+++ b/blockly/src/antlr/BlocklyConditionVisitor.java
@@ -199,7 +199,7 @@ public class BlocklyConditionVisitor extends blocklyBaseVisitor<INode> {
           case "naheMonster" -> nearComponent(ctx, BlocklyMonsterComponent.class);
           case "naheSchalter" -> nearComponent(ctx, LeverComponent.class);
           case "naheBrotkrume" -> nearComponent(ctx, BreadcrumbComponent.class);
-          case "aktiv" -> activ(ctx);
+          case "aktiv" -> active(ctx);
           default -> {
             LOGGER.warning("Unknown function " + id);
             yield false;

--- a/blockly/src/antlr/BlocklyConditionVisitor.java
+++ b/blockly/src/antlr/BlocklyConditionVisitor.java
@@ -199,6 +199,7 @@ public class BlocklyConditionVisitor extends blocklyBaseVisitor<INode> {
           case "naheMonster" -> nearComponent(ctx, BlocklyMonsterComponent.class);
           case "naheSchalter" -> nearComponent(ctx, LeverComponent.class);
           case "naheBrotkrume" -> nearComponent(ctx, BreadcrumbComponent.class);
+          case "aktiv" -> activ(ctx);
           default -> {
             LOGGER.warning("Unknown function " + id);
             yield false;
@@ -207,6 +208,26 @@ public class BlocklyConditionVisitor extends blocklyBaseVisitor<INode> {
     BaseNode node = new BaseNode(Types.BOOLEAN);
     node.boolVal = boolVal;
     return node;
+  }
+
+  private boolean active(blocklyParser.Func_callContext ctx) {
+    if (ctx.args == null) {
+      LOGGER.warning("active operation function: Expected 1 argument, got 0");
+      return false;
+    }
+
+    // Get the first argument and visit it
+    INode argNode = visit(ctx.args.expr(0));
+    String direction;
+
+    if (argNode instanceof BaseNode && ((BaseNode) argNode).baseType == Types.STRING) {
+      direction = ((BaseNode) argNode).strVal;
+    } else {
+      LOGGER.warning("Expected string argument for active operation");
+      return false;
+    }
+
+    return httpServer.active(Direction.fromString(direction));
   }
 
   private boolean nearComponent(

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -11,11 +11,13 @@ import contrib.utils.components.Debugger;
 import core.Entity;
 import core.Game;
 import core.game.ECSManagment;
+import core.level.utils.LevelElement;
 import core.systems.LevelSystem;
 import core.systems.PlayerSystem;
 import core.utils.Tuple;
 import core.utils.components.path.SimpleIPath;
 import entities.HeroTankControlledFactory;
+import entities.MiscFactory;
 import java.io.IOException;
 import java.util.logging.Level;
 import level.MazeLevel;
@@ -28,7 +30,7 @@ import utils.CheckPatternPainter;
  * have any effect
  */
 public class Client {
-  private static final boolean KEYBOARD_DEACTIVATION = true;
+  private static final boolean KEYBOARD_DEACTIVATION = false;
   private static final boolean DRAW_CHECKER_PATTERN = true;
 
   private static HttpServer httpServer;
@@ -89,6 +91,7 @@ public class Client {
   private static void onLevelLoad() {
     Game.userOnLevelLoad(
         (firstLoad) -> {
+          Game.add(MiscFactory.pressurePlate(Game.randomTilePoint(LevelElement.FLOOR).get()));
           if (DRAW_CHECKER_PATTERN)
             CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
           Server.instance().interruptExecution = true;

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -28,7 +28,7 @@ import utils.CheckPatternPainter;
  * have any effect
  */
 public class Client {
-  private static final boolean KEYBOARD_DEACTIVATION = false;
+  private static final boolean KEYBOARD_DEACTIVATION = true;
   private static final boolean DRAW_CHECKER_PATTERN = true;
 
   private static HttpServer httpServer;

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -11,13 +11,11 @@ import contrib.utils.components.Debugger;
 import core.Entity;
 import core.Game;
 import core.game.ECSManagment;
-import core.level.utils.LevelElement;
 import core.systems.LevelSystem;
 import core.systems.PlayerSystem;
 import core.utils.Tuple;
 import core.utils.components.path.SimpleIPath;
 import entities.HeroTankControlledFactory;
-import entities.MiscFactory;
 import java.io.IOException;
 import java.util.logging.Level;
 import level.MazeLevel;
@@ -91,7 +89,6 @@ public class Client {
   private static void onLevelLoad() {
     Game.userOnLevelLoad(
         (firstLoad) -> {
-          Game.add(MiscFactory.pressurePlate(Game.randomTilePoint(LevelElement.FLOOR).get()));
           if (DRAW_CHECKER_PATTERN)
             CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
           Server.instance().interruptExecution = true;

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -133,7 +133,7 @@ public class Server {
     "geheZumAusgang",
     "aufsammeln",
     "fallen_lassen",
-    "aktiv",
+    "active",
   };
   private final Stack<String> currently_repeating_scope = new Stack<>();
 

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -1394,10 +1394,9 @@ public class Server {
   public boolean active(final Direction direction) {
     Tile targetTile = Game.tileAT(EntityUtils.getHeroPosition().add(direction.toPoint()));
     if (targetTile instanceof DoorTile) return ((DoorTile) targetTile).isOpen();
-    else
-      return Game.entityAtTile(targetTile)
-          .flatMap(e -> e.fetch(LeverComponent.class).stream())
-          .allMatch(LeverComponent::isOn);
+    return Game.entityAtTile(targetTile)
+        .flatMap(e -> e.fetch(LeverComponent.class).stream())
+        .allMatch(LeverComponent::isOn);
   }
 
   /**


### PR DESCRIPTION
fixes #1833 

fügt einen Block ein, der mittels Direction Input prüft ob auf dem Tile was "aktives" ist
Aktiv sind
- offene türen
- Schalter im On State