### PR TITLE
Escaperoom: add player count target to documentation

### DIFF
--- a/escape-room/doc/design/game.md
+++ b/escape-room/doc/design/game.md
@@ -2,6 +2,10 @@
 title: "Entwicklung des Designs der Implementierung von Escape-Rooms im Spiel"
 ---
 
+# Rahmenentscheidungen
+
+*   Escape Rooms sind für 2–4 Spieler konzipiert. Die genaue Anzahl der Spieler kann für jeden Escape Room individuell festgelegt werden. Die Spieleranzahl hilft uns dabei, die Escape Rooms so zu gestalten, dass alle Teilnehmenden aktiv eingebunden sind und sinnvoll zur Lösung beitragen können.
+
 # Multiplayer-Implementierung
 
 Annahme: wir brauchen Netzwerk-Multiplayer

--- a/escape-room/doc/design/game.md
+++ b/escape-room/doc/design/game.md
@@ -4,7 +4,11 @@ title: "Entwicklung des Designs der Implementierung von Escape-Rooms im Spiel"
 
 # Rahmenentscheidungen
 
-*   Escape Rooms sind für 2–4 Spieler konzipiert. Die genaue Anzahl der Spieler kann für jeden Escape Room individuell festgelegt werden. Die Spieleranzahl hilft uns dabei, die Escape Rooms so zu gestalten, dass alle Teilnehmenden aktiv eingebunden sind und sinnvoll zur Lösung beitragen können.
+Unsere Escape Rooms sind für **2–4 Spieler** ausgelegt – je nach Raum kann die genaue Anzahl festgelegt werden.
+*   In kleinen Gruppen können sich alle aktiv beteiligen, gemeinsam Lösungen entwickeln und Verantwortung übernehmen. 
+*   Gruppengrößen besonders förderlich für Kommunikation, Zusammenarbeit und ein intensives gemeinsames Erlebnis sind (vgl [O’Szabo et al., 2022](../research/sources/the_anatomy_of_social_dynamics_in_escape_rooms.md)). 
+*   Coop-Spiele: vor allem Zweierteams; besonders eng zusammenarbeiten; starkes Wir-Gefühl
+*   Multiplayer-Spiele: Teams um 5 Leute; starke Rollen/ Aufgabenverteilung; höher Kommunikatiosaufwand; 
 
 # Multiplayer-Implementierung
 

--- a/escape-room/doc/research/sources/sources.bib
+++ b/escape-room/doc/research/sources/sources.bib
@@ -159,3 +159,13 @@
   copyright = "https://creativecommons.org/licenses/by/4.0/",
   language  = "en"
 }
+@article{o2022anatomy,
+  title={The anatomy of social dynamics in escape rooms},
+  author={O′ Szabo, Rebeka and Chowdhary, Sandeep and Deritei, David and Battiston, Federico},
+  journal={Scientific Reports},
+  volume={12},
+  number={1},
+  pages={10498},
+  year={2022},
+  publisher={Nature Publishing Group UK London}
+}

--- a/escape-room/doc/research/sources/the_anatomy_of_social_dynamics_in_escape_rooms.md
+++ b/escape-room/doc/research/sources/the_anatomy_of_social_dynamics_in_escape_rooms.md
@@ -7,4 +7,26 @@ source: https://www.researchgate.net/publication/354982868_The_anatomy_of_social
 
 ## Zusammenfassung
 
+Das Team untersucht soziales Verhalten und die Dynamik von Gruppen in Escape Rooms.
+Dabei liegt der Fokus insbesondere auf der Zusammensetzung der Teams – etwa hinsichtlich Alter, Geschlecht und Bildungsstand – und wie sich diese Faktoren auf die Kommunikation innerhalb der Gruppe und deren Problemlösekompetenz auswirken.
+
+Die Forschenden kommen zu dem Schluss, dass ein Minimum an angespannter Kommunikation („tense communication“) sich möglicherweise positiv auf das gemeinsame Problemlösen und eine erfolgreiche Teamarbeit auswirkt.
+
+**Weitere Erkenntnisse aus der Studie:**
+
+* Escape Rooms wurden mit Gruppen von 4–5 Personen gespielt
+* Gruppen galten als erfolgreich, wenn sie den Raum innerhalb der Zeit lösen konnten – andernfalls als nicht erfolgreich
+* Es wurde sowohl verbale als auch nonverbale Kommunikation beobachtet
+* Die Kommunikation wurde als neutral, positiv oder negativ klassifiziert
+* Etwa 80 % der Kommunikation fand paarweise statt, nur etwa 20 % in der Gesamtgruppe
+* Hohe Kommunikationsfrequenz: ca. 30 Interaktionen pro Minute (Ø ca. 3 Sekunden pro Interaktion)
+* Personen, die sich bereits kannten, kommunizierten häufiger miteinander
+* Ältere bzw. erfahrenere Teilnehmer:innen redeten länger
+* Jüngere Teilnehmer:innen (14-25 Jahre) zeigten insgesamt mehr nonverbale Kommunikation
+
 ## Übertragung auf unsere Arbeit
