### PR TITLE
Blockly: refactor 'shootFireball' (BlocklyCommands)

### DIFF
--- a/blockly/src/utils/Direction.java
+++ b/blockly/src/utils/Direction.java
@@ -121,6 +121,22 @@ public enum Direction {
   }
 
   /**
+   * Convert a {@link PositionComponent.Direction} into a {@link Point}.
+   *
+   * <p>This is a convenience method to avoid unnecessary method calls/method chaining, i.e. instead
+   * of writing <code>
+   * Direction.fromPositionCompDirection(EntityUtils.getViewDirection(hero)).toPoint()</code> all
+   * the time we can just use <code>
+   * Direction.asPoint(EntityUtils.getViewDirection(hero))</code> now.
+   *
+   * @param viewDirection Direction to convert.
+   * @return Converted direction.
+   */
+  public static Point asPoint(PositionComponent.Direction viewDirection) {
+    return fromPositionCompDirection(viewDirection).toPoint();
+  }
+
+  /**
    * Transforms a relative direction into a world direction based on this view direction.
    *
    * <p>For example, if the hero is looking to the RIGHT and wants to check LEFT (relative to their


### PR DESCRIPTION
This is a follow-up to #1909 (0116e47), were methods like shootFireball() and aimAndShoot() got moved from Server to BlocklyCommands.

Unfortunately, some attributes are no longer available in the new auxiliary class BlocklyCommands, so the old (moved) code now has to fetch some things multiple times.

This PR performs a refactoring of the shootFireball method in BlocklyCommands to increase efficiency and readbility of this method.