### PR TITLE
LevelUtils: refactor randomAccessibleTileCoordinateInRange to improve readability

### DIFF
--- a/dungeon/src/contrib/utils/components/ai/idle/StaticRadiusWalk.java
+++ b/dungeon/src/contrib/utils/components/ai/idle/StaticRadiusWalk.java
@@ -6,7 +6,6 @@ import core.Entity;
 import core.Game;
 import core.components.PositionComponent;
 import core.level.Tile;
-import core.level.utils.Coordinate;
 import core.level.utils.LevelUtils;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
@@ -58,11 +57,7 @@ public final class StaticRadiusWalk implements Consumer<Entity> {
         // center is the start position of the entity, so it must be
         // accessible
         Point newEndTile =
-            LevelUtils.randomAccessibleTileCoordinateInRange(center, radius)
-                .map(Coordinate::toPoint)
-                // center is the start position of the entity, so it must be
-                // accessible
-                .orElse(center);
+            LevelUtils.randomAccessibleTileInRangeAsPoint(center, radius).orElse(center);
         path = LevelUtils.calculatePath(currentPosition, newEndTile);
         accept(entity);
       }

--- a/dungeon/src/contrib/utils/components/interaction/DropItemsInteraction.java
+++ b/dungeon/src/contrib/utils/components/interaction/DropItemsInteraction.java
@@ -7,7 +7,6 @@ import core.Entity;
 import core.Game;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
-import core.level.utils.Coordinate;
 import core.level.utils.LevelUtils;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
@@ -83,15 +82,15 @@ public final class DropItemsInteraction implements BiConsumer<Entity, Entity> {
    * @param item The item to drop
    * @param positionComponent The position component of the entity
    * @return true if the item was dropped, false otherwise
-   * @see LevelUtils#randomAccessibleTileCoordinateInRange(Point, float)
+   * @see LevelUtils#randomAccessibleTileInRangeAsPoint(Point, float)
    */
   private boolean tryDropItem(Item item, PositionComponent positionComponent) {
     for (int i = 1; i <= MAX_ITEM_DROP_RADIUS; i++) {
-      Coordinate randomTile =
-          LevelUtils.randomAccessibleTileCoordinateInRange(positionComponent.position(), i)
+      Point randomTile =
+          LevelUtils.randomAccessibleTileInRangeAsPoint(positionComponent.position(), i)
               .orElse(null);
       if (randomTile != null) {
-        item.drop(randomTile.toPoint());
+        item.drop(randomTile);
         return true;
       }
     }

--- a/dungeon/src/core/level/utils/LevelUtils.java
+++ b/dungeon/src/core/level/utils/LevelUtils.java
@@ -67,9 +67,7 @@ public final class LevelUtils {
    * @return Path from the center point to the randomly selected tile.
    */
   public static GraphPath<Tile> calculatePathToRandomTileInRange(final Point point, float radius) {
-    Coordinate newPosition =
-        randomAccessibleTileCoordinateInRange(point, radius).orElse(point.toCoordinate());
-    return calculatePath(point.toCoordinate(), newPosition);
+    return calculatePath(point, randomAccessibleTileInRangeAsPoint(point, radius).orElse(point));
   }
 
   /**
@@ -260,12 +258,9 @@ public final class LevelUtils {
    * @return An Optional containing a random Coordinate object representing an accessible tile
    *     within the range, or an empty Optional if no accessible tiles were found.
    */
-  public static Optional<Coordinate> randomAccessibleTileCoordinateInRange(
+  public static Optional<Point> randomAccessibleTileInRangeAsPoint(
       final Point center, float radius) {
-    List<Tile> tiles = accessibleTilesInRange(center, radius);
-    if (tiles.isEmpty()) return Optional.empty();
-    Coordinate newPosition = tiles.get(RANDOM.nextInt(tiles.size())).coordinate();
-    return Optional.of(newPosition);
+    return accessibleTilesInRange(center, radius).stream().map(Tile::position).findAny();
   }
 
   /**


### PR DESCRIPTION
The method `LevelUtils#randomAccessibleTileCoordinateInRange` was returning the `Coordinate` of a random tile in range. However, all uses would convert the result to `Point` - so let's do this right in the method itself. 

Also, just use `findAny()` instead of a custom randomisation. According to the [doc](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/stream/Stream.html#findAny()) `findAny()` is "_explicitly nondeterministic_", thus it will return a random element from the stream. 