+
+* In Kombination mit Erfahrungs- und Praxisberichten aus Escape-Room-Foren und Plattformen deutet die hier gewonnene Erkenntnis – dass ein Minimum an „tense communication“ (angespannter Kommunikation) positiv auf den Erfolg wirken kann – darauf hin, dass kleinere Gruppen tendenziell erfolgreicher sind.
+* Unsere Zielgruppe befindet sich in vergleichbaren Alters- und Bildungskontexten, sodass ein ähnliches Kommunikationsverhalten zu erwarten ist.
+* Trotz Gruppenarbeit findet viel direkte Interaktion zwischen einzelnen Personen („one-on-one“) statt – wir sollten Systeme einbauen, die genau solche Interaktionen ermöglichen und unterstützen.
+* Jüngere Teilnehmende kommunizieren häufig nonverbal, z. B. durch Zeigen auf Objekte – solche Formen der Interaktion sollten wir bei der Gestaltung (z. B. durch Pointer- oder Ping-Funktionen) berücksichtigen.

--- a/escape-room/doc/research/sources/the_anatomy_of_social_dynamics_in_escape_rooms.md
+++ b/escape-room/doc/research/sources/the_anatomy_of_social_dynamics_in_escape_rooms.md
@@ -1,0 +1,10 @@
+---
+title: "The anatomy of social dynamics in escape rooms"
+source: https://www.researchgate.net/publication/354982868_The_anatomy_of_social_dynamics_in_escape_rooms
+---
+
+@o2022anatomy
+
+## Zusammenfassung
+
+## Übertragung auf unsere Arbeit


### PR DESCRIPTION
In unseren Diskussionen haben wir uns bewusst auf eine Zielspielerzahl von **2 bis 4 Spielern** geeinigt. Das bedeutet, dass jeder Escape Room, den wir gestalten, für eine feste Spieleranzahl innerhalb dieses Bereichs (zum Beispiel 3 Spieler) ausgelegt ist – und nur mit dieser Anzahl gespielt werden kann.

Diese Entscheidung gibt uns mehr Flexibilität beim Design der Räume. Wir können die Rätsel und Aufgaben gezielt auf die Gruppengröße abstimmen und so sicherstellen, dass jeder Spieler aktiv eingebunden wird. Zudem hält es zeitgleich die Komplexität im Design der Räume flacher (sich für 6. Leute zu überlegen was die alle zu jedem Moment machen sollen, ist schon schwer).

Die Wahl der Gruppengröße basiert auf verschiedenen Beobachtungen aus der Praxis:

* Kooperative Spiele finden oft zu zweit statt,
* Multiplayer-Spiele werden meist in Teams von etwa fünf Personen gespielt,
* Escape Rooms sind häufig für 4 bis 6 Spieler ausgelegt.

Das angehängten Pape zeigt, dass eine geringere, weniger angespannte Kommunikation zu erfolgreicheren Durchläufen führt. Große Gruppen neigen dazu, ihre Kommunikation auf einzelne Paargespräche auszulagern,

Für unsere didaktischen Escape Rooms ziehe ich daraus, dass. die gemeinsame "Nutzung von Wissen" und das Teamgefühl dadurch auch aufgeteilt wird.

Unsere Zielspielerzahl greift zudem die Gruppengrößen auf, die wir aus unseren Praktika kennen.

tldr: Mit 2 bis 4 Spielern schaffen wir ein Gleichgewicht zwischen sozialer Interaktion, Zusammenarbeit und Umsetzungsaufwand
