### PR TITLE
Blockly: Refactor Frontend Logic and Fix Multiple Start Block Issue

### DIFF
--- a/blockly/frontend/src/api/api.ts
+++ b/blockly/frontend/src/api/api.ts
@@ -1,22 +1,111 @@
-import { config } from "../config.ts";
+import {config} from "../config.ts";
+import {displayErrorOnBlock} from "../utils/workspace.ts";
+import * as VariableListUtils from "../utils/variableList.ts";
+import {Block} from "blockly";
 
-export class Api {
+interface ApiResponse {
+  data: string;
+  error: string;
+}
+
+class Api {
   public async post(endpoint: string, text: string = ""): Promise<Response> {
     const url = new URL(config.API_URL + endpoint);
 
     try {
-      const response = await fetch(url, {
+      return await fetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "text/plain",
         },
         body: text,
       });
-      return response;
     } catch (error) {
       alert("Fehler beim Senden der Anfrage");
       console.error("Fehler beim Senden der Anfrage", error);
       return new Response(null, { status: 500 });
     }
+  }
+}
+
+const api = new Api();
+
+/**
+ * Handle the response from the server
+ *
+ * This function checks if the response from the server was ok or
+ * the program got interrupted. If the response was not ok, an
+ * error message is displayed on the current block.
+ *
+ * @param response The response from the server
+ * @returns true if the response was ok, false otherwise
+ */
+const handleResponse = async (response: Response): Promise<ApiResponse> => {
+  if (!response.ok) {
+    const errorMessage = await response.text();
+    return {
+      data: "",
+      error: errorMessage,
+    }
+  }
+  // Status 205 means program was interrupted
+  if (response.status === 205) {
+    console.info("Programm unterbrochen!");
+    return {
+      data: "",
+      error: "Programm unterbrochen!",
+    }
+  }
+  return {
+    data: await response.text(),
+    error: "",
+  }
+}
+
+/**
+ * Call the start route of the server
+ *
+ * <p> This route is used to start the program and send the code to the server.
+ *
+ * @param code The code to send to the server
+ * @param currentBlock The current block to highlight
+ * @param first_step true if this is the first step, false otherwise. This is to check if were sending a new program or not.
+ */
+export const call_start_route = async (code: string, currentBlock: Block, first_step: boolean = true) => {
+  const start_response = await api.post(`start?first=${first_step}`, code);
+  const response = await handleResponse(start_response);
+  if (response.error !== "" && response.error !== "Programm unterbrochen!") {
+    displayErrorOnBlock(currentBlock, response.error);
+  }
+  return response.error !== "";
+}
+
+export const call_variables_route = async () => {
+  const var_response = await api.post("variables");
+  const response = await handleResponse(var_response);
+  if (response.error !== "") {
+    console.error("Fehler beim Abrufen der Variablen", response);
+    return;
+  }
+  const variableData = response.data;
+  variableData.split("\n").forEach((line) => {
+    const [name, value] = line.split("=");
+    VariableListUtils.updateVariable(name, value);
+  });
+}
+
+export const call_reset_route = async () => {
+  const reset_response = await api.post("reset");
+  const response = await handleResponse(reset_response);
+  if (response.error !== "") {
+    console.error("Fehler beim Zurücksetzen des Spiels", response);
+    return;
+  }
+}
+
+export const call_clear_route = async () => {
+  const clear_response = await api.post("clear");
+  if (!clear_response.ok) {
+    console.error("Fehler beim Zurücksetzen der Werte", clear_response);
   }
 }

