### PR TITLE
Dungeon: Fix multi-level issues in PathfindingStarter

### DIFF
--- a/blockly/src/level/AiMazeLevel.java
+++ b/blockly/src/level/AiMazeLevel.java
@@ -1,6 +1,5 @@
 package level;
 
-import contrib.utils.components.Debugger;
 import core.Entity;
 import core.Game;
 import core.components.CameraComponent;
@@ -8,6 +7,7 @@ import core.components.PositionComponent;
 import core.level.utils.Coordinate;
 import core.level.utils.DesignLabel;
 import core.level.utils.LevelElement;
+import core.systems.CameraSystem;
 import java.util.List;
 
 /**
@@ -17,9 +17,9 @@ import java.util.List;
 public class AiMazeLevel extends BlocklyLevel {
   /**
    * The zoom level of the overview camera. This is used to adjust the camera view to properly
-   * display the labyrinth. (default: 0.20f)
+   * display the labyrinth. (default: 0.55f)
    */
-  public static float ZOOM_LEVEL = 0.20f;
+  public static float ZOOM_LEVEL = 0.55f;
 
   /**
    * Call the parent constructor of a tile level with the given layout and design label. Set the
@@ -41,7 +41,7 @@ public class AiMazeLevel extends BlocklyLevel {
     Entity cameraFocusPoint = new Entity();
     cameraFocusPoint.add(new PositionComponent(x + 0.5f, y + 0.25f));
     cameraFocusPoint.add(new CameraComponent());
-    Debugger.ZOOM_CAMERA(ZOOM_LEVEL);
+    CameraSystem.camera().zoom = ZOOM_LEVEL;
     Game.add(cameraFocusPoint);
   }
 

--- a/blockly/src/starter/PathfinderStarter.java
+++ b/blockly/src/starter/PathfinderStarter.java
@@ -46,7 +46,8 @@ public class PathfinderStarter {
   private static void onSetup() {
     Game.userOnSetup(
         () -> {
-          DevDungeonLoader.addLevel(Tuple.of("dfs", AiMazeLevel.class));
+          DevDungeonLoader.addLevel(
+              Tuple.of("dfs", AiMazeLevel.class), Tuple.of("bfs", AiMazeLevel.class));
           createSystems();
 
           try {


### PR DESCRIPTION
Ich habe zwei Probleme behoben, die beim Verwenden mehrerer Levels im `PathfindingStarter` auftraten.

* `AiMazeLevel.java`: Zoom wird jetzt nur einmalig auf den gewünschten Wert gesetzt und nicht bei jedem Level-Wechsel angewandt.
* `PathSystem.java`: Entfernt die `PathComponent` von Entities nach Beenden des Pfads, sodass der Held nicht dauerhaft als "laufend“ markiert bleibt.

