### PR TITLE
Blockly: Implement A* in PathfindingSystem

### DIFF
--- a/blockly/src/utils/pathfinding/AStarPathFinding.java
+++ b/blockly/src/utils/pathfinding/AStarPathFinding.java
@@ -1,0 +1,151 @@
+package utils.pathfinding;
+
+import core.Game;
+import core.level.Tile;
+import core.level.elements.astar.TileConnection;
+import core.level.elements.astar.TileHeuristic;
+import core.level.utils.Coordinate;
+import java.util.*;
+import utils.LevelUtils;
+
+/**
+ * A* (A-Star) pathfinding algorithm implementation.
+ *
+ * <p>It uses a {@link AStarPriorityQueue} (priority queue data structure) as the frontier set to
+ * explore nodes based on their estimated total cost, maintaining g-scores (actual path cost) and
+ * f-scores (g-score + heuristic) to determine optimal paths.
+ *
+ * <p>The algorithm works by prioritizing nodes that appear most promising based on both the cost
+ * already accumulated to reach them and their estimated distance to the goal.
+ *
+ * <p>This implementation provides a priority queue as the frontier data structure, with nodes
+ * ordered by their f-scores. It overrides the parent's search algorithm to implement the A*
+ * specific behavior.
+ *
+ * @see PathfindingLogic
+ * @see TileHeuristic
+ * @see TileConnection
+ * @see systems.PathfindingSystem PathfindingSystem
+ */
+public class AStarPathFinding extends PathfindingLogic {
+  private final Map<Coordinate, Double> gScore = new HashMap<>();
+  private final Map<Coordinate, Double> fScore = new HashMap<>();
+  private final TileHeuristic heuristic = new TileHeuristic();
+
+  /**
+   * Constructor for AStarPathFinding.
+   *
+   * @param startNode The starting coordinate for the pathfinding search.
+   * @param endNode The ending coordinate for the pathfinding search.
+   */
+  public AStarPathFinding(Coordinate startNode, Coordinate endNode) {
+    super(startNode, endNode, new AStarPriorityQueue());
+    // Initialize gScore and fScore maps
+    gScore.put(startNode, 0.0);
+    fScore.put(startNode, heuristicCost(startNode, endNode));
+  }
+
+  /**
+   * Calculate heuristic cost between two coordinates using TileHeuristic.
+   *
+   * @param from source coordinate
+   * @param to destination coordinate
+   * @return estimated cost to reach destination
+   */
+  private double heuristicCost(Coordinate from, Coordinate to) {
+    // Create temporary Tile objects to use with TileHeuristic
+    Tile fromTile = Game.tileAT(from);
+    Tile toTile = Game.tileAT(to);
+
+    return heuristic.estimate(fromTile, toTile);
+  }
+
+  /**
+   * Perform the A* pathfinding search.
+   *
+   * <p>This method overrides the template method to implement the A* algorithm that balances actual
+   * path costs with heuristic estimations. The algorithm follows these steps:
+   *
+   * <ol>
+   *   <li>Add start node to frontier with f-score = h-score
+   *   <li>While frontier is not empty:
+   *       <ol>
+   *         <li>Get node with lowest f-score from frontier
+   *         <li>If node is goal, end search
+   *         <li>Mark node as explored
+   *         <li>For each neighbor:
+   *             <ol>
+   *               <li>Calculate tentative g-score = current g-score + cost to neighbor
+   *               <li>If tentative g-score is better than previous:
+   *                   <ol>
+   *                     <li>Update g-score and f-score (f = g + h)
+   *                     <li>If neighbor not in frontier, add it
+   *                     <li>Update neighbor's priority in frontier
+   *                   </ol>
+   *             </ol>
+   *       </ol>
+   * </ol>
+   */
+  @Override
+  public void performSearch() {
+    // Add start node to frontier
+    addFrontier(startNode);
+
+    while (!isFrontierEmpty()) {
+      // Get the node with lowest f-score
+      Coordinate current = pollNextNode();
+
+      // If we've reached the goal, we can stop
+      if (current.equals(endNode)) {
+        return;
+      }
+
+      // Mark as explored
+      addExplored(current);
+
+      // Check all neighbors
+      for (Coordinate neighbor : LevelUtils.walkableNeighbors(current)) {
+        // Skip if already explored
+        if (isExplored(neighbor)) {
+          continue;
+        }
+
+        // Calculate tentative gScore using TileConnection for cost
+        double tentativeGScore =
+            gScore.getOrDefault(current, Double.MAX_VALUE) + connectionCost(current, neighbor);
+
+        // If this is a better path to neighbor or neighbor not in frontier
+        if (tentativeGScore < gScore.getOrDefault(neighbor, Double.MAX_VALUE)) {
+          // Update scores
+          gScore.put(neighbor, tentativeGScore);
+          fScore.put(neighbor, tentativeGScore + heuristicCost(neighbor, endNode));
+
+          // Add to frontier if not already there
+          if (!isFrontier(neighbor)) {
+            addFrontier(neighbor);
+
+            // Use inherited getter instead of reflection
+            ((AStarPriorityQueue) frontierSet()).updatePriority(neighbor, fScore.get(neighbor));
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Calculate cost between two coordinates using {@link TileConnection}.
+   *
+   * @param from source coordinate
+   * @param to destination coordinate
+   * @return cost of moving from source to destination
+   */
+  private double connectionCost(Coordinate from, Coordinate to) {
+    // Create temporary Tile objects
+    Tile fromTile = Game.tileAT(from);
+    Tile toTile = Game.tileAT(to);
+
+    // Create a TileConnection between the tiles and get its cost
+    TileConnection connection = new TileConnection(fromTile, toTile);
+    return connection.getCost();
+  }
+}

--- a/blockly/src/utils/pathfinding/AStarPriorityQueue.java
+++ b/blockly/src/utils/pathfinding/AStarPriorityQueue.java
@@ -1,0 +1,98 @@
+package utils.pathfinding;
+
+import core.level.utils.Coordinate;
+import java.util.*;
+
+/**
+ * AStarPriorityQueue is a custom priority queue implementation for pathfinding algorithms. It uses
+ * a priority map to manage elements based on their priority. The queue ensures that elements are
+ * ordered by their priority (lower values indicate higher priority).
+ */
+public class AStarPriorityQueue extends ArrayDeque<Coordinate> {
+  // A map to store the priority (f-score) of each coordinate
+  private final Map<Coordinate, Double> priorityMap = new HashMap<>();
+
+  /**
+   * Adds a coordinate to the queue with a default priority of Double.MAX_VALUE. If the coordinate
+   * already exists, its position is updated based on its priority.
+   *
+   * @param coord The coordinate to be added to the queue.
+   */
+  @Override
+  public void push(Coordinate coord) {
+    priorityMap.putIfAbsent(coord, Double.MAX_VALUE);
+    addOrUpdatePosition(coord);
+  }
+
+  /**
+   * Updates the priority of a coordinate in the queue. If the coordinate is already in the queue,
+   * it is removed and reinserted at the correct position based on the updated priority.
+   *
+   * @param coord The coordinate whose priority is to be updated.
+   * @param priority The new priority value for the coordinate.
+   */
+  public void updatePriority(Coordinate coord, double priority) {
+    priorityMap.put(coord, priority);
+    // Reorder the queue if the element is already in it
+    if (contains(coord)) {
+      remove(coord);
+      addOrUpdatePosition(coord);
+    }
+  }
+
+  /**
+   * Adds a coordinate to the queue in the correct position based on its priority. If the queue is
+   * empty, the coordinate is simply added. If the coordinate already exists, it is removed and
+   * reinserted at the correct position.
+   *
+   * @param coord The coordinate to be added or updated in the queue.
+   */
+  private void addOrUpdatePosition(Coordinate coord) {
+    // If queue is empty, just add it
+    if (isEmpty()) {
+      super.add(coord);
+      return;
+    }
+
+    // Remove if already exists
+    if (contains(coord)) {
+      remove(coord);
+    }
+
+    double priority = priorityMap.get(coord);
+
+    // Find the correct position and insert
+    Iterator<Coordinate> it = iterator();
+    int index = 0;
+
+    while (it.hasNext()) {
+      Coordinate current = it.next();
+      if (priority < priorityMap.getOrDefault(current, Double.MAX_VALUE)) {
+        break;
+      }
+      index++;
+    }
+
+    // Create a new list with the element inserted at the right position
+    List<Coordinate> tempList = new ArrayList<>(this);
+    tempList.add(index, coord);
+
+    // Clear and repopulate the queue
+    clear();
+    addAll(tempList);
+  }
+
+  /**
+   * Removes and returns the highest priority (lowest f-score) element from the queue. If the queue
+   * is empty, returns null.
+   *
+   * @return The coordinate with the highest priority, or null if the queue is empty.
+   */
+  @Override
+  public Coordinate pop() {
+    if (isEmpty()) {
+      return null;
+    }
+    return removeFirst();
+  }
+}

--- a/blockly/src/utils/pathfinding/PathfindingLogic.java
+++ b/blockly/src/utils/pathfinding/PathfindingLogic.java
@@ -126,6 +126,15 @@ public abstract class PathfindingLogic {
   }
 
   /**
+   * Provides direct access to the frontier set for subclasses.
+   *
+   * @return the deque used as the frontier.
+   */
+  protected ArrayDeque<Coordinate> frontierSet() {
+    return frontierSet;
+  }
+
+  /**
    * Build the final path from the end coordinate to the start coordinate.
    *
    * @return A list of nodes representing the final path from start to end.

--- a/game/src/core/level/Tile.java
+++ b/game/src/core/level/Tile.java
@@ -297,6 +297,21 @@ public abstract class Tile {
         + '}';
   }
 
+  /**
+   * Calculates the manhattan distance between this tile and the given tile.
+   *
+   * <p>The manhattan distance is the sum the absolute differences of the x and y coordinates. The
+   * manhattan distance is used in pathfinding algorithms when the movement is restricted to
+   * orthogonal directions.
+   *
+   * @param to The tile to which the distance is calculated.
+   * @return The distance between this tile and the given tile.
+   */
+  public int distance(Tile to) {
+    return Math.abs(globalPosition.x - to.globalPosition.x)
+        + Math.abs(globalPosition.y - to.globalPosition.y);
+  }
+
   /** The direction of a tile. */
   @DSLType(name = "tile_direction")
   public enum Direction {

--- a/game/src/core/level/elements/astar/TileConnection.java
+++ b/game/src/core/level/elements/astar/TileConnection.java
@@ -1,7 +1,6 @@
 package core.level.elements.astar;
 
 import com.badlogic.gdx.ai.pfa.Connection;
-import com.badlogic.gdx.math.Vector2;
 import core.level.Tile;
 
 /**
@@ -24,8 +23,7 @@ public class TileConnection implements Connection<Tile> {
   public TileConnection(Tile from, Tile to) {
     this.from = from;
     this.to = to;
-    this.cost =
-        Vector2.dst(from.coordinate().x, from.coordinate().y, to.coordinate().x, to.coordinate().y);
+    this.cost = from.distance(to);
   }
 
   @Override

--- a/game/src/core/level/elements/astar/TileHeuristic.java
+++ b/game/src/core/level/elements/astar/TileHeuristic.java
@@ -13,7 +13,7 @@ public class TileHeuristic implements Heuristic<Tile> {
    *
    * @param start From
    * @param goal To
-   * @return Distance between from and to tile
+   * @return Manhattan Distance between from and to tile
    */
   @Override
   public float estimate(Tile start, Tile goal) {

--- a/game/src/core/level/elements/astar/TileHeuristic.java
+++ b/game/src/core/level/elements/astar/TileHeuristic.java
@@ -1,7 +1,6 @@
 package core.level.elements.astar;
 
 import com.badlogic.gdx.ai.pfa.Heuristic;
-import com.badlogic.gdx.math.Vector2;
 import core.level.Tile;
 
 /**
@@ -18,7 +17,6 @@ public class TileHeuristic implements Heuristic<Tile> {
    */
   @Override
   public float estimate(Tile start, Tile goal) {
-    return Vector2.dst2(
-        start.coordinate().x, start.coordinate().y, goal.coordinate().x, goal.coordinate().y);
+    return start.distance(goal);
   }
 }


### PR DESCRIPTION
Ich habe den A\* Algorithmus in das neuen `PathfindingSystem` integriert, um ihn visuell darzustellen.

* `Tile.java`: Hinzufügen der Methode `distance(Tile other)` zur Berechnung der Manhattan-Distanz.
* `PathfindingLogic.java`: Rausgeben des FrontierSets um auch Prioritäten zu unterstützen.
* `TileHeuristic.java` & `TileConnection.java`: Anpassung der Distanzberechnung auf Manhattan-Distanz.
* `PathfindingSystem.java`: Aufruf der A\*-Logik und Weitergabe der einzelnen Schritte an den `PathfindingVisualizer.java`.

Die Manhattan-Distanz wird verwendet, da sich die Mobs ausschließlich in orthogonalen Richtungen bewegen und so die Pfadfindung effizienter (genauere Kosten) wird.

closes #1859
