### PR TITLE
Blockly: refactor BlocklyCommands#active()

### DIFF
--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -26,6 +26,7 @@ import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import entities.MiscFactory;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import server.Server;
 
@@ -347,18 +348,19 @@ public class BlocklyCommands {
    * @return The target tile, or empty if hero is not found or target tile doesn't exist
    */
   private static Optional<Tile> targetTile(final Direction direction) {
-    // calculate direction to check relative to hero's view direction
-    Coordinate dirToCheck =
-        Optional.ofNullable(EntityUtils.getHeroViewDirection())
-            .map(Direction::fromPositionCompDirection)
-            .map(d -> d.relativeToAbsoluteDirection(direction))
-            .map(Direction::toCoordinate)
-            .orElseThrow();
+    // find tile in a direction or empty
+    Function<Coordinate, Optional<Tile>> dirToCheck =
+        dtc ->
+            Optional.ofNullable(EntityUtils.getHeroCoordinate())
+                .map(coordinate -> coordinate.add(dtc))
+                .map(Game::tileAT);
 
-    // find tile in that direction
-    return Optional.ofNullable(EntityUtils.getHeroCoordinate())
-        .map(coordinate -> coordinate.add(dirToCheck))
-        .map(Game::tileAT);
+    // calculate direction to check relative to hero's view direction
+    return Optional.ofNullable(EntityUtils.getHeroViewDirection())
+        .map(Direction::fromPositionCompDirection)
+        .map(d -> d.relativeToAbsoluteDirection(direction))
+        .map(Direction::toCoordinate)
+        .flatMap(dirToCheck::apply);
   }
 
   /**

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -297,7 +297,7 @@ public class BlocklyCommands {
   /**
    * Determines whether the specified direction leads to an active state.
    *
-   * <p>A tile in the given direction is considered active iff
+   * <p>A tile in the given direction is considered active if:
    *
    * <ul>
    *   <li>it is a {@link DoorTile} and it is "open", or

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -25,8 +25,8 @@ import core.utils.MissingHeroException;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
 import entities.MiscFactory;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 import server.Server;
 
 /** A utility class that contains all methods for Blockly Blocks. */
@@ -276,11 +276,7 @@ public class BlocklyCommands {
    *     returns false.
    */
   public static boolean isNearTile(LevelElement tileElement, final Direction direction) {
-    Tile targetTile = targetTile(direction);
-    if (targetTile == null) {
-      return false;
-    }
-    return targetTile.levelElement() == tileElement;
+    return targetTile(direction).map(tile -> tile.levelElement() == tileElement).orElse(false);
   }
 
   /**
@@ -293,59 +289,76 @@ public class BlocklyCommands {
    */
   public static boolean isNearComponent(
       Class<? extends Component> componentClass, final Direction direction) {
-    Tile targetTile = targetTile(direction);
-    if (targetTile == null) {
-      return false;
-    }
-    return Game.entityAtTile(targetTile).anyMatch(e -> e.isPresent(componentClass));
+    return targetTile(direction)
+        .map(tile -> Game.entityAtTile(tile).anyMatch(e -> e.isPresent(componentClass)))
+        .orElse(false);
   }
 
   /**
    * Determines whether the specified direction leads to an active state.
    *
-   * <p>A tile in the given direction is considered active if:
+   * <p>A tile in the given direction is considered active iff
    *
-   * <p>It is a {@link DoorTile} and is open.
-   *
-   * <p>It contains at least one {@link LeverComponent}, and all found levers are in the "on" state.
+   * <ul>
+   *   <li>it is a {@link DoorTile} and it is "open", or
+   *   <li>it contains at least one {@link LeverComponent}, and all found levers are in the "on"
+   *       state.
+   * </ul>
    *
    * @param direction the direction to check relative to the hero's position.
    * @return {@code true} if the tile in the given direction is active, {@code false} otherwise.
    */
   public static boolean active(final Direction direction) {
-    Tile targetTile = targetTile(direction);
-    if (targetTile == null) {
-      return false; // no tile in the given direction
-    }
+    return targetTile(direction).map(BlocklyCommands::checkTileForDoorOrLevers).orElse(false);
+  }
 
-    if (targetTile instanceof DoorTile doorTile) {
-      return doorTile.isOpen();
-    }
+  /**
+   * Determines whether the specified tile is in active state.
+   *
+   * <p>A tile in the given direction is considered active iff
+   *
+   * <ul>
+   *   <li>it is a {@link DoorTile} and it is "open", or
+   *   <li>it contains at least one {@link LeverComponent}, and all found levers are in the "on"
+   *       state.
+   * </ul>
+   *
+   * @param tile the direction to check
+   * @return {@code true} if the tile is active, {@code false} otherwise.
+   */
+  private static Boolean checkTileForDoorOrLevers(Tile tile) {
+    // is this a door? is it open?
+    if (tile instanceof DoorTile doorTile) return doorTile.isOpen();
 
-    List<LeverComponent> levers =
-        Game.entityAtTile(targetTile).flatMap(e -> e.fetch(LeverComponent.class).stream()).toList();
+    // find all levers on a given tile and split those into "isOn" (true) and "isOff" (false)
+    Map<Boolean, List<LeverComponent>> levers =
+        Game.entityAtTile(tile)
+            .flatMap(e -> e.fetch(LeverComponent.class).stream())
+            .collect(Collectors.partitioningBy(LeverComponent::isOn));
 
-    return !levers.isEmpty() && levers.stream().allMatch(LeverComponent::isOn);
+    // there needs to be at least one lever; all levers need to be "isOn" (true)
+    return levers.get(false).isEmpty() && !levers.get(true).isEmpty();
   }
 
   /**
    * Gets the target tile in the given direction relative to the hero.
    *
    * @param direction Direction to check relative to hero's view direction
-   * @return The target tile, or null if hero is not found or target tile doesn't exist
+   * @return The target tile, or empty if hero is not found or target tile doesn't exist
    */
-  private static Tile targetTile(final Direction direction) {
-    Coordinate heroCoords = EntityUtils.getHeroCoordinate();
-    if (heroCoords == null) {
-      return null;
-    }
-    Direction heroViewDir =
-        Direction.fromPositionCompDirection(
-            EntityUtils.getViewDirection(Game.hero().orElseThrow(MissingHeroException::new)));
-    Direction toCheck = heroViewDir.relativeToAbsoluteDirection(direction);
+  private static Optional<Tile> targetTile(final Direction direction) {
+    // calculate direction to check relative to hero's view direction
+    Coordinate dirToCheck =
+        Optional.ofNullable(EntityUtils.getHeroViewDirection())
+            .map(Direction::fromPositionCompDirection)
+            .map(d -> d.relativeToAbsoluteDirection(direction))
+            .map(Direction::toCoordinate)
+            .orElseThrow();
 
-    Coordinate targetCoords = heroCoords.add(new Coordinate(toCheck.x(), toCheck.y()));
-    return Game.tileAT(targetCoords);
+    // find tile in that direction
+    return Optional.ofNullable(EntityUtils.getHeroCoordinate())
+        .map(coordinate -> coordinate.add(dirToCheck))
+        .map(Game::tileAT);
   }
 
   /**

--- a/dungeon/src/contrib/utils/Direction.java
+++ b/dungeon/src/contrib/utils/Direction.java
@@ -77,7 +77,7 @@ public enum Direction {
    * @return Coordinate with the x and y from this direction
    */
   public Coordinate toCoordinate() {
-    return new Coordinate(x, x);
+    return new Coordinate(x, y);
   }
 
   /**

--- a/dungeon/src/contrib/utils/Direction.java
+++ b/dungeon/src/contrib/utils/Direction.java
@@ -2,6 +2,7 @@ package contrib.utils;
 
 import core.components.PositionComponent;
 import core.level.Tile;
+import core.level.utils.Coordinate;
 import core.utils.Point;
 
 /** Direction enum for the four cardinal directions. */
@@ -68,6 +69,15 @@ public enum Direction {
    */
   public Point toPoint() {
     return new Point(x, y);
+  }
+
+  /**
+   * Convert this direction to a {@link Coordinate}.
+   *
+   * @return Coordinate with the x and y from this direction
+   */
+  public Coordinate toCoordinate() {
+    return new Coordinate(x, x);
   }
 
   /**

--- a/dungeon/src/contrib/utils/EntityUtils.java
+++ b/dungeon/src/contrib/utils/EntityUtils.java
@@ -119,6 +119,8 @@ public class EntityUtils {
    * @return The current position of the hero, or a null value if the hero is not present.
    */
   public static Point getHeroPosition() {
+    // TODO: SMELL!
+    // we really shouldn't return `null` if no hero was found, but `Optional.empty()` instead!
     return Game.hero()
         .map(
             e ->
@@ -138,6 +140,8 @@ public class EntityUtils {
    */
   public static Coordinate getHeroCoordinate() {
     Point heroPos = getHeroPosition();
+    // TODO: SMELL!
+    // we really shouldn't return `null` if no hero was found, but `Optional.empty()` instead!
     return heroPos == null ? null : heroPos.toCoordinate();
   }
 

--- a/dungeon/src/contrib/utils/EntityUtils.java
+++ b/dungeon/src/contrib/utils/EntityUtils.java
@@ -142,16 +142,24 @@ public class EntityUtils {
   }
 
   /**
+   * Retrieves the direction the hero is facing.
+   *
+   * @return the direction the hero is facing, or null if there is no hero.
+   */
+  public static PositionComponent.Direction getHeroViewDirection() {
+    return Game.hero().map(EntityUtils::getViewDirection).orElse(null);
+  }
+
+  /**
    * Returns the direction the entity is facing.
    *
    * @param entity the entity to get the direction of
    * @return the direction the entity is facing
    */
   public static PositionComponent.Direction getViewDirection(Entity entity) {
-    PositionComponent pc =
-        entity
-            .fetch(PositionComponent.class)
-            .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-    return pc.viewDirection();
+    return entity
+        .fetch(PositionComponent.class)
+        .map(PositionComponent::viewDirection)
+        .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
   }
 }

--- a/dungeon/src/contrib/utils/EntityUtils.java
+++ b/dungeon/src/contrib/utils/EntityUtils.java
@@ -147,6 +147,10 @@ public class EntityUtils {
    * @return the direction the hero is facing, or null if there is no hero.
    */
   public static PositionComponent.Direction getHeroViewDirection() {
+    // TODO: SMELL!
+    // we really shouldn't return `null` if no hero was found, but `Optional.empty()` instead!
+    // this approach has been chosen solely to ensure a symmetric modelling to the existing methods.
+    // when refactoring, *all* these methods here should be changed to return `Optional<>`.
     return Game.hero().map(EntityUtils::getViewDirection).orElse(null);
   }
 

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -430,7 +430,7 @@ public final class Game {
    */
   public static Tile tileAT(final Coordinate coordinate) {
     // TODO: SMELL!
-    // we really shouldn't return `null` if no hero was found, but `Optional.empty()` instead!
+    // we really shouldn't return `null` if no tile was found, but `Optional.empty()` instead!
     return currentLevel().tileAt(coordinate);
   }
 

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -429,6 +429,8 @@ public final class Game {
    *     out of bounds.
    */
   public static Tile tileAT(final Coordinate coordinate) {
+    // TODO: SMELL!
+    // we really shouldn't return `null` if no hero was found, but `Optional.empty()` instead!
     return currentLevel().tileAt(coordinate);
   }
 

--- a/game/src/core/Game.java
+++ b/game/src/core/Game.java
@@ -425,7 +425,8 @@ public final class Game {
    * Get the tile at the given coordinate in the level.
    *
    * @param coordinate Coordinate from where to get the tile
-   * @return the tile at the given coordinate.
+   * @return The tile at the specified coordinate, or null if there is no tile or the coordinate is
+   *     out of bounds.
    */
   public static Tile tileAT(final Coordinate coordinate) {
     return currentLevel().tileAt(coordinate);


### PR DESCRIPTION
This is a follow-up to #2110, where changes to the `active()` method in [BlocklyCommands](url) were introduced. This required multiple terminating and reopening operations on the stream, which is not particularly attractive. In addition, the value `null` was also returned in the auxiliary method `active()`, which forces all callers to use the usual scheme `var wuppie = active(); if (wuppie == null) foo();`.

This refactoring introduces an `Optional<Tile>` as return of `active()`, which should lead to a better readability and maintainability of the code.

Additionally, some convenience methods were defined to make the code more readable and increase the symmetry of the operations.

---

~~edit: waiting for #2120 (`Direction` gets moved)~~