### PR TITLE
Blockly: declutter webview, allow game resizing 

### DIFF
--- a/blockly/frontend/index.html
+++ b/blockly/frontend/index.html
@@ -29,9 +29,10 @@
 </div>
 
 <div id="buttons">
-  <button type="button" id="startBtn">Start</button>
   <button type="button" id="stepBtn">Step</button>
+  <button type="button" id="startBtn">Start</button>
   <button type="button" id="resetBtn">Reset</button>
+
 </div>
 
 <script type="module" src="/src/index.ts"></script>

--- a/blockly/frontend/index.html
+++ b/blockly/frontend/index.html
@@ -5,18 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Blockly Dungeon</title>
   <link rel="hsbi-icon" href="/favicon.ico" type="image/x-icon" />
-  <style>
-      #buttons {
-        position: fixed;
-        bottom: 0;
-        left: 0;
-        width: 100%;
-        background-color: white;
-        padding: 10px;
-        text-align: center;
-        box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
-      }
-    </style>
 </head>
 <body>
 <header>

--- a/blockly/frontend/index.html
+++ b/blockly/frontend/index.html
@@ -1,35 +1,51 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blockly Dungeon</title>
-    <link rel="hsbi-icon" href="/favicon.ico" type="image/x-icon" />
-  </head>
-  <body>
-    <header>
-      <h1 id="page-title">Blockly Dungeon</h1>
-      <img id="cat-logo" src="/cat_logo.png" alt="cat-logo" />
-    </header>
-    <div id="pageContainer">
-      <div id="blockly"></div>
-      <div id="outputPanel">
-        <pre id="generatedCode"><code></code></pre>
-        <div id="response">
-          <div id="responseStatus">HTTP response status:</div>
-          <div id="characterPosition">Character position:</div>
-        </div>
-        <div id="config_div">
-          <label for="delay">Verzögerung (in Sek.)</label>
-          <input type="text" inputmode="numeric" id="delay" name="delay" min="1" max="5">
-        </div>
-        <div id="buttons">
-          <button type="button" id="startBtn">Start</button>
-          <button type="button" id="stepBtn">Step</button>
-          <button type="button" id="resetBtn">Reset</button>
-        </div>
-      </div>
-    </div>
-    <script type="module" src="/src/index.ts"></script>
-  </body>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Blockly Dungeon</title>
+  <link rel="hsbi-icon" href="/favicon.ico" type="image/x-icon" />
+  <style>
+      #buttons {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        background-color: white;
+        padding: 10px;
+        text-align: center;
+        box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
+      }
+    </style>
+</head>
+<body>
+<header>
+  <h1 id="page-title">Blockly Dungeon</h1>
+  <img id="cat-logo" src="/cat_logo.png" alt="cat-logo" />
+</header>
+
+<div id="pageContainer">
+  <div id="blockly"></div>
+</div>
+
+<div id="config_div">
+  <label for="delay">Verzögerung (in Sek.)</label>
+  <input
+          type="text"
+          inputmode="numeric"
+          id="delay"
+          name="delay"
+          min="1"
+          max="5"
+  />
+</div>
+
+<div id="buttons">
+  <button type="button" id="startBtn">Start</button>
+  <button type="button" id="stepBtn">Step</button>
+  <button type="button" id="resetBtn">Reset</button>
+</div>
+
+<script type="module" src="/src/index.ts"></script>
+</body>
 </html>

--- a/blockly/frontend/src/style.css
+++ b/blockly/frontend/src/style.css
@@ -82,8 +82,8 @@ header {
   color: #eeeeee;
   text-align: center;
   font-size: 28px;
-  padding: 20px;
-  width: 150px;
+  padding: 10px;
+  width: 125px;
   cursor: pointer;
   margin: 5px;
 }
@@ -106,8 +106,8 @@ header {
   color: #eeeeee;
   text-align: center;
   font-size: 28px;
-  padding: 20px;
-  width: 150px;
+  padding: 10px;
+  width: 125px;
   cursor: pointer;
   margin: 5px;
 }
@@ -130,8 +130,8 @@ header {
   color: #eeeeee;
   text-align: center;
   font-size: 28px;
-  padding: 20px;
-  width: 150px;
+  padding: 10px;
+  width: 125px;
   cursor: pointer;
   margin: 5px;
 }

--- a/blockly/frontend/src/style.css
+++ b/blockly/frontend/src/style.css
@@ -56,10 +56,12 @@ header {
 }
 
 #buttons {
-  height: 30%;
   display: flex;
   justify-content: center;
-  align-items: center;
+  position: fixed;
+  bottom: 15px;
+  width:100%;
+  left: 10%;
 }
 
 #config_div {

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -152,6 +152,7 @@ public class Client {
         core.configuration.KeyboardConfig.class);
     Game.frameRate(30);
     Game.disableAudio(true);
+    Game.resizeable(true);
     Game.windowTitle("Blockly Dungeon");
   }
 

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -114,6 +114,24 @@ public final class Game {
   }
 
   /**
+   * Checks if the game-window can be resized.
+   *
+   * @return True if the game-window can be resized. , false otherwise.
+   */
+  public static boolean resizeable() {
+    return PreRunConfiguration.resizeable();
+  }
+
+  /**
+   * Sets whether the game-window can be resized..
+   *
+   * @param resizeable True to enable resizing, false otherwise.
+   */
+  public static void resizeable(boolean resizeable) {
+    PreRunConfiguration.resizeable(resizeable);
+  }
+
+  /**
    * Sets the window title in the pre-run configuration.
    *
    * @param windowTitle The new window title.


### PR DESCRIPTION
Um Blockly richtig nutzen zu können, muss man Web und Spiel im Split-View Side by Side haben. 
Auf kleinen Monitoren ist das ganz schön doof:

![IMG_1289](https://github.com/user-attachments/assets/981e7a76-fb56-41bf-af0e-a8678ce0f32d)


Ich hab hier (mehr quick and dirty als stukturiert) die Ansicht für den generierten Code entfernt und die Buttons nach unten geschoben, dadurch hat das Block Feld deutlich mehr platz.

So sieht das jetzt auf meinen MacBook aus (ich hab etwas seltsame Skalierungseinstellungne, da ich die Sehhilfe optionen von Mac nutze)
![image](https://github.com/user-attachments/assets/9f97b0c0-9189-423b-b1b7-ac531c5855de)



