### PR TITLE
Blockly: `InevitableFireball` now restarts the level, even if it hits a wall

### DIFF
--- a/blockly/src/utils/components/skill/InevitableFireballSkill.java
+++ b/blockly/src/utils/components/skill/InevitableFireballSkill.java
@@ -1,5 +1,6 @@
 package utils.components.skill;
 
+import client.Client;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.math.MathUtils;
@@ -52,7 +53,8 @@ public class InevitableFireballSkill extends DamageProjectile {
         HIT_BOX_SIZE,
         targetSelection,
         DEFAULT_PROJECTILE_RANGE,
-        DamageProjectile.DEFAULT_ON_WALL_HIT,
+        // If the fireball does not hit the player, still restart the level
+        entity -> Client.restart(),
         (projectile, entity) -> {
           // Set the velocity back to the original value (hero only)
           if (!entity.isPresent(PlayerComponent.class)) return;


### PR DESCRIPTION
fixes #2074

In seltenen Fällen konnte man den Helden in genau so einen Winkel zum Monster bewegen, dass das Monster den Helden zwar sehen und besiegen **sollte** (wichtig: das war im Level-Design auch so gedacht, dass der Held dort nicht stehen kann), aber der Feuerball, der vom Monster verschossen wird, den Helden nicht trifft, weil eine Wand in der Flugbahn liegt.

In diesem PR wird der `InevitableFireball` so erweitert, dass er das Level auch neu startet, wenn er eine Wand trifft.

Cooler wäre es, wenn der Feuerball einfach durch die Wand oder um die Wand fliegen würde, aber das würde größere Umbauarbeiten im Core voraussetzen, die für diesen super Edge-Case nicht gerechtfertigt sind.

Hier in Gründ konnte man sonst vorher stehen. 

![Bildschirmfoto 2025-07-07 um 12 17 03](https://github.com/user-attachments/assets/bf4dde28-bb0a-4007-9c5c-da349fc4a081)
