### PR TITLE
Blockly: Fix incorrect range for BlocklyMonster

### DIFF
--- a/blockly/src/entities/BlocklyMonster.java
+++ b/blockly/src/entities/BlocklyMonster.java
@@ -272,8 +272,11 @@ public enum BlocklyMonster {
       pc.viewDirection(viewDirection);
       pc.position(spawnPoint);
 
-      Consumer<Entity> fightAI = monsterType.fightAISupplier.get();
-      if (fightAI instanceof StraightRangeAI straightRangeAI) {
+      AIComponent aic =
+        monster
+          .fetch(AIComponent.class)
+          .orElseThrow(() -> MissingComponentException.build(monster, AIComponent.class));
+      if (aic.fightBehavior() instanceof StraightRangeAI straightRangeAI) {
         if (range == -1) {
           range = straightRangeAI.range();
         }


### PR DESCRIPTION
Dieser PR behebt einen Fehler, bei dem die `range` von `BlocklyMonstern` nicht korrekt gesetzt wurde. Ursache war die doppelte Verwendung des Suppliers, wodurch versehentlich zwei verschiedene Instanzen erstellt wurden. Jetzt wird sichergestellt, dass nur eine Instanz erzeugt und darauf korrekt die Reichweite gesetzt wird.

fixes #1892