### PR TITLE
Gradle: associate custom starter with gradle group 'starter'

### DIFF
--- a/advancedDungeon/build.gradle
+++ b/advancedDungeon/build.gradle
@@ -15,21 +15,25 @@ processResources {
 }
 
 tasks.register('runAdvancedDungeon', JavaExec) {
+    group 'starter'
     mainClass = 'produsAdvanced.AdvancedDungeon'
     classpath = sourceSets.main.runtimeClasspath
 }
 
 tasks.register('runPathfinder', JavaExec) {
+    group 'starter'
     mainClass = 'aiAdvanced.starter.PathfinderStarter'
     classpath = sourceSets.main.runtimeClasspath
 }
 
 tasks.register('runPathFindingComparison', JavaExec) {
+    group 'starter'
     mainClass = 'aiAdvanced.starter.ComparePathfindingStarter'
     classpath = sourceSets.main.runtimeClasspath
 }
 
 tasks.register('buildAdvancedDungeonJar', Jar) {
+    group 'starter'
     dependsOn ':dungeon:jar'
     archiveBaseName = 'AdvancedDungeon'
     from sourceSets.main.output

--- a/advancedDungeon/build.gradle
+++ b/advancedDungeon/build.gradle
@@ -33,7 +33,7 @@ tasks.register('runPathFindingComparison', JavaExec) {
 }
 
 tasks.register('buildAdvancedDungeonJar', Jar) {
-    group 'starter'
+    group 'jar'
     dependsOn ':dungeon:jar'
     archiveBaseName = 'AdvancedDungeon'
     from sourceSets.main.output

--- a/blockly/build.gradle
+++ b/blockly/build.gradle
@@ -37,11 +37,13 @@ generateGrammarSource {
 
 
 tasks.register('runBlockly', JavaExec) {
+    group 'starter'
     mainClass = 'client.Client'
     classpath = sourceSets.main.runtimeClasspath
 }
 
 tasks.register('buildBlocklyJar', Jar) {
+    group 'starter'
     dependsOn ':dungeon:jar'
     archiveBaseName = 'Blockly'
     from sourceSets.main.output

--- a/blockly/build.gradle
+++ b/blockly/build.gradle
@@ -43,7 +43,7 @@ tasks.register('runBlockly', JavaExec) {
 }
 
 tasks.register('buildBlocklyJar', Jar) {
-    group 'starter'
+    group 'jar'
     dependsOn ':dungeon:jar'
     archiveBaseName = 'Blockly'
     from sourceSets.main.output

--- a/devDungeon/build.gradle
+++ b/devDungeon/build.gradle
@@ -12,10 +12,12 @@ sourceSets.main.java.srcDirs = ['src/']
 sourceSets.main.resources.srcDirs = ['assets/']
 
 tasks.register('runDevDungeon', JavaExec) {
+    group 'starter'
     mainClass = 'starter.DevDungeon'
     classpath = sourceSets.main.runtimeClasspath
 }
 tasks.register('buildDevDungeonJar', Jar) {
+    group 'starter'
     dependsOn ':dungeon:jar'
     archiveBaseName = 'DevDungeon'
     from sourceSets.main.output

--- a/devDungeon/build.gradle
+++ b/devDungeon/build.gradle
@@ -17,7 +17,7 @@ tasks.register('runDevDungeon', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
 }
 tasks.register('buildDevDungeonJar', Jar) {
-    group 'starter'
+    group 'jar'
     dependsOn ':dungeon:jar'
     archiveBaseName = 'DevDungeon'
     from sourceSets.main.output

--- a/dungeon/build.gradle
+++ b/dungeon/build.gradle
@@ -28,6 +28,7 @@ sourceSets.test.resources.srcDirs = ['test_resources/']
 
 // create our Starter.jar
 tasks.register('buildStarterJar', Jar) {
+    group 'starter'
     manifest {
         attributes 'Main-Class': 'starter.Starter'
     }
@@ -43,11 +44,13 @@ tasks.register('buildStarterJar', Jar) {
 }
 
 tasks.register('runBasicStarter', JavaExec) {
+    group 'starter'
     mainClass = 'starter.BasicStarter'
     classpath = sourceSets.main.runtimeClasspath
 }
 
 tasks.register('debugBasicStarter', JavaExec) {
+    group 'starter'
     mainClass = 'starter.BasicStarter'
     classpath = sourceSets.main.runtimeClasspath
     debug = true

--- a/dungeon/build.gradle
+++ b/dungeon/build.gradle
@@ -27,8 +27,8 @@ sourceSets.test.java.srcDirs = ['test/']
 sourceSets.test.resources.srcDirs = ['test_resources/']
 
 // create our Starter.jar
-tasks.register('buildStarterJar', Jar) {
-    group 'starter'
+tasks.register('buildDungeonJar', Jar) {
+    group 'jar'
     manifest {
         attributes 'Main-Class': 'starter.Starter'
     }


### PR DESCRIPTION
1. Alle Starter werden in die Gradle-Group "starter" assoziert.
2. Alle Jar-Building-Tasks werden in die Gradle-Group "jar" assoziert.
3. Die Namen sind halbwegs vereinheitlicht: 
    - "runXYZ" zum Starten eines Dungeons
    - "buildXYZ" zum Bauen der Jars

Damit hat man für das Gesamtprojekt die Reiter "starter" und "jar" mit allen entsprechenden Tasks, und für die Subprojekte dann nochmal individuell. 

<img width="484" height="961" alt="Screenshot 2025-07-15 at 17 24 05" src="https://github.com/user-attachments/assets/b68cf52d-3abb-4a6d-a931-2cf7355c640a" />


fixes #1336 