### PR TITLE
Blockly: Change webserver default port

### DIFF
--- a/blockly/frontend/webserver/webserver.ts
+++ b/blockly/frontend/webserver/webserver.ts
@@ -1,7 +1,7 @@
 import { serveFile } from "jsr:@std/http/file-server";
 
 const BASE_DIR = "/content";
-const PORT = 8080;
+const PORT = 8081;
 
 const handler = async (request: Request): Promise<Response> => {
     const url = new URL(request.url);


### PR DESCRIPTION
Um zu verhindern, dass der Blockly Server und der Webserver für das Frontend den gleichen Port verwenden, habe ich den Standard-Port vom Webserver geändert.