### PR TITLE
Refactoring: reduce spaghetti code 

### DIFF
--- a/advancedDungeon/src/aiAdvanced/starter/ComparePathfindingStarter.java
+++ b/advancedDungeon/src/aiAdvanced/starter/ComparePathfindingStarter.java
@@ -194,8 +194,7 @@ public class ComparePathfindingStarter {
             Entity runner = RUNNERS[i];
             if (runner == null) continue;
 
-            Coordinate spawn =
-                runner.fetch(PositionComponent.class).orElseThrow().position().toCoordinate();
+            Coordinate spawn = runner.fetch(PositionComponent.class).orElseThrow().coordinate();
             Coordinate end = Game.currentLevel().endTile().coordinate();
 
             if (i == 1) {

--- a/blockly/src/entities/BlocklyMonster.java
+++ b/blockly/src/entities/BlocklyMonster.java
@@ -316,7 +316,7 @@ public enum BlocklyMonster {
           range = straightRangeAI.range();
         }
         straightRangeAI.range(this.range);
-        monster.add(new TintDirectionComponent(pc.position().toCoordinate(), this.range));
+        monster.add(new TintDirectionComponent(pc.coordinate(), this.range));
       }
 
       if (addToGame) {

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -67,11 +67,10 @@ public class BlocklyCommands {
         hero.fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(hero, PositionComponent.class));
 
-    GraphPath<Tile> pathToExit =
-        LevelUtils.calculatePath(pc.position().toCoordinate(), exitTile.coordinate());
+    GraphPath<Tile> pathToExit = LevelUtils.calculatePath(pc.coordinate(), exitTile.coordinate());
 
     for (Tile nextTile : pathToExit) {
-      Tile currentTile = Game.tileAT(pc.position().toCoordinate());
+      Tile currentTile = Game.tileAT(pc.position());
       if (currentTile != nextTile) {
         PositionComponent.Direction viewDirection = EntityUtils.getViewDirection(hero);
         PositionComponent.Direction targetDirection =

--- a/blockly/src/utils/EntityUtils.java
+++ b/blockly/src/utils/EntityUtils.java
@@ -28,8 +28,8 @@ public class EntityUtils {
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(other, PositionComponent.class));
 
-    Coordinate entityCoordinate = entityPos.position().toCoordinate();
-    Coordinate otherCoordinate = otherPos.position().toCoordinate();
+    Coordinate entityCoordinate = entityPos.coordinate();
+    Coordinate otherCoordinate = otherPos.coordinate();
     if (entityCoordinate.equals(otherCoordinate)) return true;
     Direction viewDirectionEntity = Direction.fromPositionCompDirection(entityPos.viewDirection());
 

--- a/devDungeon/src/level/devlevel/IllusionRiddleLevel.java
+++ b/devDungeon/src/level/devlevel/IllusionRiddleLevel.java
@@ -321,10 +321,7 @@ public class IllusionRiddleLevel extends DevDungeonLevel {
     return Game.hero()
         .flatMap(hero -> hero.fetch(PositionComponent.class))
         .flatMap(
-            heroPc ->
-                rooms.stream()
-                    .filter(room -> room.contains(heroPc.position().toCoordinate()))
-                    .findFirst())
+            heroPc -> rooms.stream().filter(room -> room.contains(heroPc.coordinate())).findFirst())
         .orElse(null);
   }
 

--- a/devDungeon/src/level/devlevel/riddleHandler/DamagedBridgeRiddleHandler.java
+++ b/devDungeon/src/level/devlevel/riddleHandler/DamagedBridgeRiddleHandler.java
@@ -87,7 +87,7 @@ public class DamagedBridgeRiddleHandler {
           hero.fetch(PositionComponent.class)
               .orElseThrow(() -> MissingComponentException.build(hero, PositionComponent.class));
 
-      if (!rewardGiven && riddleRewardSpawn.equals(pc.position().toCoordinate())) {
+      if (!rewardGiven && riddleRewardSpawn.equals(pc.coordinate())) {
         giveReward();
       }
     } else {

--- a/devDungeon/src/systems/FogOfWarSystem.java
+++ b/devDungeon/src/systems/FogOfWarSystem.java
@@ -194,7 +194,7 @@ public class FogOfWarSystem extends System {
   }
 
   private void darkenTile(Tile tile, int maxDistance, float scale, Point heroPos) {
-    int newTint = getTintColor(tile.coordinate().toPoint(), maxDistance, scale, heroPos);
+    int newTint = getTintColor(tile.position(), maxDistance, scale, heroPos);
     int orgTint = tile.tintColor();
     int mixedTint = orgTint == -1 ? newTint : (orgTint & 0xFFFFFF00) | (newTint & 0x000000FF);
     if (!darkenedTiles.containsKey(tile)) {

--- a/devDungeon/src/systems/MobSpawnerSystem.java
+++ b/devDungeon/src/systems/MobSpawnerSystem.java
@@ -95,7 +95,7 @@ public class MobSpawnerSystem extends System {
         LevelUtils.accessibleTilesInRange(position.position(), mobSpawner.maxSpawnRadius());
     possibleSpawns =
         filterTilesWithinMinRadius(
-            position.position().toCoordinate(), mobSpawner.minSpawnRadius(), possibleSpawns);
+            position.coordinate(), mobSpawner.minSpawnRadius(), possibleSpawns);
 
     if (possibleSpawns.isEmpty()) {
       throw new IllegalStateException("No possible spawn locations found for mob spawner");

--- a/dungeon/src/contrib/systems/FogSystem.java
+++ b/dungeon/src/contrib/systems/FogSystem.java
@@ -193,7 +193,7 @@ public class FogSystem extends System {
 
   private void darkenTile(Tile tile, int maxDistance, float scale, Point heroPos) {
     if (tile == null) return;
-    int newTint = getTintColor(tile.coordinate().toPoint(), maxDistance, scale, heroPos);
+    int newTint = getTintColor(tile.position(), maxDistance, scale, heroPos);
     int orgTint = tile.tintColor();
     int mixedTint = orgTint == -1 ? newTint : (orgTint & 0xFFFFFF00) | (newTint & 0x000000FF);
     if (!darkenedTiles.containsKey(tile)) {

--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -461,7 +461,7 @@ public final class Game {
    * @return The tile that is the next tile from the given point in the specified direction.
    */
   public static Tile tileAT(final Point point, PositionComponent.Direction direction) {
-    return tileAT(point.toCoordinate(), direction);
+    return tileAT(point, direction);
   }
 
   /**

--- a/dungeon/src/core/components/PositionComponent.java
+++ b/dungeon/src/core/components/PositionComponent.java
@@ -2,6 +2,7 @@ package core.components;
 
 import core.Component;
 import core.level.Tile;
+import core.level.utils.Coordinate;
 import core.utils.Point;
 
 /**
@@ -133,6 +134,15 @@ public final class PositionComponent implements Component {
    */
   public void position(final Tile tile) {
     position(tile.position().toCenteredPoint());
+  }
+
+  /**
+   * Get the position as coordinate.
+   *
+   * @return The position as coordinate.
+   */
+  public Coordinate coordinate() {
+    return position.toCoordinate();
   }
 
   /**

--- a/dungeon/src/core/level/elements/ILevel.java
+++ b/dungeon/src/core/level/elements/ILevel.java
@@ -491,7 +491,7 @@ public interface ILevel extends IndexedGraph<Tile> {
         entity
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-    return tileAt(pc.position().toCoordinate());
+    return tileAt(pc.position());
   }
 
   /**

--- a/dungeon/src/core/level/utils/LevelUtils.java
+++ b/dungeon/src/core/level/utils/LevelUtils.java
@@ -209,15 +209,17 @@ public final class LevelUtils {
   }
 
   private static boolean isPointInTile(final Point point, final Tile tile) {
-    return tile.coordinate().toPoint().x() < point.x()
-        && point.x() < (tile.coordinate().toPoint().x() + 1)
-        && tile.coordinate().toPoint().y() < point.y()
-        && point.y() < (tile.coordinate().toPoint().y() + 1);
+    Point tileposition = tile.position();
+
+    return tileposition.x() < point.x()
+        && point.x() < (tileposition.x() + 1)
+        && tileposition.y() < point.y()
+        && point.y() < (tileposition.y() + 1);
   }
 
   private static boolean isAnyCornerOfTileInRadius(
       final Point center, float radius, final Tile tile) {
-    Point origin = tile.coordinate().toPoint();
+    Point origin = tile.position();
     Vector2[] cornerOffsets = {
       Vector2.ZERO, Vector2.RIGHT, Vector2.UP, Vector2.RIGHT.add(Vector2.UP)
     };
@@ -425,7 +427,7 @@ public final class LevelUtils {
     PositionComponent pc =
         hero.fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(hero, PositionComponent.class));
-    Tile heroTile = Game.currentLevel().tileAt(pc.position().toCoordinate());
+    Tile heroTile = Game.currentLevel().tileAt(pc.position());
     if (heroTile == null) {
       return false;
     }

--- a/dungeon/test/core/level/TileLevelTest.java
+++ b/dungeon/test/core/level/TileLevelTest.java
@@ -414,7 +414,7 @@ public class TileLevelTest {
 
     Point randomWallPoint = tileLevel.randomTilePoint(LevelElement.WALL).get();
     assertNotNull(randomWallPoint);
-    Tile randomWall = tileLevel.tileAt(randomWallPoint.toCoordinate());
+    Tile randomWall = tileLevel.tileAt(randomWallPoint);
     assertNotNull(randomWall);
     assertEquals(LevelElement.WALL, randomWall.levelElement());
   }
@@ -429,7 +429,7 @@ public class TileLevelTest {
     var level = new TileLevel(levelLayout, DesignLabel.randomDesign());
     Point randomPoint = level.randomTilePoint();
     assertNotNull(randomPoint);
-    assertNotNull(level.tileAt(randomPoint.toCoordinate()));
+    assertNotNull(level.tileAt(randomPoint));
   }
 
   /** WTF? . */
@@ -451,8 +451,8 @@ public class TileLevelTest {
 
     Point randomWallPoint = tileLevel.randomTilePoint(LevelElement.WALL).get();
     Point randomFloorPoint = tileLevel.randomTilePoint(LevelElement.FLOOR).get();
-    Tile randomWall = tileLevel.tileAt(randomWallPoint.toCoordinate());
-    Tile randomFloor = tileLevel.tileAt(randomFloorPoint.toCoordinate());
+    Tile randomWall = tileLevel.tileAt(randomWallPoint);
+    Tile randomFloor = tileLevel.tileAt(randomFloorPoint);
     assertEquals(LevelElement.WALL, randomWall.levelElement());
     assertEquals(LevelElement.FLOOR, randomFloor.levelElement());
   }


### PR DESCRIPTION
1. `ILevel` bietet neben `Tile tileAt(final Coordinate coordinate)` auch eine Methode `Tile tileAt(final Point point)` => Die explizite Konvertierung von `Point` nach `Coordinate` ist bei Aufrufen von `tileAt()` unnötig. Entferne hier nach Möglichkeit die Aufrufe von `.toCoordinate()`.

2. Die `PositionComponent` bekommt eine Convenience-Methode `.coordinate()` in Symmetrie zu `.position()`. Damit lassen sich die Spaghetti-Aufrufe der Art `.position().toCoordinate()` lesbarer als `.coordinate()` schreiben.


fixes #2234