### PR TITLE
Blockly: Retry fetching levels until timeout

### DIFF
--- a/blockly/frontend/src/index.ts
+++ b/blockly/frontend/src/index.ts
@@ -213,10 +213,7 @@ if (config.HIDE_RESPONSE_INFO) {
 updateLevelList().then(() => {
   load(workspace, getCurrentLevel()); // load initial state if available
   updateCodeDiv();
-
-  workspace.scrollCenter(); // centering workspace
-
-  const startBlock = getStartBlock(workspace);
-  if (!startBlock)
-    placeDefaultStartBlock(workspace);
 });
+
+placeDefaultStartBlock(workspace);
+workspace.scrollCenter(); // centering workspace


### PR DESCRIPTION
Wenn im Frontend keine Levels gefunden werden, wird jetzt alle 5 Sekunden erneut versucht, die Level-Liste zu aktualisieren, wobei die Wartezeit nach jedem Versuch um 5 Sekunden erhöht wird. Dieser Vorgang wird fortgesetzt, bis Levels gefunden werden oder die Wartezeit 60 Sekunden überschreitet.