### PR TITLE
Blockly: Prevent level progress downgrade in localStorage

### DIFF
--- a/blockly/frontend/src/utils/level.ts
+++ b/blockly/frontend/src/utils/level.ts
@@ -95,7 +95,9 @@ export const completeLevel = () => {
     console.info("[CompleteLevel] No more levels available");
     return;
   }
-  setLevelProgress(newLevelIndex);
+  if (newLevelIndex > getLevelProgress()) {
+    setLevelProgress(newLevelIndex);
+  }
   setCurrentLevel(levelNames[newLevelIndex]);
 }
 


### PR DESCRIPTION
Dieser PR behebt ein Problem, bei dem durch das erneute Abschließen eines niedrigeren Levels der gespeicherte Level-Fortschritt zurückgesetzt wurde. Es wurde eine Abfrage ergänzt, die nur den höheren Fortschritt speichert.

fixes #1894