### PR TITLE
Blockly: Support variables in numeric comparisons

### DIFF
--- a/blockly/frontend/src/blocks/dungeon.ts
+++ b/blockly/frontend/src/blocks/dungeon.ts
@@ -273,7 +273,11 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
       {
         type: "input_value",
         name: "TIMES",
-        check: "Number",
+        check: ["Number",
+          "Variable",
+          "Array_get",
+          "Expression"
+        ]
       },
     ],
     message1: "%{BKY_CONTROLS_REPEAT_INPUT_DO} %1",

--- a/blockly/frontend/src/blocks/dungeon.ts
+++ b/blockly/frontend/src/blocks/dungeon.ts
@@ -48,19 +48,6 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
   },
   // ---------------------- Variables ----------------------
   {
-    type: "get_number",
-    message0: "%1",
-    args0: [
-      {
-        type: "field_variable",
-        name: "VAR",
-        variable: "%{BKY_VARIABLES_DEFAULT_NAME}",
-      },
-    ],
-    output: "Move",
-    colour: 290,
-  },
-  {
     type: "set_number",
     previousStatement: null,
     nextStatement: null,
@@ -366,7 +353,11 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
       {
         type: "input_value",
         name: "INPUT_A",
-        check: "Number",
+        check: ["Number",
+          "Variable",
+          "Array_get",
+          "Expression"
+        ],
       },
       {
         type: "field_dropdown",
@@ -383,7 +374,11 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
       {
         type: "input_value",
         name: "INPUT_B",
-        check: "Number",
+        check: ["Number",
+          "Variable",
+          "Array_get",
+          "Expression"
+        ],
       },
     ],
     inputsInline: true,

--- a/blockly/frontend/src/toolbox.ts
+++ b/blockly/frontend/src/toolbox.ts
@@ -169,10 +169,6 @@ export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
           kind: "block",
           type: "get_variable",
         },
-        {
-          kind: "block",
-          type: "get_number",
-        },
       ],
     },
     {


### PR DESCRIPTION
Ich habe die numerischen Vergleichsblöcke so angepasst, dass jetzt Variablen in Bedingungen verwendet werden können (z. B. `var < 5`). Bisher waren nur Konstantenzahlen erlaubt. Da aktuell alle Variablen Zahlen repräsentieren, werden nun Variablen, numerische Literale, Expressions (z. B. `1+1`) und Array-Werte unterstützt.

* `dungeon.ts` - Block-Definition: Inputs erweitert, um die neuen Typen zu akzeptieren.
* `toolbox.ts` - `get_number` aus der Auswahlliste entfernt.

closes #2064