--- a/blockly/frontend/src/api/api.ts
+++ b/blockly/frontend/src/api/api.ts
@@ -70,6 +70,8 @@ const handleResponse = async (response: Response): Promise<ApiResponse> => {
  * @param code The code to send to the server
  * @param currentBlock The current block to highlight
  * @param first_step true if this is the first step, false otherwise. This is to check if were sending a new program or not.
+ *
+ * @returns true if the program was successfully started, false otherwise
  */
 export const call_start_route = async (code: string, currentBlock: Block, first_step: boolean = true) => {
   const start_response = await api.post(`start?first=${first_step}`, code);
@@ -80,29 +82,52 @@ export const call_start_route = async (code: string, currentBlock: Block, first_
   return response.error !== "";
 }
 
-export const call_variables_route = async () => {
+/**
+ * Call the variables route of the server
+ *
+ * <p> This route is used to get the variables from the server and update the variable list.
+ *
+ * @returns true if the variables were successfully retrieved, false otherwise
+ */
+export const call_variables_route = async (): Promise<boolean> => {
   const var_response = await api.post("variables");
   const response = await handleResponse(var_response);
   if (response.error !== "") {
     console.error("Fehler beim Abrufen der Variablen", response);
-    return;
+    return false;
   }
   const variableData = response.data;
   variableData.split("\n").forEach((line) => {
     const [name, value] = line.split("=");
     VariableListUtils.updateVariable(name, value);
   });
+  return true;
 }
 
-export const call_reset_route = async () => {
+/**
+ * Call the reset route of the server
+ *
+ * <p> This route is used to reset the game (current level)
+ *
+ * @returns true if the game was successfully reset, false otherwise
+ */
+export const call_reset_route = async (): Promise<boolean> => {
   const reset_response = await api.post("reset");
   const response = await handleResponse(reset_response);
   if (response.error !== "") {
     console.error("Fehler beim Zurücksetzen des Spiels", response);
-    return;
   }
+
+  return response.error === "";
 }
 
+/**
+ * Call the clear route of the server
+ *
+ * <p> This route is used to reset all variables and values
+ *
+ * @returns true if the values were successfully cleared, false otherwise
+ */
 export const call_clear_route = async () => {
   const clear_response = await api.post("clear");
   if (!clear_response.ok) {

--- a/blockly/frontend/src/api/api.ts
+++ b/blockly/frontend/src/api/api.ts
@@ -79,7 +79,7 @@ export const call_start_route = async (code: string, currentBlock: Block, first_
   if (response.error !== "" && response.error !== "Programm unterbrochen!") {
     displayErrorOnBlock(currentBlock, response.error);
   }
-  return response.error !== "";
+  return response.error === "";
 }
 
 /**

--- a/blockly/frontend/src/index.ts
+++ b/blockly/frontend/src/index.ts
@@ -1,10 +1,10 @@
 import * as Blockly from "blockly";
 import * as De from "blockly/msg/de";
-import { blocks } from "./blocks/dungeon.ts";
-import { javaGenerator } from "./generators/java.ts";
-import { save, load } from "./serialization.ts";
-import { toolbox } from "./toolbox.ts";
-import { config } from "./config.ts";
+import {blocks} from "./blocks/dungeon.ts";
+import {javaGenerator} from "./generators/java.ts";
+import {load, save} from "./serialization.ts";
+import {toolbox} from "./toolbox.ts";
+import {config} from "./config.ts";
 import "./style.css";
 import * as LimitUtils from "./utils/limits.ts";
 import {getStartBlock, placeDefaultStartBlock, setupButtons} from "./utils/workspace.ts";
@@ -132,6 +132,31 @@ workspace.addChangeListener((e: Blockly.Events.Abstract) => {
     const newVariableName = (e as Blockly.Events.VarRename).newName;
     if (oldVariableName === undefined || newVariableName === undefined) return;
     VariableListUtils.renameVariable(oldVariableName, newVariableName);
+  }
+});
+
+// Prevent restoring multiple start blocks
+workspace.addChangeListener(async (e: Blockly.Events.Abstract) => {
+  if (e.type !== Blockly.Events.BLOCK_CREATE) return;
+
+  const startBlock = getStartBlock(workspace);
+  if (!startBlock) return; // no start block, so we allow any block to be created
+
+  const newStartBlocks = (e as Blockly.Events.BlockCreate).ids
+    ?.map(id => workspace.getBlockById(id))
+    .filter(block => block?.type === "start") ?? [];
+
+  if (newStartBlocks.length === 0) return;
+
+  const extraStartBlocks = newStartBlocks.filter(block => block?.id !== startBlock.id);
+  if (extraStartBlocks.length > 1) { // More than one extra start block, prevent adding at all (should never happen)
+    extraStartBlocks.forEach(block => block?.dispose());
+    return;
+  }
+
+  if (extraStartBlocks.length === 1) { // delete the old start block, so we can restore the new one
+    workspace.removeBlockById(startBlock.id);
+    startBlock.dispose();
   }
 });
 

--- a/blockly/frontend/src/index.ts
+++ b/blockly/frontend/src/index.ts
@@ -72,7 +72,6 @@ load(workspace);
 updateCodeDiv();
 
 // Every time the workspace changes state, save the changes to storage.
-
 workspace.addChangeListener((e: Blockly.Events.Abstract) => {
   // UI events are things like scrolling, zooming, etc.
   // No need to save after one of these.

--- a/blockly/frontend/src/index.ts
+++ b/blockly/frontend/src/index.ts
@@ -4,11 +4,10 @@ import { blocks } from "./blocks/dungeon.ts";
 import { javaGenerator } from "./generators/java.ts";
 import { save, load } from "./serialization.ts";
 import { toolbox } from "./toolbox.ts";
-import { Api } from "./api/api.ts";
 import { config } from "./config.ts";
 import "./style.css";
-import {sleep} from "./utils/utils.ts";
 import * as LimitUtils from "./utils/limits.ts";
+import {getStartBlock, placeDefaultStartBlock, setupButtons} from "./utils/workspace.ts";
 import * as VariableListUtils from "./utils/variableList.ts";
 
 Blockly.setLocale(De as any); // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -33,19 +32,21 @@ const workspace =
       scaleSpeed: 1.2,
     },
   });
-const api = new Api();
-const startBtn = document.getElementById("startBtn") as HTMLButtonElement;
-const delay = document.getElementById("delay") as HTMLInputElement;
-const stepBtn = document.getElementById("stepBtn") as HTMLButtonElement;
-const resetBtn = document.getElementById("resetBtn") as HTMLButtonElement;
+
+if (!workspace) {
+  throw new Error("No workspace available");
+}
+
+setupButtons(workspace);
+
+// Disable all blocks that aren't connected to the start block.
+workspace.addChangeListener(Blockly.Events.disableOrphans);
 
 // Variable List
 const addVarCallback = () => {
-  if (workspace === null) throw new Error("No workspace available");
   Blockly.Variables.createVariableButtonHandler(workspace);
 }
 const removeVarCallback = (varName: string) => {
-  if (workspace === null) throw new Error("No workspace available");
   const variable = Blockly.Variables.getVariable(workspace, null, varName, '');
   if (variable === null) return;
   if (window.confirm(`Soll die Variable "${varName}" wirklich gelöscht werden?`)) {
@@ -53,296 +54,87 @@ const removeVarCallback = (varName: string) => {
   }
 }
 VariableListUtils.setupVariableDisplay(addVarCallback);
-
-// Disable all blocks that aren't connected to the start block.
-if (workspace !== null) {
-  workspace.addChangeListener(Blockly.Events.disableOrphans);
-  workspace.registerButtonCallback("createVariable", addVarCallback);
-} else {
-  throw new Error("No workspace available");
-}
-
+workspace.registerButtonCallback("createVariable", addVarCallback);
 
 // This function resets the code and output divs, shows the
 // generated code from the workspace, and evals the code.
 // In a real application, you probably shouldn't use `eval`.
 let code = "";
-const runCode = () => {
+const updateCodeDiv = () => {
   code = javaGenerator.workspaceToCode(Blockly.getMainWorkspace());
   if (codeDiv) {
     codeDiv.textContent = code;
   }
 };
 
-if (workspace) {
-  // Load the initial state from storage and run the code.
-  load(workspace);
-  runCode();
+// Load the initial state from storage and run the code.
+load(workspace);
+updateCodeDiv();
 
-  // Every time the workspace changes state, save the changes to storage.
+// Every time the workspace changes state, save the changes to storage.
 
-  workspace.addChangeListener((e: Blockly.Events.Abstract) => {
-    // UI events are things like scrolling, zooming, etc.
-    // No need to save after one of these.
-    if (e.isUiEvent) return;
-    save(workspace);
-  });
+workspace.addChangeListener((e: Blockly.Events.Abstract) => {
+  // UI events are things like scrolling, zooming, etc.
+  // No need to save after one of these.
+  if (e.isUiEvent) return;
+  save(workspace);
+});
 
-  // Whenever the workspace changes meaningfully, run the code again.
-  workspace.addChangeListener((e: Blockly.Events.Abstract) => {
-    // Don't run the code when the workspace finishes loading; we're
-    // already running it once when the application starts.
-    // Don't run the code during drags; we might have invalid state.
-    if (
-      e.isUiEvent ||
-      e.type == Blockly.Events.FINISHED_LOADING ||
-      workspace.isDragging()
-    ) {
-      return;
-    }
-    runCode();
-  });
-
-  // Limiting Blocks Logic
-  workspace.addChangeListener((e: Blockly.Events.Abstract) => {
-    let update = false;
-    if (e.type == Blockly.Events.BLOCK_CREATE) {
-      const newBlockId = (e as Blockly.Events.BlockCreate).blockId;
-      if (newBlockId === undefined) return;
-      const newBlock = workspace.getBlockById(newBlockId);
-      if (newBlock === null) return;
-      LimitUtils.registerBlockAdded(newBlock as unknown as Blockly.serialization.blocks.State);
-      update = true;
-    } else if (e.type == Blockly.Events.BLOCK_DELETE) {
-      const oldBlockState = (e as Blockly.Events.BlockDelete).oldJson;
-      if (oldBlockState === undefined) return;
-      LimitUtils.registerBlockRemoved(oldBlockState);
-      update = true;
-    }
-    // Enable/disable affected blocks
-    if (update) {
-      LimitUtils.refreshToolbox(workspace);
-      workspace.getToolbox()?.refreshSelection();
-    }
-  });
-
-  // Link Variable List to the workspace
-  workspace.addChangeListener((e: Blockly.Events.Abstract) => {
-    if (e.type == Blockly.Events.VAR_CREATE) {
-      const newVariableName = (e as Blockly.Events.VarCreate).varName;
-      if (newVariableName === undefined) return;
-      VariableListUtils.addVariable(newVariableName, removeVarCallback);
-    } else if (e.type == Blockly.Events.VAR_DELETE) {
-      const oldVariableName = (e as Blockly.Events.VarDelete).varName;
-      if (oldVariableName === undefined) return;
-      VariableListUtils.removeVariable(oldVariableName);
-    } else if (e.type == Blockly.Events.VAR_RENAME) {
-      const oldVariableName = (e as Blockly.Events.VarRename).oldName;
-      const newVariableName = (e as Blockly.Events.VarRename).newName;
-      if (oldVariableName === undefined || newVariableName === undefined) return;
-      VariableListUtils.renameVariable(oldVariableName, newVariableName);
-    }
-  });
-}
-
-
-async function call_clear_route(){
-  const clear_response = await api.post("clear");
-  if (!clear_response.ok) {
-    console.error("Fehler beim Zurücksetzen der Werte", clear_response);
+// Whenever the workspace changes meaningfully, run the code again.
+workspace.addChangeListener((e: Blockly.Events.Abstract) => {
+  // Don't run the code when the workspace finishes loading; we're
+  // already running it once when the application starts.
+  // Don't run the code during drags; we might have invalid state.
+  if (
+    e.isUiEvent ||
+    e.type == Blockly.Events.FINISHED_LOADING ||
+    workspace.isDragging()
+  ) {
+    return;
   }
-}
+  updateCodeDiv();
+});
 
-const displayErrorOnBlock = (block: Blockly.Block, error: string) => {
-    const errorArray = error.split("Fehlermeldung: ");
-    let errorText;
-    if (errorArray.length > 1) {
-        errorText = errorArray[1];
-    } else {
-        errorText = error;
-    }
-    block.setWarningText(errorText);
-}
-
-const clearAllWarnings = (workspace: Blockly.Workspace) => {
-    const allBlocks = workspace.getAllBlocks();
-    for (let i = 0; i < allBlocks.length; i++) {
-        const block = allBlocks[i];
-        block.setWarningText(null);
-    }
-}
-
-/**
- * Handle the response from the server
- *
- * This function checks if the response from the server was ok or
- * the program got interrupted. If the response was not ok, an
- * error message is displayed on the current block.
- *
- * @param response The response from the server
- * @param currentBlock The current block
- * @returns true if the response was ok, false otherwise
- */
-const handleResponse = async (response: Response, currentBlock: Blockly.Block): Promise<boolean> => {
-    if (!response.ok) {
-        const errorMessage = await response.text();
-        displayErrorOnBlock(currentBlock, errorMessage);
-        console.error("Fehler beim Ausführen des Codes", response);
-        return false;
-    }
-    // Status 205 means program was interrupted
-    if (response.status === 205) {
-        console.info("Programm unterbrochen!");
-        return false;
-    }
-    return true;
-}
-
-const updateVariables = async () => {
-  const varResponse = await api.post("variables");
-  if (varResponse.ok) {
-    const variableData = await varResponse.text();
-    variableData.split("\n").forEach((line) => {
-      const [name, value] = line.split("=");
-      VariableListUtils.updateVariable(name, value);
-    });
-  } else {
-    console.error("Fehler beim Abrufen der Variablen", varResponse);
+// Limiting Blocks Logic
+workspace.addChangeListener((e: Blockly.Events.Abstract) => {
+  let update = false;
+  if (e.type == Blockly.Events.BLOCK_CREATE) {
+    const newBlockId = (e as Blockly.Events.BlockCreate).blockId;
+    if (newBlockId === undefined) return;
+    const newBlock = workspace.getBlockById(newBlockId);
+    if (newBlock === null) return;
+    LimitUtils.registerBlockAdded(newBlock as unknown as Blockly.serialization.blocks.State);
+    update = true;
+  } else if (e.type == Blockly.Events.BLOCK_DELETE) {
+    const oldBlockState = (e as Blockly.Events.BlockDelete).oldJson;
+    if (oldBlockState === undefined) return;
+    LimitUtils.registerBlockRemoved(oldBlockState);
+    update = true;
   }
-}
-
-if (startBtn) {
-  startBtn.addEventListener("click", async () => {
-    clearAllWarnings(workspace);
-
-    resetBtn.click();
-
-    let sleepingTimeStr = delay.value;
-    if (sleepingTimeStr === "") {
-      sleepingTimeStr = "1";
-    }
-    const sleepingTime = Number(sleepingTimeStr);
-    if (isNaN(sleepingTime)) {
-      throw new Error("Die konfigurierte Verzögerung muss eine Zahl sein");
-    }
-
-    startBtn.disabled = true;
-    stepBtn.disabled = true;
-    workspace.highlightBlock(null);
-    let currentBlock = getStartBlock(workspace);
-    let first = true;
-    while (currentBlock !== null) {
-      // Highlight current block
-      if (currentBlock) {
-        workspace.highlightBlock(currentBlock.id);
-      }
-      // Do nothing except highlighting on start block
-      if (currentBlock.type === "start") {
-        currentBlock = currentBlock.getNextBlock();
-        continue;
-      }
-
-      // Get code of the current block
-      const currentCode = javaGenerator.blockToCode(currentBlock, true);
-
-      const response = await api.post(`start?first=${first}`, currentCode as string);
-      first = false;
-
-      const ok = await handleResponse(response, currentBlock);
-      if (!ok) break;
-
-      await updateVariables();
-
-      // Get next block and sleep x seconds
-      currentBlock = currentBlock.getNextBlock();
-      await sleep(sleepingTime);
-    }
-    // Reset values in backend
-    call_clear_route();
-
-    workspace.highlightBlock(null);
-    // Enable button again
-    startBtn.disabled = false;
-    stepBtn.disabled = false;
-  });
-}
-
-function getStartBlock(workspace: Blockly.Workspace) {
-  const allBlocks = workspace.getAllBlocks();
-  for (let i = 0; i < allBlocks.length; i++) {
-      const block = allBlocks[i];
-      if (block.type == "start") {
-        return block;
-      }
+  // Enable/disable affected blocks
+  if (update) {
+    LimitUtils.refreshToolbox(workspace);
+    workspace.getToolbox()?.refreshSelection();
   }
-  return null;
-}
+});
 
-let currentBlock: Blockly.Block | null = null;
-
-if (stepBtn !== null) {
-  workspace.highlightBlock(null);
-  stepBtn.addEventListener("click", async () => {
-      clearAllWarnings(workspace);
-
-      if (currentBlock === null) {
-        workspace.highlightBlock(null);
-        currentBlock = getStartBlock(workspace)
-        // Reset values in backend
-        call_clear_route();
-        return;
-      }
-
-      // Highlight current block
-      workspace.highlightBlock(currentBlock.id);
-
-      // Do nothing except highlighting on start block
-      if (currentBlock.type === "start") {
-        currentBlock = currentBlock.getNextBlock();
-        return;
-      }
-      const first = currentBlock.getParent()?.type === "start";
-
-      // Disable buttons
-      stepBtn.disabled = true;
-      startBtn.disabled = true;
-      // Get code of the current block
-      const currentCode = javaGenerator.blockToCode(currentBlock, true);
-      // Send code to server
-      const response = await api.post(`start?first=${first}`, currentCode as string);
-
-      // Check if response was not ok
-      const ok = await handleResponse(response, currentBlock);
-      if (!ok) {
-        currentBlock = getStartBlock(workspace);
-        call_clear_route();
-        workspace.highlightBlock(null);
-      }
-
-      await updateVariables();
-
-      // Enable button again
-      startBtn.disabled = false;
-      stepBtn.disabled = false;
-
-    // Get next block. Current block may be null if program was interrupted
-    if (currentBlock) {
-      currentBlock = currentBlock.getNextBlock();
-    }
-  });
-}
-
-if (resetBtn) {
-  resetBtn.addEventListener("click", async () => {
-    clearAllWarnings(workspace);
-    // Reset code highlighting
-    workspace.highlightBlock(null);
-    // Reset currentBlock for step button
-    currentBlock = getStartBlock(workspace);
-    VariableListUtils.resetVariables();
-    await api.post("reset");
-  });
-}
+// Link Variable List to the workspace
+workspace.addChangeListener((e: Blockly.Events.Abstract) => {
+  if (e.type == Blockly.Events.VAR_CREATE) {
+    const newVariableName = (e as Blockly.Events.VarCreate).varName;
+    if (newVariableName === undefined) return;
+    VariableListUtils.addVariable(newVariableName, removeVarCallback);
+  } else if (e.type == Blockly.Events.VAR_DELETE) {
+    const oldVariableName = (e as Blockly.Events.VarDelete).varName;
+    if (oldVariableName === undefined) return;
+    VariableListUtils.removeVariable(oldVariableName);
+  } else if (e.type == Blockly.Events.VAR_RENAME) {
+    const oldVariableName = (e as Blockly.Events.VarRename).oldName;
+    const newVariableName = (e as Blockly.Events.VarRename).newName;
+    if (oldVariableName === undefined || newVariableName === undefined) return;
+    VariableListUtils.renameVariable(oldVariableName, newVariableName);
+  }
+});
 
 if (config.HIDE_GENERATED_CODE) {
   const generatedCodeDiv = document.getElementById("generatedCode");
@@ -358,13 +150,8 @@ if (config.HIDE_RESPONSE_INFO) {
   }
 }
 
-workspace.clear(); // clearing workspace
 workspace.scrollCenter(); // centering workspace
 
-if (workspace) { // placing default start block
-  const startBlock = workspace.newBlock("start");
-  startBlock.initSvg();
-  startBlock.render();
-  startBlock.setDeletable(false);
-  currentBlock = startBlock;
-}
+const startBlock = getStartBlock(workspace);
+if (!startBlock)
+  placeDefaultStartBlock(workspace);

--- a/blockly/frontend/src/utils/workspace.ts
+++ b/blockly/frontend/src/utils/workspace.ts
@@ -17,6 +17,10 @@ export const getStartBlock = (workspace: Blockly.Workspace) => {
   return null;
 }
 
+/**
+ * Clear all warnings from all blocks in the workspace
+ * @param workspace The workspace to clear warnings from
+ */
 export const clearAllWarnings = (workspace: Blockly.Workspace) => {
   const allBlocks = workspace.getAllBlocks();
   for (let i = 0; i < allBlocks.length; i++) {
@@ -25,6 +29,11 @@ export const clearAllWarnings = (workspace: Blockly.Workspace) => {
   }
 }
 
+/**
+ * Display an error message on a block
+ * @param block The block to display the error on
+ * @param error The error message to display
+ */
 export const displayErrorOnBlock = (block: Blockly.Block | null, error: string) => {
   if (block === null) {
     console.error("Cannot display error on block: block is null");
@@ -194,6 +203,14 @@ const setupResetButton = (buttons: Buttons, workspace: Blockly.WorkspaceSvg) => 
   });
 }
 
+/**
+ * Place the default start block in the workspace
+ *
+ * <p> This function creates a new block of type "start" and places it in the workspace.
+ * The block is not deletable and is rendered immediately. Also, the currentBlock variable is set to the new block.
+ *
+ * @param workspace The workspace to place the block in
+ */
 export const placeDefaultStartBlock = (workspace: Blockly.WorkspaceSvg) => {
   const startBlock = workspace.newBlock("start");
   startBlock.initSvg();

--- a/blockly/frontend/src/utils/workspace.ts
+++ b/blockly/frontend/src/utils/workspace.ts
@@ -4,13 +4,19 @@ import {sleep} from "./utils.ts";
 import * as VariableListUtils from "./variableList.ts";
 import {call_clear_route, call_reset_route, call_start_route, call_variables_route} from "../api/api.ts";
 
+let startBlock: Blockly.Block | null = null;
 export let currentBlock: Blockly.Block | null = null;
 
 export const getStartBlock = (workspace: Blockly.Workspace) => {
+  if (startBlock !== null && !startBlock.isDeadOrDying()) {
+    return startBlock;
+  }
+
   const allBlocks = workspace.getAllBlocks();
   for (let i = 0; i < allBlocks.length; i++) {
     const block = allBlocks[i];
-    if (block.type == "start") {
+    if (block.type == "start" && !block.isDeadOrDying()) {
+      startBlock = block;
       return block;
     }
   }
@@ -163,7 +169,7 @@ const setupStepButton = (buttons: Buttons, workspace: Blockly.WorkspaceSvg) => {
         currentBlock = currentBlock.getNextBlock();
         return;
       }
-      let first = currentBlock.getParent()?.type === "start";
+      const first = currentBlock.getParent()?.type === "start";
 
       // Disable buttons
       buttons.stepBtn.disabled = true;

--- a/blockly/frontend/src/utils/workspace.ts
+++ b/blockly/frontend/src/utils/workspace.ts
@@ -1,0 +1,203 @@
+import * as Blockly from "blockly";
+import {javaGenerator} from "../generators/java.ts";
+import {sleep} from "./utils.ts";
+import * as VariableListUtils from "./variableList.ts";
+import {call_clear_route, call_reset_route, call_start_route, call_variables_route} from "../api/api.ts";
+
+export let currentBlock: Blockly.Block | null = null;
+
+export const getStartBlock = (workspace: Blockly.Workspace) => {
+  const allBlocks = workspace.getAllBlocks();
+  for (let i = 0; i < allBlocks.length; i++) {
+    const block = allBlocks[i];
+    if (block.type == "start") {
+      return block;
+    }
+  }
+  return null;
+}
+
+export const clearAllWarnings = (workspace: Blockly.Workspace) => {
+  const allBlocks = workspace.getAllBlocks();
+  for (let i = 0; i < allBlocks.length; i++) {
+    const block = allBlocks[i];
+    block.setWarningText(null);
+  }
+}
+
+export const displayErrorOnBlock = (block: Blockly.Block | null, error: string) => {
+  if (block === null) {
+    console.error("Cannot display error on block: block is null");
+    console.error("Error message: ", error);
+    return;
+  }
+
+  const errorArray = error.split("Fehlermeldung: ");
+  let errorText;
+  if (errorArray.length > 1) {
+    errorText = errorArray[1];
+  } else {
+    errorText = error;
+  }
+  block.setWarningText(errorText);
+}
+
+interface Buttons {
+  startBtn: HTMLButtonElement;
+  stepBtn: HTMLButtonElement;
+  resetBtn: HTMLButtonElement;
+}
+
+/**
+ * Set up the buttons for the workspace
+ *
+ * <p> Each button has its own function that is called when the button is clicked.
+ * The start button starts the program, the step button executes one step and the reset button resets the program.
+ *
+ * <p> The buttons are disabled while the program is running to prevent multiple clicks.
+ * The start button is disabled while the step button is enabled and vice versa.
+ * The reset button is always enabled.
+ *
+ * @param workspace The workspace to set up the buttons for
+ */
+export const setupButtons = (workspace: Blockly.WorkspaceSvg) => {
+  const buttons: Buttons = {
+    startBtn: document.getElementById("startBtn") as HTMLButtonElement,
+    stepBtn: document.getElementById("stepBtn") as HTMLButtonElement,
+    resetBtn: document.getElementById("resetBtn") as HTMLButtonElement
+  };
+  const delayInput = document.getElementById("delay") as HTMLInputElement;
+
+  if (buttons.startBtn === null || buttons.stepBtn === null || buttons.resetBtn === null) {
+    throw new Error("Buttons not found");
+  }
+  if (delayInput === null) {
+    throw new Error("Delay input not found");
+  }
+
+  setupStartButton(buttons, workspace, delayInput);
+  setupStepButton(buttons, workspace);
+  setupResetButton(buttons, workspace);
+
+  return buttons;
+}
+
+const setupStartButton = (buttons: Buttons, workspace: Blockly.WorkspaceSvg, delayInput: HTMLInputElement) => {
+  buttons.startBtn.addEventListener("click", async () => {
+    buttons.resetBtn.click();
+
+    let sleepingTimeStr = delayInput.value;
+    if (sleepingTimeStr === "") {
+      sleepingTimeStr = "1";
+    }
+    const sleepingTime = Number(sleepingTimeStr);
+    if (isNaN(sleepingTime)) {
+      throw new Error("Die konfigurierte Verzögerung muss eine Zahl sein");
+    }
+
+    buttons.startBtn.disabled = true;
+    buttons.stepBtn.disabled = true;
+    workspace.highlightBlock(null);
+    currentBlock = getStartBlock(workspace);
+    let first = true;
+    while (currentBlock !== null) {
+      // Highlight current block
+      if (currentBlock) {
+        workspace.highlightBlock(currentBlock.id);
+      }
+      // Do nothing except highlighting on start block
+      if (currentBlock.type === "start") {
+        currentBlock = currentBlock.getNextBlock();
+        continue;
+      }
+
+      // Get code of the current block
+      const currentCode = javaGenerator.blockToCode(currentBlock, true);
+
+      const apiResponse = await call_start_route(currentCode as string, currentBlock, first);
+      first = false;
+      if (!apiResponse) break;
+
+      await call_variables_route();
+
+      // Get next block and sleep x seconds
+      currentBlock = currentBlock.getNextBlock();
+      await sleep(sleepingTime);
+    }
+    // Reset values in backend
+    await call_clear_route();
+
+    workspace.highlightBlock(null);
+    // Enable button again
+    buttons.startBtn.disabled = false;
+    buttons.stepBtn.disabled = false;
+  });
+}
+
+const setupStepButton = (buttons: Buttons, workspace: Blockly.WorkspaceSvg) => {
+  buttons.stepBtn.addEventListener("click", async () => {
+      clearAllWarnings(workspace);
+
+      if (currentBlock === null) {
+        workspace.highlightBlock(null);
+        currentBlock = getStartBlock(workspace)
+        // Reset values in backend
+        call_clear_route();
+        return;
+      }
+
+      // Highlight current block
+      workspace.highlightBlock(currentBlock.id);
+
+      // Do nothing except highlighting on start block
+      if (currentBlock.type === "start") {
+        currentBlock = currentBlock.getNextBlock();
+        return;
+      }
+      let first = currentBlock.getParent()?.type === "start";
+
+      // Disable buttons
+      buttons.stepBtn.disabled = true;
+      buttons.startBtn.disabled = true;
+      // Get code of the current block
+      const currentCode = javaGenerator.blockToCode(currentBlock, true);
+      // Send code to server
+      const response = await call_start_route(currentCode as string, currentBlock, first);
+      if (!response) {
+        currentBlock = getStartBlock(workspace);
+        await call_clear_route();
+        workspace.highlightBlock(null);
+      }
+
+      await call_variables_route();
+
+      // Enable button again
+      buttons.startBtn.disabled = false;
+      buttons.stepBtn.disabled = false;
+
+      // Get next block. Current block may be null if program was interrupted
+      if (currentBlock) {
+        currentBlock = currentBlock.getNextBlock();
+      }
+    });
+}
+
+const setupResetButton = (buttons: Buttons, workspace: Blockly.WorkspaceSvg) => {
+  buttons.resetBtn.addEventListener("click", async () => {
+    clearAllWarnings(workspace);
+    // Reset code highlighting
+    workspace.highlightBlock(null);
+    // Reset currentBlock for step button
+    currentBlock = getStartBlock(workspace);
+    VariableListUtils.resetVariables();
+    await call_reset_route();
+  });
+}
+
+export const placeDefaultStartBlock = (workspace: Blockly.WorkspaceSvg) => {
+  const startBlock = workspace.newBlock("start");
+  startBlock.initSvg();
+  startBlock.render();
+  startBlock.setDeletable(false);
+  currentBlock = startBlock;
+}


### PR DESCRIPTION
Ich habe die `index.ts` im Blockly Frontend refactored. Der Großteil der Logik wurde in `workspace.ts` ausgelagert, und die API-Methoden befinden sich jetzt in `api.ts`. Zudem wurde das Problem mit mehreren Start-Blöcken, das in Issue #1868 beschrieben wurde, behoben. Nun wird beim Platzieren eines Blocks überprüft, ob es mehrere Start-Blöcke gibt, und der älteste Block wird gelöscht. Das Laden und Speichern der letzten Session wurde ebenfalls korrekt implementiert: Wenn keine vorherige Session vorhanden ist, wird ein Start-Block platziert.

- `index.ts`: Refactoring der Logik und Auslagerung in separate Dateien.
- `workspace.ts`: Auslagerung der Hauptlogik, die zuvor in `index.ts` war.
- `api.ts`: Verschiebung der API-Methoden für eine bessere Strukturierung.
- Start-Block Fix: Verhindert das Spawnen mehrerer Start-Blöcke, indem der älteste Start-Block gelöscht wird.
- Session Loading: Letzte Session wird wieder geladen, oder ein Start-Block platziert wird, wenn keine vorhanden ist.

closes #1868