### PR TITLE
Blockly: Prevent hero spawn race on restart

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -11,10 +11,12 @@ import contrib.systems.*;
 import contrib.utils.components.Debugger;
 import core.Entity;
 import core.Game;
+import core.System;
 import core.components.PlayerComponent;
 import core.game.ECSManagment;
 import core.systems.LevelSystem;
 import core.systems.PlayerSystem;
+import core.systems.PositionSystem;
 import core.utils.Tuple;
 import core.utils.components.path.SimpleIPath;
 import entities.HeroTankControlledFactory;
@@ -210,10 +212,16 @@ public class Client {
    * level.
    *
    * <p>This effectively resets the game state to its initial configuration.
+   *
+   * <p>During the restart, the {@link PositionSystem} is stopped and then run again to ensure that
+   * the hero is placed correctly in the level. This prevents a race condition where the hero might
+   * be placed before the level is fully loaded.
    */
   public static void restart() {
     Game.removeAllEntities();
+    Game.system(PositionSystem.class, System::stop);
     createHero();
     DevDungeonLoader.reloadCurrentLevel();
+    Game.system(PositionSystem.class, System::run);
   }
 }


### PR DESCRIPTION
Ich habe im `restart()` des Blockly-`Client` das `PositionSystem` vorübergehend deaktiviert und danach wieder gestartet, um zu verhindern, dass der Held an einer falschen Stelle spawnt:

* `Client.java`:

  * In `restart()` wird vor `createHero()` und `reloadCurrentLevel()` nun `PositionSystem` abgeschaltet.
  * Nach dem Neuladen des Levels wird `PositionSystem` wieder aktiviert.

Dadurch wird sichergestellt, dass das PositionSystem den Helden erst platziert, nachdem das Level vollständig geladen wurde. Dies verhindert Race-Conditions und zufälliges Spawnen an ungültigen Positionen während des Restart-Vorgangs.
