### PR TITLE
Produs: add coyote time for red light green lite (level 20)

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -180,6 +180,7 @@ public class Client {
             }
           }
         });
+    if (DEBUG_MODE) Game.add(new LevelEditorSystem());
   }
 
   private static void startServer() {

--- a/blockly/src/level/produs/Level020.java
+++ b/blockly/src/level/produs/Level020.java
@@ -11,6 +11,7 @@ import core.components.PositionComponent;
 import core.components.VelocityComponent;
 import core.level.elements.tile.DoorTile;
 import core.level.elements.tile.PitTile;
+import core.level.loader.DungeonLoader;
 import core.level.utils.Coordinate;
 import core.level.utils.DesignLabel;
 import core.level.utils.LevelElement;
@@ -179,10 +180,10 @@ public class Level020 extends BlocklyLevel {
 
     // If the hero gets close enough to the boss, the boss escapes
     if (heroX >= bossX - ESCAPE_DISTANCE) {
-      DialogUtils.showTextPopup("Mich kriegst du nie!", "BOSS");
       Game.remove(boss);
       boss = null;
       EventScheduler.clear();
+      DialogUtils.showTextPopup("Mich kriegst du nie!", "BOSS", DungeonLoader::loadNextLevel);
     }
   }
 }

--- a/blockly/src/server/Server.java
+++ b/blockly/src/server/Server.java
@@ -108,7 +108,7 @@ public class Server {
     "benutzen",
     "schieben",
     "ziehen",
-    "geheZumAusgang",
+    "geheZumAuCsgang",
     "aufsammeln",
     "fallen_lassen",
     "active",
@@ -230,7 +230,6 @@ public class Server {
     // Reset values
     interruptExecution = true;
     Client.restart();
-
     sendHeroPosition(exchange);
   }
 


### PR DESCRIPTION
Anpassungen an Level 020

* Coyote Time hinzugefügt, damit ein laufender Schritt noch ausgeführt werden kann, wenn der Boss sich dreht
* EventScheduler ersetzt bisherigen Counter zur Ablaufsteuerung
* Automatischer Levelwechsel nach Schließen des letzten Dialogs
