### PR TITLE
[blockly] make lever blockable, disable stone push into monster

### DIFF
--- a/blockly/src/entities/MiscFactory.java
+++ b/blockly/src/entities/MiscFactory.java
@@ -5,6 +5,7 @@ import contrib.components.CollideComponent;
 import contrib.components.InteractionComponent;
 import contrib.components.LeverComponent;
 import contrib.components.ProjectileComponent;
+import contrib.entities.LeverFactory;
 import contrib.hud.DialogUtils;
 import contrib.utils.ICommand;
 import core.Entity;
@@ -84,6 +85,30 @@ public class MiscFactory {
         };
     pressurePlate.add(new CollideComponent(collide, collide));
     return pressurePlate;
+  }
+
+  /**
+   * Create a Lever with a {@link BlockComponent}.
+   *
+   * @param position Position to place on (will be centered)
+   * @return lever entity
+   */
+  public static Entity blocklyLever(final Point position) {
+    Entity lever = LeverFactory.createLever(position.toCoordinate().toCenteredPoint());
+    lever.add(new BlockComponent());
+    return lever;
+  }
+
+  /**
+   * Create a Lever that looks like a torch with a {@link BlockComponent}.
+   *
+   * @param position Position to place on (will be centered)
+   * @return lever entity
+   */
+  public static Entity blocklyTorch(final Point position) {
+    Entity torch = LeverFactory.createTorch(position.toCoordinate().toCenteredPoint());
+    torch.add(new BlockComponent());
+    return torch;
   }
 
   /**

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -13,10 +13,7 @@ import components.AmmunitionComponent;
 import components.BlockComponent;
 import components.BlocklyItemComponent;
 import components.PushableComponent;
-import contrib.components.CollideComponent;
-import contrib.components.InteractionComponent;
-import contrib.components.ItemComponent;
-import contrib.components.LeverComponent;
+import contrib.components.*;
 import contrib.level.DevDungeonLoader;
 import contrib.utils.EntityUtils;
 import contrib.utils.components.skill.FireballSkill;
@@ -1651,7 +1648,8 @@ public class Server {
       moveDirection = Direction.fromPositionCompDirection(viewDirection.opposite());
     }
     if (!checkTile.isAccessible()
-        || Game.entityAtTile(checkTile).anyMatch(e -> e.isPresent(BlockComponent.class))) return;
+        || Game.entityAtTile(checkTile).anyMatch(e -> e.isPresent(BlockComponent.class))
+        || Game.entityAtTile(checkTile).anyMatch(e -> e.isPresent(AIComponent.class))) return;
     ArrayList<Entity> toMove =
         new ArrayList<>(
             Game.entityAtTile(inFront).filter(e -> e.isPresent(PushableComponent.class)).toList());


### PR DESCRIPTION
Setzt Feedback aus #1783 um

- Steine können nicht mehr in Monster geschoben werden
- Blockly-Schalter sind jetzt Blockable (außer die Trittschalter), dafür muss dann aber die `MiscFactory` aus Blockly zum generieren von Schaltern verwendet werden, nicht mehr die `LeverFactory`
