### PR TITLE
Blockly: Add `loadNextLevel` and `loadLevel(index)` 

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -27,6 +27,7 @@ import level.produs.*;
 import server.Server;
 import systems.BlockSystem;
 import systems.TintTilesSystem;
+import utils.BlocklyCodeRunner;
 import utils.CheckPatternPainter;
 
 /**
@@ -132,7 +133,7 @@ public class Client {
         (firstLoad) -> {
           if (DRAW_CHECKER_PATTERN)
             CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
-          Server.instance().interruptExecution = true;
+          BlocklyCodeRunner.instance().stopCode();
           Game.hero()
               .flatMap(e -> e.fetch(AmmunitionComponent.class))
               .map(AmmunitionComponent::resetCurrentAmmunition);

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -429,7 +429,9 @@ public class Server {
       int statusCode;
 
       if (interruptExecution) {
-        response = errorMsg;
+        response = errorMsg.isEmpty()
+            ? "Code execution interrupted"
+            : "Error: " + errorMsg;
         statusCode = 400;
         BlocklyCodeRunner.instance().stopCode();
       } else if (!BlocklyCodeRunner.instance().isCodeRunning()) {

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -429,9 +429,7 @@ public class Server {
       int statusCode;
 
       if (interruptExecution) {
-        response = errorMsg.isEmpty()
-            ? "Code execution interrupted"
-            : "Error: " + errorMsg;
+        response = errorMsg.isEmpty() ? "Code execution interrupted" : "Error: " + errorMsg;
         statusCode = 400;
         BlocklyCodeRunner.instance().stopCode();
       } else if (!BlocklyCodeRunner.instance().isCodeRunning()) {

--- a/blockly/src/utils/BlocklyCodeRunner.java
+++ b/blockly/src/utils/BlocklyCodeRunner.java
@@ -52,11 +52,25 @@ public class BlocklyCodeRunner {
           }
 
           private static void sleep() {
+            sleep(%d);
+          }
+
+          private static void sleep(int millis) {
             try {
-              Thread.sleep(%d * 1000);
+              Thread.sleep(millis);
             } catch (InterruptedException e) {
               Thread.currentThread().interrupt();
             }
+          }
+
+          private static void loadNextLevel() {
+            contrib.level.DevDungeonLoader.loadNextLevel();
+            sleep(1000);
+          }
+
+          private static void loadLevel(int index) {
+            contrib.level.DevDungeonLoader.loadLevel(index);
+            sleep(1000);
           }
       }
       """;

--- a/blockly/vs-code-extension/src/extension.ts
+++ b/blockly/vs-code-extension/src/extension.ts
@@ -21,7 +21,19 @@ const codeObjects = {
         detail: 'An element of an Tile in the game',
         insertText: 'LevelElement',
         onlyInRoot: false
-    }
+    },
+    'loadNextLevel()': {
+        kind: vscode.CompletionItemKind.Method,
+        detail: 'Loads the next level in the game',
+        insertText: 'loadNextLevel()',
+        onlyInRoot: true
+    },
+    'loadLevel(index: number)': {
+        kind: vscode.CompletionItemKind.Method,
+        detail: 'Loads a specific level by index',
+        insertText: new vscode.SnippetString('loadLevel(${1:index})'),
+        onlyInRoot: true
+    },
 }
 
 // Store API data for reuse


### PR DESCRIPTION
Die VS Code Extension stellt nun Methoden bereit, mit denen man das nächste Level laden (`loadNextLevel`) oder ein spezifisches Level per Index auswählen (`loadLevel(index)`) kann.

closes #2014
