### PR TITLE
Blockly: `nearTile(FLOOR)` now also is true for exit

### DIFF
--- a/blockly/src/antlr/BlocklyConditionVisitor.java
+++ b/blockly/src/antlr/BlocklyConditionVisitor.java
@@ -269,7 +269,10 @@ public class BlocklyConditionVisitor extends blocklyBaseVisitor<INode> {
       return false;
     }
 
-    return BlocklyCommands.isNearTile(tileType, Direction.fromString(direction));
+    if (tileType == LevelElement.FLOOR) {
+      return BlocklyCommands.isNearTile(LevelElement.FLOOR, Direction.fromString(direction))
+          || BlocklyCommands.isNearTile(LevelElement.EXIT, Direction.fromString(direction));
+    } else return BlocklyCommands.isNearTile(tileType, Direction.fromString(direction));
   }
 
   /** {@inheritDoc} */


### PR DESCRIPTION
Damit wird der Ausgang auch als Boden betrachtet (für schleifen interessant) 