### PR TITLE
Pathfinder: PathfindingStarter reset and reselection support

### DIFF
--- a/blockly/src/systems/PathfindingSystem.java
+++ b/blockly/src/systems/PathfindingSystem.java
@@ -59,16 +59,43 @@ public class PathfindingSystem extends System {
   }
 
   private boolean isEveryRunnerRunning() {
-    return runningRunners == pathfindingAlgorithms.size();
+    return runningRunners > 0 && runningRunners == pathfindingAlgorithms.size();
   }
 
-  private boolean isEveryAlgorithmFinished() {
+  /**
+   * Checks if every pathfinding algorithm is running.
+   *
+   * <p>A pathfinding algorithm is considered running if its visualizer is not finished.
+   *
+   * <p>If no pathfinding algorithms are present, it returns false.
+   *
+   * @return true if every pathfinding algorithm is running, false otherwise
+   */
+  public boolean isEveryAlgorithmRunning() {
+    for (PathfindingData pathfindingData : pathfindingAlgorithms) {
+      if (!pathfindingData.visualizer.isRunning()) {
+        return false;
+      }
+    }
+    return !pathfindingAlgorithms.isEmpty();
+  }
+
+  /**
+   * Checks if every pathfinding algorithm is finished.
+   *
+   * <p>A pathfinding algorithm is considered finished if its visualizer is finished.
+   *
+   * <p>If no pathfinding algorithms are present, it returns false.
+   *
+   * @return true if every pathfinding algorithm is finished, false otherwise
+   */
+  public boolean isEveryAlgorithmFinished() {
     for (PathfindingData pathfindingData : pathfindingAlgorithms) {
       if (!pathfindingData.visualizer.isFinished()) {
         return false;
       }
     }
-    return true;
+    return !pathfindingAlgorithms.isEmpty();
   }
 
   /**
@@ -147,7 +174,7 @@ public class PathfindingSystem extends System {
    * <p>This method stops the current pathfinding process, clears the scheduled actions, and resets
    * the state of the system.
    */
-  private void reset() {
+  public void reset() {
     for (PathfindingData pathfindingData : pathfindingAlgorithms) {
       pathfindingData.visualizer.reset();
     }

--- a/blockly/src/utils/pathfinding/PathfindingVisualizer.java
+++ b/blockly/src/utils/pathfinding/PathfindingVisualizer.java
@@ -143,6 +143,8 @@ public class PathfindingVisualizer {
   /**
    * Returns whether the pathfinding process is currently running.
    *
+   * <p>If the Algo {@link #isFinished()} is true, it means the pathfinding process is not running.
+   *
    * @return true if the pathfinding process is running, false otherwise
    */
   public boolean isRunning() {


### PR DESCRIPTION
Ich habe den `PathfindingStarter` so angepasst, dass er bei einem Levelwechsel alle Algorithmen zurücksetzt um mehrere Levels hintereinander zu unterstützen. Zudem kann jetzt ein Algorithmus neu ausgewählt werden, solange noch keiner läuft – der Titel zeigt zudem den Status, wenn kein Algorithmus ausgewählt wurde. Zur Reduzierung von Code-Duplizierung wurde die Klasse mit privaten Helper-Methoden refactored.

* `ComparePathfindingStarter.java`:
  * Zurücksetzen aller Algorithmen bei Levelwechsel.
  * Erlauben deine Algo-Auswahl zu ändern, solange noch keine gestartet wurde
  * Refactoring durch private Helper-Methoden.
  * Refactoring bessere Benutzung von Streams.
 
* `PathfindingSystem.java`:
  * Neue Public-Methoden `isEveryAlgorithmRunning()` und `isEveryAlgorithmFinished()` zur Abfrage des Algorithmus-Status.
