### PR TITLE
Blockly: fix draw order in level 8

### DIFF
--- a/blockly/src/level/produs/Chapter18Level.java
+++ b/blockly/src/level/produs/Chapter18Level.java
@@ -59,8 +59,6 @@ public class Chapter18Level extends BlocklyLevel {
     LevelManagementUtils.centerHero();
     LevelManagementUtils.cameraFocusHero();
     LevelManagementUtils.zoomDefault();
-    Game.add(MiscFactory.stone(customPoints().get(0).toCenteredPoint()));
-    Game.add(MiscFactory.stone(customPoints().get(1).toCenteredPoint()));
 
     BlocklyMonster.BlocklyMonsterBuilder guardBuilder = BlocklyMonster.GUARD.builder();
     guardBuilder.addToGame();
@@ -110,6 +108,9 @@ public class Chapter18Level extends BlocklyLevel {
     door4.close();
     door5 = (DoorTile) Game.tileAT(new Coordinate(8, 5));
     door5.close();
+
+    Game.add(MiscFactory.stone(customPoints().get(0).toCenteredPoint()));
+    Game.add(MiscFactory.stone(customPoints().get(1).toCenteredPoint()));
   }
 
   @Override


### PR DESCRIPTION
fixes #2184 

solange bis #2030 offen ist, fixt dieser PR das Problem im Level 8 durch das spätere hinzufügen der Steine.
Aktuell gilt, wer zuletzt kommt wird oben gezeichnet. 