### PR TITLE
Blockly: Compare two Pathfinding Algorithms side by side

### DIFF
--- a/blockly/build.gradle
+++ b/blockly/build.gradle
@@ -42,6 +42,11 @@ tasks.register('runBlockly', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
 }
 
+tasks.register('runPathFindingComparison', JavaExec) {
+    mainClass = 'start.ComparePathfindingStarter'
+    classpath = sourceSets.main.runtimeClasspath
+}
+
 tasks.register('buildBlocklyJar', Jar) {
     dependsOn ':game:jar', ':dungeon:jar'
     archiveBaseName = 'Blockly'

--- a/blockly/build.gradle
+++ b/blockly/build.gradle
@@ -43,7 +43,7 @@ tasks.register('runBlockly', JavaExec) {
 }
 
 tasks.register('runPathFindingComparison', JavaExec) {
-    mainClass = 'start.ComparePathfindingStarter'
+    mainClass = 'starter.ComparePathfindingStarter'
     classpath = sourceSets.main.runtimeClasspath
 }
 

--- a/blockly/src/entities/BlocklyMonster.java
+++ b/blockly/src/entities/BlocklyMonster.java
@@ -98,6 +98,10 @@ public enum BlocklyMonster {
       99999, // one hit kill
       0,
       MonsterIdleSound.BURP),
+  /**
+   * The Runner Mob for the {@link starter.ComparePathfindingStarter}. This monster looks and moves
+   * like the hero.
+   */
   RUNNER(
       "Blockly Runner",
       "character/wizard",

--- a/blockly/src/entities/BlocklyMonster.java
+++ b/blockly/src/entities/BlocklyMonster.java
@@ -5,10 +5,7 @@ import com.badlogic.gdx.audio.Sound;
 import components.BlockViewComponent;
 import components.TintDirectionComponent;
 import contrib.components.AIComponent;
-import contrib.entities.AIFactory;
-import contrib.entities.MonsterDeathSound;
-import contrib.entities.MonsterFactory;
-import contrib.entities.MonsterIdleSound;
+import contrib.entities.*;
 import contrib.utils.EntityUtils;
 import contrib.utils.components.skill.Skill;
 import core.Entity;
@@ -99,6 +96,19 @@ public enum BlocklyMonster {
       () -> entity -> {}, // no idle needed
       () -> entity -> false, // instant fight
       99999, // one hit kill
+      0,
+      MonsterIdleSound.BURP),
+  RUNNER(
+      "Blockly Runner",
+      "character/wizard",
+      1,
+      HeroFactory.defaultHeroSpeed().x, // same speed as hero
+      0.0f,
+      MonsterDeathSound.LOWER_PITCH,
+      () -> entity -> {},
+      () -> entity -> {},
+      () -> entity -> false, // no ai
+      0,
       0,
       MonsterIdleSound.BURP);
 

--- a/blockly/src/level/AiMazeLevel.java
+++ b/blockly/src/level/AiMazeLevel.java
@@ -15,9 +15,11 @@ import java.util.List;
  * labyrinth.
  */
 public class AiMazeLevel extends BlocklyLevel {
+  /**
+   * The zoom level of the overview camera. This is used to adjust the camera view to properly
+   * display the labyrinth. (default: 0.20f)
+   */
   public static float ZOOM_LEVEL = 0.20f;
-
-  private static boolean showText = true;
 
   /**
    * Call the parent constructor of a tile level with the given layout and design label. Set the

--- a/blockly/src/level/AiMazeLevel.java
+++ b/blockly/src/level/AiMazeLevel.java
@@ -15,6 +15,8 @@ import java.util.List;
  * labyrinth.
  */
 public class AiMazeLevel extends BlocklyLevel {
+  public static float ZOOM_LEVEL = 0.20f;
+
   private static boolean showText = true;
 
   /**
@@ -37,7 +39,7 @@ public class AiMazeLevel extends BlocklyLevel {
     Entity cameraFocusPoint = new Entity();
     cameraFocusPoint.add(new PositionComponent(x + 0.5f, y + 0.25f));
     cameraFocusPoint.add(new CameraComponent());
-    Debugger.ZOOM_CAMERA(0.20f);
+    Debugger.ZOOM_CAMERA(ZOOM_LEVEL);
     Game.add(cameraFocusPoint);
   }
 

--- a/blockly/src/starter/ComparePathfindigsStarter.java
+++ b/blockly/src/starter/ComparePathfindigsStarter.java
@@ -1,0 +1,203 @@
+package starter;
+
+import com.badlogic.gdx.Gdx;
+import contrib.entities.HeroFactory;
+import contrib.level.DevDungeonLevel;
+import contrib.level.DevDungeonLoader;
+import contrib.systems.EventScheduler;
+import contrib.systems.LevelEditorSystem;
+import contrib.systems.LevelTickSystem;
+import contrib.systems.PathSystem;
+import contrib.utils.components.Debugger;
+import core.Entity;
+import core.Game;
+import core.components.CameraComponent;
+import core.components.PositionComponent;
+import core.level.Tile;
+import core.level.utils.Coordinate;
+import core.level.utils.LevelElement;
+import core.systems.LevelSystem;
+import core.systems.PlayerSystem;
+import core.utils.MissingHeroException;
+import core.utils.Tuple;
+import core.utils.components.path.SimpleIPath;
+import entities.BlocklyMonster;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import level.AiMazeLevel;
+import systems.PathfindingSystem;
+import utils.CheckPatternPainter;
+import utils.pathfinding.BFSPathFinding;
+import utils.pathfinding.DFSPathFinding;
+import utils.pathfinding.PathfindingLogic;
+
+/** This class starts a comparator for the pathfinding algorithms. */
+public class ComparePathfindigsStarter {
+  private static final boolean DRAW_CHECKER_PATTERN = true;
+  private static final Entity[] RUNNERS = new Entity[2];
+
+  private static final Class<? extends PathfindingLogic> pathFindingA = BFSPathFinding.class;
+  private static final Class<? extends PathfindingLogic> pathFindingB = DFSPathFinding.class;
+
+  /**
+   * Setup and run the game. Also start the server that is listening to the requests from blockly
+   * frontend.
+   *
+   * @param args
+   * @throws IOException
+   */
+  public static void main(String[] args) throws IOException {
+    Game.initBaseLogger(Level.WARNING);
+
+    // start the game
+    configGame();
+    // Set up components and level
+    onSetup();
+
+    onLevelLoad();
+
+    // build and start game
+    Game.run();
+  }
+
+  private static void onSetup() {
+    Game.userOnSetup(
+        () -> {
+          Gdx.graphics.setWindowedMode(
+              Gdx.graphics.getWidth(), (int) (Gdx.graphics.getHeight() * 1.9f));
+
+          AiMazeLevel.ZOOM_LEVEL = 0.25f;
+
+          DevDungeonLoader.addLevel(Tuple.of("bfs", AiMazeLevel.class));
+          createSystems();
+
+          try {
+            createHero();
+            RUNNERS[0] = Game.hero().orElseThrow(MissingHeroException::new);
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+          Game.system(
+              LevelSystem.class, ls -> ls.onEndTile(ComparePathfindigsStarter::loadNextLevel));
+          Game.remove(PlayerSystem.class);
+          loadNextLevel();
+        });
+  }
+
+  private static void loadNextLevel() {
+    DevDungeonLoader.loadNextLevel();
+    Tile[][] curLevel = Game.currentLevel().layout();
+    // copy the same layout below the current level with Wall Tiles between
+    LevelElement[][] newLevel = new LevelElement[curLevel.length * 2 + 1][curLevel[0].length];
+    for (int i = 0; i < curLevel.length; i++) {
+      for (int j = 0; j < curLevel[i].length; j++) {
+        LevelElement newElement = curLevel[i][j].levelElement();
+        newLevel[i][j] = newElement;
+        newLevel[i + curLevel.length + 1][j] = newElement;
+      }
+    }
+    for (int i = 0; i < newLevel.length; i++) {
+      for (int j = 0; j < newLevel[i].length; j++) {
+        if (newLevel[i][j] == null) {
+          newLevel[i][j] = LevelElement.WALL;
+        }
+      }
+    }
+    Coordinate orgStart = Game.startTile().coordinate();
+    Coordinate newStart = orgStart.add(new Coordinate(0, curLevel.length + 1));
+    Game.currentLevel(
+        new AiMazeLevel(
+            newLevel,
+            Game.currentLevel().startTile().designLabel(),
+            ((DevDungeonLevel) Game.currentLevel()).customPoints()));
+    Debugger.TELEPORT(orgStart.toCenteredPoint());
+    RUNNERS[1] =
+        BlocklyMonster.RUNNER
+            .builder()
+            .spawnPoint(newStart.toCenteredPoint())
+            .addToGame()
+            .build()
+            .get();
+
+    Game.system(
+        PathfindingSystem.class,
+        (pfs) -> {
+          pfs.autoStep(true);
+
+          List<Tuple<PathfindingLogic, Entity>> pathfindingAlgorithms = new ArrayList<>();
+          for (int i = 0; i < RUNNERS.length; i++) {
+            Entity runner = RUNNERS[i];
+            if (runner == null) {
+              continue;
+            }
+            Coordinate spawn =
+                runner.fetch(PositionComponent.class).get().position().toCoordinate();
+            Coordinate end = Game.currentLevel().endTile().coordinate();
+            PathfindingLogic algo;
+            if (i == 0) {
+              algo = instancePathfindingLogic(pathFindingA, spawn, end);
+            } else {
+              algo =
+                  instancePathfindingLogic(
+                      pathFindingB, spawn, end.add(new Coordinate(0, curLevel.length + 1)));
+            }
+
+            pathfindingAlgorithms.add(Tuple.of(algo, runner));
+          }
+          pfs.updatePathfindingAlgorithm(pathfindingAlgorithms.toArray(new Tuple[0]));
+        });
+  }
+
+  private static void onLevelLoad() {
+    Game.userOnLevelLoad(
+        (firstLoad) -> {
+          if (DRAW_CHECKER_PATTERN)
+            CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
+        });
+  }
+
+  private static PathfindingLogic instancePathfindingLogic(
+      Class<? extends PathfindingLogic> clazz, Coordinate start, Coordinate end) {
+    try {
+      return clazz.getConstructor(Coordinate.class, Coordinate.class).newInstance(start, end);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create instance of PathfindingLogic", e);
+    }
+  }
+
+  private static void configGame() throws IOException {
+    Game.loadConfig(
+        new SimpleIPath("dungeon_config.json"),
+        contrib.configuration.KeyboardConfig.class,
+        core.configuration.KeyboardConfig.class);
+    Game.frameRate(30);
+    Game.disableAudio(true);
+    Game.windowTitle(
+        "Blockly " + pathFindingA.getSimpleName() + " vs " + pathFindingB.getSimpleName());
+  }
+
+  private static void createSystems() {
+    Game.add(new LevelEditorSystem());
+    Game.add(new PathSystem());
+    Game.add(new LevelTickSystem());
+    Game.add(new EventScheduler());
+    Game.add(new PathfindingSystem());
+  }
+
+  /**
+   * Creates and adds a new hero entity to the game.
+   *
+   * <p>The new hero is generated using the {@link HeroFactory} and the {@link CameraComponent} of
+   * the hero is removed.
+   *
+   * @throws RuntimeException if an {@link IOException} occurs during hero creation
+   */
+  public static void createHero() throws IOException {
+    Entity hero;
+    hero = HeroFactory.newHero();
+    hero.remove(CameraComponent.class);
+    Game.add(hero);
+  }
+}

--- a/blockly/src/starter/ComparePathfindingStarter.java
+++ b/blockly/src/starter/ComparePathfindingStarter.java
@@ -219,6 +219,7 @@ public class ComparePathfindingStarter {
    * generated using the {@link HeroTankControlledFactory} and the {@link CameraComponent} of the
    * hero is removed.
    *
+   * @return The newly created hero entity
    * @throws RuntimeException if an {@link IOException} occurs during hero creation
    */
   public static Entity createHero() {

--- a/blockly/src/starter/ComparePathfindingStarter.java
+++ b/blockly/src/starter/ComparePathfindingStarter.java
@@ -229,7 +229,6 @@ public class ComparePathfindingStarter {
         core.configuration.KeyboardConfig.class);
     Game.frameRate(30);
     Game.disableAudio(true);
-    Game.resizeable(true);
     Game.windowTitle(
         "Blockly " + pathFindingA.getSimpleName() + " vs " + pathFindingB.getSimpleName());
   }

--- a/blockly/src/starter/ComparePathfindingStarter.java
+++ b/blockly/src/starter/ComparePathfindingStarter.java
@@ -34,7 +34,7 @@ import utils.pathfinding.DFSPathFinding;
 import utils.pathfinding.PathfindingLogic;
 
 /** This class starts a comparator for the pathfinding algorithms. */
-public class ComparePathfindigsStarter {
+public class ComparePathfindingStarter {
   private static final boolean DRAW_CHECKER_PATTERN = true;
   private static final Entity[] RUNNERS = new Entity[2];
 
@@ -75,7 +75,7 @@ public class ComparePathfindigsStarter {
           RUNNERS[0] = createHero();
 
           Game.system(
-              LevelSystem.class, ls -> ls.onEndTile(ComparePathfindigsStarter::loadNextLevel));
+              LevelSystem.class, ls -> ls.onEndTile(ComparePathfindingStarter::loadNextLevel));
           Game.remove(PlayerSystem.class);
           loadNextLevel();
         });

--- a/blockly/src/starter/PathfinderStarter.java
+++ b/blockly/src/starter/PathfinderStarter.java
@@ -8,6 +8,7 @@ import core.Entity;
 import core.Game;
 import core.components.CameraComponent;
 import core.systems.LevelSystem;
+import core.utils.MissingHeroException;
 import core.utils.Tuple;
 import core.utils.components.path.SimpleIPath;
 import java.io.IOException;
@@ -15,6 +16,7 @@ import java.util.logging.Level;
 import level.AiMazeLevel;
 import systems.PathfindingSystem;
 import utils.CheckPatternPainter;
+import utils.pathfinding.DFSPathFinding;
 
 /** This class starts the dungeon Ai level to visualize the DFS and BFS. */
 public class PathfinderStarter {
@@ -62,6 +64,18 @@ public class PathfinderStarter {
         (firstLoad) -> {
           if (DRAW_CHECKER_PATTERN)
             CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
+
+          Game.system(
+              PathfindingSystem.class,
+              (pfs) -> {
+                pfs.autoStep(true);
+                pfs.updatePathfindingAlgorithm(
+                    Tuple.of(
+                        new DFSPathFinding(
+                            Game.currentLevel().startTile().coordinate(),
+                            Game.currentLevel().endTile().coordinate()),
+                        Game.hero().orElseThrow(MissingHeroException::new)));
+              });
         });
   }
 

--- a/blockly/src/starter/PathfinderStarter.java
+++ b/blockly/src/starter/PathfinderStarter.java
@@ -15,7 +15,6 @@ import java.util.logging.Level;
 import level.AiMazeLevel;
 import systems.PathfindingSystem;
 import utils.CheckPatternPainter;
-import utils.pathfinding.DFSPathFinding;
 
 /** This class starts the dungeon Ai level to visualize the DFS and BFS. */
 public class PathfinderStarter {
@@ -63,16 +62,6 @@ public class PathfinderStarter {
         (firstLoad) -> {
           if (DRAW_CHECKER_PATTERN)
             CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
-
-          Game.system(
-              PathfindingSystem.class,
-              (pfs) -> {
-                pfs.autoStep(true);
-                pfs.updatePathfindingAlgorithm(
-                    new DFSPathFinding(
-                        Game.currentLevel().startTile().coordinate(),
-                        Game.currentLevel().endTile().coordinate()));
-              });
         });
   }
 

--- a/blockly/src/systems/PathfindingSystem.java
+++ b/blockly/src/systems/PathfindingSystem.java
@@ -14,17 +14,16 @@ import utils.pathfinding.PathfindingVisualizer;
 import utils.pathfinding.TileState;
 
 /**
- * This class is responsible for managing the pathfinding logic and visualizing the pathfinding
- * process.
+ * This system is responsible for visualizing multiple pathfinding logics.
  *
  * <p>It allows for both manual and automatic stepping through the pathfinding process.
  *
- * <p>It checks every frame 2 things: 1. If the pathfinding is finished and the hero is not moving,
- * it will start moving the hero on the final path, and stop the system.2. If the step pathfinding
- * key is pressed, it will visualize the pathfinding process.
+ * <p>It checks every frame 2 things: 1. If all pathfindings are finished and the runners are not
+ * moving, it will start moving them on each final path, and stop the system.2. If the step
+ * pathfinding key is pressed, it will visualize the pathfinding process.
  *
- * <p>Use {@link #updatePathfindingAlgorithm(Tuple[])} to start the system and set a new pathfinding
- * algorithm.
+ * <p>Use {@link #updatePathfindingAlgorithm(Tuple[])} to start the system and set new pathfinding
+ * algorithms.
  *
  * @see PathfindingLogic
  * @see TileState
@@ -120,10 +119,10 @@ public class PathfindingSystem extends System {
   /**
    * Sets a new pathfinding algorithm and starts the pathfinding process.
    *
-   * <p>This method starts this system, resets the current pathfinding process, and initializes a
-   * new one with the provided pathfinding algorithm.
+   * <p>This method starts this system, resets the current pathfinding processes, and initializes
+   * new ones with the provided pathfinding algorithms.
    *
-   * @param pathFindingAlgorithms the pathfinding algorithm to use
+   * @param pathFindingAlgorithms the pathfinding algorithms to use
    */
   @SafeVarargs
   public final void updatePathfindingAlgorithm(

--- a/blockly/src/systems/PathfindingSystem.java
+++ b/blockly/src/systems/PathfindingSystem.java
@@ -31,24 +31,24 @@ import utils.pathfinding.TileState;
  * @see PathfindingVisualizer
  */
 public class PathfindingSystem extends System {
-  private final List<Helper> pathfindingAlgorithms = new ArrayList<>();
+  private final List<PathfindingData> pathfindingAlgorithms = new ArrayList<>();
 
   private boolean autoStep = false;
-  private long stepDelay = 2; // Step delay in milliseconds if using autoStep
+  private long stepDelay = 100; // Step delay in milliseconds if using autoStep
   private int runningRunners = 0;
 
   @Override
   public void execute() {
-    for (Helper helper : pathfindingAlgorithms) {
-      PathfindingVisualizer visualizer = helper.visualizer;
-      Entity runner = helper.runner;
+    for (PathfindingData pathfindingData : pathfindingAlgorithms) {
+      PathfindingVisualizer visualizer = pathfindingData.visualizer;
+      Entity runner = pathfindingData.runner;
 
-      if (runner.isPresent(PathComponent.class)) { // already moving?
+      if (runner.isPresent(PathComponent.class)) {
         continue;
       }
 
       if (isEveryAlgorithmFinished() && !isEveryRunnerRunning() && isStartMovingKeyPressed()) {
-        runner.add(new PathComponent(helper.finalPath));
+        runner.add(new PathComponent(pathfindingData.finalPath));
         runningRunners++;
 
         if (isEveryRunnerRunning()) this.stop();
@@ -64,8 +64,8 @@ public class PathfindingSystem extends System {
   }
 
   private boolean isEveryAlgorithmFinished() {
-    for (Helper helper : pathfindingAlgorithms) {
-      if (!helper.visualizer.isFinished()) {
+    for (PathfindingData pathfindingData : pathfindingAlgorithms) {
+      if (!pathfindingData.visualizer.isFinished()) {
         return false;
       }
     }
@@ -132,8 +132,8 @@ public class PathfindingSystem extends System {
     reset();
     for (Tuple<PathfindingLogic, Entity> pathFindingAlgorithm : pathFindingAlgorithms) {
       pathFindingAlgorithm.a().performSearch(); // Perform the search to populate the path
-      Helper algo =
-          new Helper(
+      PathfindingData algo =
+          new PathfindingData(
               new PathfindingVisualizer(
                   pathFindingAlgorithm.a().steps(), pathFindingAlgorithm.a().finalPath()),
               pathFindingAlgorithm.a().finalPath(),
@@ -149,12 +149,13 @@ public class PathfindingSystem extends System {
    * the state of the system.
    */
   private void reset() {
-    for (Helper helper : pathfindingAlgorithms) {
-      helper.visualizer.reset();
+    for (PathfindingData pathfindingData : pathfindingAlgorithms) {
+      pathfindingData.visualizer.reset();
     }
     pathfindingAlgorithms.clear();
     runningRunners = 0;
   }
 
-  record Helper(PathfindingVisualizer visualizer, List<Coordinate> finalPath, Entity runner) {}
+  private record PathfindingData(
+      PathfindingVisualizer visualizer, List<Coordinate> finalPath, Entity runner) {}
 }

--- a/blockly/src/utils/pathfinding/PathfindingVisualizer.java
+++ b/blockly/src/utils/pathfinding/PathfindingVisualizer.java
@@ -101,7 +101,7 @@ public class PathfindingVisualizer {
     if (isRunning() || isFinished()) {
       return;
     }
-
+    stepCount = 1; // mark as running
     // Schedule all remaining steps
     for (int i = 0; i < path.size(); i++) {
       Tuple<Coordinate, TileState> step = path.get(i);
@@ -112,10 +112,13 @@ public class PathfindingVisualizer {
     // final path
     scheduledActions.add(
         EventScheduler.scheduleAction(
-            () -> finalPath.forEach(coordinate -> colorTile(Tuple.of(coordinate, TileState.PATH))),
+            () ->
+                finalPath.forEach(
+                    coordinate -> {
+                      colorTile(Tuple.of(coordinate, TileState.PATH));
+                      stepCount = path.size(); // mark as finished
+                    }),
             stepDelay * path.size()));
-
-    stepCount = path.size(); // mark as finished
   }
 
   /**

--- a/dungeon/src/contrib/level/DevDungeonLoader.java
+++ b/dungeon/src/contrib/level/DevDungeonLoader.java
@@ -35,7 +35,7 @@ public class DevDungeonLoader {
 
   private static final List<Tuple<String, Class<? extends DevDungeonLevel>>> levelOrder =
       new ArrayList<>();
-  private static int currentLevel = 0;
+  private static int currentLevel = -1;
   private static int currentVariant = 0;
   private static IVoidFunction afterAllLevels =
       () -> {


### PR DESCRIPTION
Ich habe eine neue Starter-Klasse `ComparePathfindingStarter.java` erstellt, mit der zwei Pathfinding-Algorithmen parallel angezeigt und ausgeführt werden.

* `ComparePathfindingStarter.java`: Dupliziert das aktuelle Level nach oben, platziert den Helden im Original und einen Dummy-Runner im Duplikat, und startet beide Algorithmen nebeneinander über das erweiterte `PathfindingSystem`. Es wird automatisch eine passende Zoom Stufe für das Spiel gefunden und gesetzt. Das Fenster ist per Default Maximiert.
* `PathfindingSystem.java`: Unterstützung für mehrere Pathfinding-Instanzen, um parallele Ausführung und Visualisierung zu ermöglichen.
* `AiMazeLevel.java`: Neue Kamera-Zoom-Einstellung, damit beide Level-Duplikate gleichzeitig gut sichtbar sind.
* `PathfindingVisualizer.java`: Bugfix – markiert nun beim Autostep korrekt, ob ein Algorithmus noch läuft oder bereits abgeschlossen ist.
* `DevDungeonLoader.java`: Standard-`levelIndex` auf `-1` gesetzt, sodass `loadNextLevel()` beim ersten Aufruf das erste Level lädt.
* `build.gradle`: Hinzufügen eines Starter-Skripts zum einfachen Start der neuen `ComparePathfindingStarter`.

closes #1933
