### PR TITLE
delete not needed build jar tasks

### DIFF
--- a/advancedDungeon/build.gradle
+++ b/advancedDungeon/build.gradle
@@ -31,27 +31,3 @@ tasks.register('runPathFindingComparison', JavaExec) {
     mainClass = 'aiAdvanced.starter.ComparePathfindingStarter'
     classpath = sourceSets.main.runtimeClasspath
 }
-
-tasks.register('buildAdvancedDungeonJar', Jar) {
-    group 'jar'
-    dependsOn ':dungeon:jar'
-    archiveBaseName = 'AdvancedDungeon'
-    from sourceSets.main.output
-    from project(':dungeon').sourceSets.main.output
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
-    manifest {
-        attributes 'Main-Class': 'produsAdvanced.AdvancedDungeon'
-    }
-
-    archiveFileName = 'AdvancedDungeon.jar'
-
-    into('assets') {
-        from new File(project(':dungeon').projectDir, '/assets')
-    }
-
-    exclude('META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.RSA')
-}

--- a/dungeon/build.gradle
+++ b/dungeon/build.gradle
@@ -26,23 +26,6 @@ sourceSets.main.resources.srcDirs = ['assets/']
 sourceSets.test.java.srcDirs = ['test/']
 sourceSets.test.resources.srcDirs = ['test_resources/']
 
-// create our Starter.jar
-tasks.register('buildDungeonJar', Jar) {
-    group 'jar'
-    manifest {
-        attributes 'Main-Class': 'starter.Starter'
-    }
-    archiveFileName = 'Starter.jar'
-
-    from sourceSets.main.output
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
-
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*module-info.class'
-}
-
 tasks.register('runBasicStarter', JavaExec) {
     group 'starter'
     mainClass = 'starter.BasicStarter'


### PR DESCRIPTION
Dieser Pull Request entfernt die Gradle-Tasks zur Erstellung von JAR-Dateien für die Subprojekte `advancedDungeon` und `dungeon`.

- `advancedDungeon` setzt den Source Code voraus, um ihn spielen zu können
- `dungeon` enthält keine spielerischen Elemente, wodurch eine gebaute Version keinen Mehrwert bietet  

closes #2228 