### PR TITLE
Blockly: Initialize `levelProgress` to 0 if missing

### DIFF
--- a/blockly/frontend/src/utils/level.ts
+++ b/blockly/frontend/src/utils/level.ts
@@ -225,5 +225,10 @@ export const setupLevelSelector = () => {
     nextButton.disabled = select.selectedIndex === levelNames.length - 1 || !isLevelAvailable(levelNames[select.selectedIndex + 1]);
   }
 
+  // Initialize level progress if not set
+  if (localStorage.getItem("levelProgress") === null) {
+    setLevelProgress(0);
+  }
+
   return select;
 }


### PR DESCRIPTION
Setzt im `localStorage` den Schlüssel `levelProgress` per Default auf 0, falls er noch nicht existiert.

closes #2015
