### PR TITLE
Blockly: rename `wait` command into `doNothing` for Code-API

### DIFF
--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -1306,7 +1306,7 @@ public class Server {
         BlocklyCommands.rotate(firstArg);
       }
       case "feuerball" -> BlocklyCommands.shootFireball();
-      case "warte" -> waitDelta();
+      case "warte" -> BlocklyCommands.doNothing();
       case "benutzen" -> {
         Direction firstArg;
         if (args[0] instanceof String firstArgStr) {

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -511,4 +511,9 @@ public class BlocklyCommands {
         .map(d -> d.equals(Direction.toPositionCompDirection(direction)))
         .orElse(false);
   }
+
+  /** Let the hero do nothing for a short moment. */
+  public static void doNothing() {
+    Server.waitDelta();
+  }
 }

--- a/doc/produs_unterlagen/materials/commands_cheat_sheet.md
+++ b/doc/produs_unterlagen/materials/commands_cheat_sheet.md
@@ -3,7 +3,7 @@
 ## Befehle für den Helden (hero)
 
 | Befehl                                             | Beschreibung                                                                                                       |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+|----------------------------------------------------| ------------------------------------------------------------------------------------------------------------------ |
 | `hero.move();`                                     | Bewegt den Helden einen Schritt vorwärts.                                                                          |
 | `hero.rotate(direction);`                          | Dreht den Helden in die angegebene Richtung.                                                                       |
 | `hero.interact(direction);`                        | Interagiert mit einem Objekt in der angegebenen Richtung des Helden.                                               |
@@ -16,7 +16,7 @@
 | `hero.isNearComponent(componentClass, direction);` | Prüft, ob ein bestimmtes Komponenten-Objekt in der angegebenen Richtung in der Nähe (ein Feld vor dem Helden) ist. |
 | `hero.dropItem("Brotkrumen");`                     | Lässt ein Item („Brotkrumen“) fallen.                                                                              |
 | `hero.dropItem("Kleeblatt");`                      | Lässt ein Item („Kleeblatt“) fallen.                                                                               |
-| `hero.wait();`                                     | Macht einen kurzen moment nichts.                                                                                  |
+| `hero.doNothing();`                                | Macht einen kurzen moment nichts.                                                                                  |
 | `hero.checkBossViewDirection(direction)`           | **Nur für Level 20:** Prüfe in welche Richtung der Boss guckt.                                                     |
 | `hero.moveToExit();`                               | **Nur als Cheat-Block:** Bewegt den Helden direkt zum Ausgang. Nicht für Lösungen verwenden.                       |
 


### PR DESCRIPTION
In Blockly gibt es den Block "warte", der `Server.waitDelta()` aufruft.
Eigentlich wollte ich analog das command `hero.wait()` für VS-Code haben.
Problem: `Object#wait` existiert und sollte nicht überschrieben werden. 

In diesen PR füge ich daher `BlocklyCommands#doNothing` hinzu, welches dann `wait` ablöst.
In Blockly-Web heißt das Ding noch `warte` und das würde ich so lassen.

Außerdem
- anpassen des Command Cheat Sheets
- Der Blockly `warte` Block verwendet jetzt auch r `BlocklyCommands#doNothing`, für einheitlichen Code-Flow