### PR TITLE
AdvancedDungeon: Fix fireball missing defaults in constructor

### DIFF
--- a/blockly/src/produsAdvanced/abstraction/FireballSkill.java
+++ b/blockly/src/produsAdvanced/abstraction/FireballSkill.java
@@ -89,6 +89,10 @@ public class FireballSkill extends DamageProjectile {
         DamageProjectile.DEFAULT_ON_WALL_HIT,
         (projectile, target) -> onHit.accept(target),
         DamageProjectile.DEFAULT_ON_SPAWN);
+    this.texture = texture;
+    this.range = range;
+    this.speed = speed;
+    this.damage = damageAmount;
     this.coolDown = Math.max(0, coolDown);
   }
 


### PR DESCRIPTION
Standardwerte für Feuerball wurden im Konstruktor nicht gesetzt, sodass per Default kein Feuerball geschossen wurde. Jetzt werden im Ctor folgende Felder initialisiert:

* `FireballSkill.java`:

  ```java
  this.texture     = texture;
  this.range       = range;
  this.speed       = speed;
  this.damage      = damageAmount;
  ```
