### PR TITLE
Blockly: Fix tint persisting after Guard death and level change

### DIFF
--- a/blockly/src/components/TintDirectionComponent.java
+++ b/blockly/src/components/TintDirectionComponent.java
@@ -73,10 +73,14 @@ public class TintDirectionComponent implements Component {
   /**
    * Adds the original color of the tile at the given coordinate.
    *
+   * <p> If the coordinate already exists in the map, it will not be added again to keep the
+   * original color.
+   *
    * @param coordinate The coordinate of the tile.
    * @param color The original color of the tile.
    */
   public void originalColor(Coordinate coordinate, int color) {
+    if (tintMap.containsKey(coordinate)) return;
     tintMap.put(coordinate, color);
   }
 

--- a/blockly/src/components/TintDirectionComponent.java
+++ b/blockly/src/components/TintDirectionComponent.java
@@ -73,8 +73,8 @@ public class TintDirectionComponent implements Component {
   /**
    * Adds the original color of the tile at the given coordinate.
    *
-   * <p> If the coordinate already exists in the map, it will not be added again to keep the
-   * original color.
+   * <p>If the coordinate already exists in the map, it will not be added again to keep the original
+   * color.
    *
    * @param coordinate The coordinate of the tile.
    * @param color The original color of the tile.


### PR DESCRIPTION
Guards haben beim Tod eingefärbte Tiles hinterlassen, die auch nach Levelwechsel sichtbar blieben. Ursache war, dass beim Speichern der Originalfarben versehentlich die bereits eingefärbten Farben (z. B. rot) gespeichert wurden. Nun wird korrekt der ursprüngliche Farbzustand gesichert.

fixes #1875