### PR TITLE
Blockly: Add `MazeEditorSystem` for in-game tile editing

### DIFF
--- a/blockly/src/starter/PathfinderStarter.java
+++ b/blockly/src/starter/PathfinderStarter.java
@@ -3,7 +3,6 @@ package starter;
 import contrib.entities.HeroFactory;
 import contrib.level.DevDungeonLoader;
 import contrib.systems.*;
-import contrib.systems.LevelEditorSystem;
 import core.Entity;
 import core.Game;
 import core.components.CameraComponent;
@@ -13,6 +12,7 @@ import core.utils.components.path.SimpleIPath;
 import java.io.IOException;
 import java.util.logging.Level;
 import level.AiMazeLevel;
+import systems.MazeEditorSystem;
 import systems.PathfindingSystem;
 import utils.CheckPatternPainter;
 import utils.pathfinding.DFSPathFinding;
@@ -87,7 +87,7 @@ public class PathfinderStarter {
   }
 
   private static void createSystems() {
-    Game.add(new LevelEditorSystem());
+    Game.add(new MazeEditorSystem());
     Game.add(new PathSystem());
     Game.add(new LevelTickSystem());
     Game.add(new EventScheduler());

--- a/blockly/src/systems/MazeEditorSystem.java
+++ b/blockly/src/systems/MazeEditorSystem.java
@@ -1,0 +1,64 @@
+package systems;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import contrib.utils.components.skill.SkillTools;
+import core.Entity;
+import core.Game;
+import core.System;
+import core.level.Tile;
+import core.level.utils.LevelElement;
+import core.systems.LevelSystem;
+import core.utils.Point;
+
+/**
+ * This system is a mini version of {@link contrib.systems.LevelEditorSystem LevelEditorSystem} that
+ * allows the user to edit the maze by clicking on the tiles. The left mouse button sets the tile to
+ * a wall, and the right mouse button sets the tile to a floor.
+ *
+ * @see starter.PathfinderStarter PathfinderStarter
+ */
+public class MazeEditorSystem extends System {
+  private static final int WALL_BUTTON = Input.Buttons.LEFT;
+  private static final int FLOOR_BUTTON = Input.Buttons.RIGHT;
+
+  @Override
+  public void execute() {
+    if (Gdx.input.isButtonPressed(FLOOR_BUTTON)) {
+      setTile(LevelElement.FLOOR);
+    } else if (Gdx.input.isButtonPressed(WALL_BUTTON)) {
+      setTile(LevelElement.WALL);
+    }
+  }
+
+  private void setTile(LevelElement element) {
+    Point mosPos = SkillTools.cursorPositionAsPoint();
+    mosPos = new Point(mosPos.x - 0.5f, mosPos.y - 0.25f);
+    Tile mouseTile = LevelSystem.level().tileAt(mosPos);
+    if (mouseTile == null) {
+      return;
+    }
+
+    if (isImportantTile(mouseTile)) {
+      return;
+    }
+
+    LevelSystem.level().changeTileElementType(mouseTile, element);
+  }
+
+  /**
+   * Check if the tile is important. The important tiles are the exit tile and the tile where the
+   * hero is located.
+   *
+   * @param tile the tile to check
+   * @return true if the tile is important, false otherwise
+   */
+  private boolean isImportantTile(Tile tile) {
+    Entity hero = Game.hero().orElse(null);
+    if (hero == null) {
+      return false;
+    }
+
+    return tile.levelElement() == LevelElement.EXIT || Game.tileAtEntity(hero) == tile;
+  }
+}


### PR DESCRIPTION
Ich habe ein Mini-Editor-System hinzugefügt, mit dem man per Linksklick Wände und per Rechtsklick Böden platzieren kann, ohne die volle Komplexität des `LevelEditorSystem`.

* `MazeEditorSystem.java`:
  * `execute()`: Überwacht Maustasten und ruft `setTile(...)` bei Linksklick (Wall) oder Rechtsklick (Floor) auf.
  * `setTile(LevelElement element)`: Ermittelt das Tile unter dem Cursor, prüft auf wichtige Tiles (Exit und Hero-Position) und ändert den Tile-Typ.
  * `isImportantTile(Tile tile)`: Blockiert Änderungen an Exit- und Hero-Tiles.

closes #1973
