### PR TITLE
Produs: close game after final boss fight

### DIFF
--- a/blockly/src/level/produs/Level022.java
+++ b/blockly/src/level/produs/Level022.java
@@ -74,7 +74,9 @@ public class Level022 extends BlocklyLevel {
         .orElseThrow()
         .onDeath(
             entity -> {
-              DialogUtils.showTextPopup("NEEEEEEEEEEEEEEEEIN! ICH WERDE MICH RÄCHEN!", "SIEG!");
+              // we shouldnt just end the game, we need a real end screen
+              DialogUtils.showTextPopup(
+                  "NEEEEEEEEEEEEEEEEIN! ICH WERDE MICH RÄCHEN!", "SIEG!", Game::exit);
               boss = null;
             });
     bossVC =


### PR DESCRIPTION
Wenn der Boss in Level 022 besiegt ist, muss man eigentlich noch zum Ausgang.
Das ist a) umständlich in der Implementierung für die kids und b) unnötig, das Spiel ist vorbei.

Dieser PR schließt das Spiel, nachdem der finale Dialog beendet wurde.

Perspektivisch wäre sowas wie ein "Back to main menue" oder Credits o.ä cool 