### PR TITLE
Blockly: fetch 'hero' only once in BlocklyCommands

### DIFF
--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -188,6 +188,7 @@ public class BlocklyCommands {
    * Shoots a fireball in direction the hero is facing.
    *
    * @param ac AmmunitionComponent of the hero, ammunition amount will be reduced by 1
+   * @param hero Entity to be used as hero for positioning
    */
   private static void aimAndShoot(AmmunitionComponent ac, Entity hero) {
     newFireballSkill(hero).execute(hero);
@@ -195,6 +196,12 @@ public class BlocklyCommands {
     Server.waitDelta();
   }
 
+  /**
+   * Create a new fireball for the given entity.
+   *
+   * @param hero Entity to be used as hero for positioning
+   * @return Nice new fireball, ready to be launched.
+   */
   private static Skill newFireballSkill(Entity hero) {
     return new Skill(
         new FireballSkill(

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -42,13 +42,19 @@ public class BlocklyCommands {
   private static final float FIREBALL_SPEED = 15f;
   private static final int FIREBALL_DMG = 1;
 
+  // Reference to our hero for all auxiliary methods defined in this class.
+  // This works only in single-player mode!
+  private static final Entity hero;
+  static {
+    hero = Game.hero().orElseThrow(MissingHeroException::new);
+  }
+
   /**
    * Moves the hero in it's viewing direction.
    *
    * <p>One move equals one tile.
    */
   public static void move() {
-    Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
     Direction viewDirection =
         Direction.fromPositionCompDirection(EntityUtils.getViewDirection(hero));
     BlocklyCommands.move(viewDirection, hero);
@@ -57,7 +63,6 @@ public class BlocklyCommands {
   /** Moves the Hero to the Exit Block of the current Level. */
   public static void moveToExit() {
     if (Game.currentLevel().exitTiles().isEmpty()) return;
-    Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
     Tile exitTile = Game.currentLevel().exitTiles().getFirst();
 
     PositionComponent pc =
@@ -91,7 +96,6 @@ public class BlocklyCommands {
     if (direction == Direction.UP || direction == Direction.DOWN) {
       return; // no rotation
     }
-    Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
     Direction viewDirection =
         Direction.fromPositionCompDirection(EntityUtils.getViewDirection(hero));
     Direction newDirection =
@@ -112,8 +116,6 @@ public class BlocklyCommands {
    * <p>The hero needs at least one unit of ammunition to successfully shoot a fireball.
    */
   public static void shootFireball() {
-    Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
-
     hero.fetch(AmmunitionComponent.class)
         .filter(AmmunitionComponent::checkAmmunition)
         .ifPresent(ac -> aimAndShoot(ac, hero));
@@ -121,7 +123,6 @@ public class BlocklyCommands {
 
   /** Triggers each interactable in front of the hero. */
   public static void interact() {
-    Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
     PositionComponent pc =
         hero.fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(hero, PositionComponent.class));
@@ -230,7 +231,6 @@ public class BlocklyCommands {
    * @param push True if you want to push, false if you want to pull.
    */
   private static void movePushable(boolean push) {
-    Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
     DISABLE_SHOOT_ON_HERO = true;
     PositionComponent heroPC =
         hero.fetch(PositionComponent.class)

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -45,6 +45,7 @@ public class BlocklyCommands {
   // Reference to our hero for all auxiliary methods defined in this class.
   // This works only in single-player mode!
   private static final Entity hero;
+
   static {
     hero = Game.hero().orElseThrow(MissingHeroException::new);
   }
@@ -118,7 +119,7 @@ public class BlocklyCommands {
   public static void shootFireball() {
     hero.fetch(AmmunitionComponent.class)
         .filter(AmmunitionComponent::checkAmmunition)
-        .ifPresent(ac -> aimAndShoot(ac, hero));
+        .ifPresent(BlocklyCommands::aimAndShoot);
   }
 
   /** Triggers each interactable in front of the hero. */
@@ -189,10 +190,9 @@ public class BlocklyCommands {
    * Shoots a fireball in direction the hero is facing.
    *
    * @param ac AmmunitionComponent of the hero, ammunition amount will be reduced by 1
-   * @param hero Entity to be used as hero for positioning
    */
-  private static void aimAndShoot(AmmunitionComponent ac, Entity hero) {
-    newFireballSkill(hero).execute(hero);
+  private static void aimAndShoot(AmmunitionComponent ac) {
+    newFireballSkill().execute(hero);
     ac.spendAmmo();
     Server.waitDelta();
   }
@@ -200,10 +200,9 @@ public class BlocklyCommands {
   /**
    * Create a new fireball for the given entity.
    *
-   * @param hero Entity to be used as hero for positioning
    * @return Nice new fireball, ready to be launched.
    */
-  private static Skill newFireballSkill(Entity hero) {
+  private static Skill newFireballSkill() {
     return new Skill(
         new FireballSkill(
             () ->

--- a/blockly/src/utils/Direction.java
+++ b/blockly/src/utils/Direction.java
@@ -121,6 +121,22 @@ public enum Direction {
   }
 
   /**
+   * Convert a {@link PositionComponent.Direction} into a {@link Point}.
+   *
+   * <p>This is a convenience method to avoid unnecessary method calls/method chaining, i.e. instead
+   * of writing <code>
+   * Direction.fromPositionCompDirection(EntityUtils.getViewDirection(hero)).toPoint()</code> all
+   * the time we can just use <code>
+   * Direction.asPoint(EntityUtils.getViewDirection(hero))</code> now.
+   *
+   * @param viewDirection Direction to convert.
+   * @return Converted direction.
+   */
+  public static Point asPoint(PositionComponent.Direction viewDirection) {
+    return fromPositionCompDirection(viewDirection).toPoint();
+  }
+
+  /**
    * Transforms a relative direction into a world direction based on this view direction.
    *
    * <p>For example, if the hero is looking to the RIGHT and wants to check LEFT (relative to their


### PR DESCRIPTION
`BlocklyCommands` is a helper class, all provided methods are class methods. Many methods need to fetch the hero entity from `Game`, which in our current design is always the same entity. This could be done once when loading the class ...

---

Edit: NICHT MERGEN! Das Ding ist nur als Gedankenexperiment gedacht für https://github.com/Dungeon-CampusMinden/Dungeon/pull/2005#discussion_r2100150047 ... (außerdem basiert #2008 auf #2005 und muss vor einem Merge erstmal rebased werden)