### PR TITLE
Blockly: fix wrong ElementName after migration

### DIFF
--- a/blockly/frontend/src/utils/variableList.ts
+++ b/blockly/frontend/src/utils/variableList.ts
@@ -1,7 +1,7 @@
 const DEFAULT_VALUE = '?';
 
 export const setupVariableDisplay = (addVarCallback: () => void) => {
-  const toolboxDiv = document.getElementsByClassName('blocklyToolbox')[0] as HTMLDivElement;
+  const toolboxDiv = document.getElementsByClassName('blocklyToolboxDiv')[0] as HTMLDivElement;
   toolboxDiv.style.display = 'flex';
   toolboxDiv.style.flexDirection = 'column';
   toolboxDiv.style.justifyContent = 'space-between';


### PR DESCRIPTION
In #1999 wurde der String zum fetchen des DOM-Elements umbenannt, das schien falsch zu sein.

@Flamtky bitte kontrollieren. evtl ist das auch ein problem mit meiner installation? 