### PR TITLE
Blockly: add switch case block

### DIFF
--- a/blockly/frontend/src/blocks/dungeon.ts
+++ b/blockly/frontend/src/blocks/dungeon.ts
@@ -616,6 +616,67 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
     colour: 250,
     suppressPrefixSuffix: true,
   },
+  // ----------------------- Switch Case ---------------------
+  {
+    type: "switch_case",
+    message0: "entscheide ueber %1",
+    args0: [
+      {
+        type: "input_value",
+        name: "SWITCH",
+      },
+    ],
+    message1: "%1", // Platz für case/default-Blöcke
+    args1: [
+      {
+        type: "input_statement",
+        name: "CASES",
+      },
+    ],
+    suppressPrefixSuffix: true,
+    previousStatement: null,
+    nextStatement: null,
+    colour: 210,
+    tooltip: "Verzweigt abhängig vom Wert.",
+  },
+  {
+    type: "case_block",
+    message0: "fall %1",
+    args0: [
+      {
+        type: "input_value",
+        name: "CASE",
+      },
+    ],
+    message1: "%1",
+    args1: [
+      {
+        type: "input_statement",
+        name: "DO",
+      },
+    ],
+    suppressPrefixSuffix: true,
+    previousStatement: null,
+    nextStatement: null,
+    colour: 200,
+    tooltip: "Ein einzelner Fall im Switch.",
+  },
+  {
+    type: "default_block",
+    message0: "sonst",
+    message1: "%1",
+    args1: [
+      {
+        type: "input_statement",
+        name: "DO",
+      },
+    ],
+    suppressPrefixSuffix: true,
+    previousStatement: null,
+    nextStatement: null,
+    colour: 180,
+    tooltip: "Standardfall im Switch, wenn kein anderer zutrifft.",
+  },
   // ---------------------- Skills ----------------------
   {
     type: "interact",

--- a/blockly/frontend/src/generators/java/condition.ts
+++ b/blockly/frontend/src/generators/java/condition.ts
@@ -167,3 +167,23 @@ export function controls_if(
 }
 
 export const controls_ifelse = controls_if;
+
+export function switch_case(block: Blockly.Block, generator: Blockly.Generator) {
+  const switch_expr = generator.valueToCode(block, "SWITCH", Order.NONE);
+  const cases_code = generator.statementToCode(block, "CASES");
+  const code = "entscheide ueber " + switch_expr + " {\n" + cases_code + "\n}";
+  return code;
+}
+
+export function case_block(block: Blockly.Block, generator: Blockly.Generator) {
+  const case_value = generator.valueToCode(block, "CASE", Order.NONE);
+  let do_code = generator.statementToCode(block, "DO");
+  do_code = generator.prefixLines(do_code, generator.INDENT);
+  return `fall ${case_value}:\n${do_code}`;
+}
+
+export function default_block(block: Blockly.Block, generator: Blockly.Generator) {
+  let do_code = generator.statementToCode(block, "DO");
+  do_code = generator.prefixLines(do_code, generator.INDENT);
+  return `default:\n${do_code}`;
+}

--- a/blockly/frontend/src/toolbox.ts
+++ b/blockly/frontend/src/toolbox.ts
@@ -123,6 +123,18 @@ export const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
           kind: "block",
           type: "controls_ifelse",
         },
+        {
+          kind: "block",
+          type: "switch_case",
+        },
+        {
+          kind: "block",
+          type: "case_block",
+        },
+        {
+          kind: "block",
+          type: "default_block",
+        }
       ],
     },
     {

--- a/blockly/src/server/SwitchStats.java
+++ b/blockly/src/server/SwitchStats.java
@@ -1,0 +1,47 @@
+package server;
+
+/** This class stores all important values of a switch scope. */
+public class SwitchStats {
+  /**
+   * The evaluated expression behind "entscheide ueber".
+   *
+   * <p>This value is the result of getActualValueFromExpression(...) for the switch statement.
+   */
+  public final int switchValue;
+
+  /**
+   * Whether a case has already matched (so that no further cases are executed after the first
+   * match).
+   *
+   * <p>Once a case is matched and executed, this flag prevents subsequent cases from running.
+   */
+  public boolean caseMatched;
+
+  /**
+   * Whether actions in the current case/default branch are allowed to execute.
+   *
+   * <p>If true, code within the matching case or default branch will run; otherwise it will be
+   * skipped.
+   */
+  public boolean executing;
+
+  /**
+   * Creates a new SwitchStats instance with the evaluated switchValue.
+   *
+   * @param switchValue the result of getActualValueFromExpression(...)
+   */
+  public SwitchStats(int switchValue) {
+    this.switchValue = switchValue;
+    this.caseMatched = false;
+    this.executing = false;
+  }
+
+  /**
+   * Checks if actions are allowed to execute in the current switch block.
+   *
+   * @return true if executing == true (i.e., we are in the matching case/default branch)
+   */
+  public boolean executeAction() {
+    return executing;
+  }
+}


### PR DESCRIPTION
Ich habe einen Switch-Case-Block hinzugefügt, inklusive entsprechender Case- und Default-Blöcke für die Verwendung innerhalb des Switch-Case.
Dafür wurden die entsprechenden Strukturen in `dungeon.ts`, `condition.ts` und `toolbox.ts` ergänzt.
Orientiert an dem bereits existierenden If-Else-Block wurde die Funktionalität in der Server.java implementiert.
Die Methode `switchEvaluation()` übernimmt die Hauptlogik und sorgt für die Verarbeitung der für den Switch-Case relevanten Aktionen `actions`. 

Aktuell kann der Switch-Case-Block nur in Kombination mit einer Integer-Variable verwendet werden, sodass die einzelnen Case-Zweige ausschließlich Zahlen als Bezeichner unterstützen.

closes  #2136 