### PR TITLE
Blockly: fixes hier-Block to work for isNearTile and isNearComponent

### DIFF
--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -286,6 +286,11 @@ public class BlocklyCommands {
    *     returns false.
    */
   public static boolean isNearTile(LevelElement tileElement, final Direction direction) {
+    // Check the tile the hero is standing on
+    if (direction == Direction.NONE) {
+      Tile checkTile = Game.tileAT(EntityUtils.getHeroCoordinate());
+      return checkTile.levelElement() == tileElement;
+    }
     return targetTile(direction).map(tile -> tile.levelElement() == tileElement).orElse(false);
   }
 
@@ -299,6 +304,11 @@ public class BlocklyCommands {
    */
   public static boolean isNearComponent(
       Class<? extends Component> componentClass, final Direction direction) {
+    // Check if there is a component on the tile the hero is standing on
+    if (direction == Direction.NONE) {
+      Tile checkTile = Game.tileAT(EntityUtils.getHeroCoordinate());
+      return Game.entityAtTile(checkTile).anyMatch(e -> e.isPresent(componentClass));
+    }
     return targetTile(direction)
         .map(tile -> Game.entityAtTile(tile).anyMatch(e -> e.isPresent(componentClass)))
         .orElse(false);

--- a/dungeon/src/core/utils/Direction.java
+++ b/dungeon/src/core/utils/Direction.java
@@ -110,8 +110,7 @@ public enum Direction implements Vector2 {
       case DOWN -> this.opposite();
       case LEFT -> this.turnLeft();
       case RIGHT -> this.turnRight();
-      case NONE -> NONE;
-      default -> this; // UP
+      default -> this; // UP or NONE
     };
   }
 

--- a/dungeon/src/core/utils/Direction.java
+++ b/dungeon/src/core/utils/Direction.java
@@ -110,7 +110,8 @@ public enum Direction implements Vector2 {
       case DOWN -> this.opposite();
       case LEFT -> this.turnLeft();
       case RIGHT -> this.turnRight();
-      default -> this; // UP or NONE
+      case NONE -> NONE;
+      default -> this; // UP
     };
   }
 


### PR DESCRIPTION
Der in #2263 beschriebene Fehler entsteht in der Methode `targetTile()` in `BlocklyCommands`. 
Dort wird `applyRelative` aufgerufen. Da NONE jedoch keine tatsächliche Richtung repräsentiert, sollte in diesem Fall keine Umrechung erfolgen.  Hierdurch wird aktuell fälschlicherweise die Blickrichtung des Helden ab diesem Punkt als Zielrichtung verwendet, obwohl die ursprüngliche Intention war, die aktuelle Position des Helden (`hier`-Block) zu prüfen. 

Als Lösung habe ich die Methoden `isNearTile` und `isNearComponent` um jeweils eine zusätzliche Abfrage ergänzt. Wenn `Direction.NONE` übergeben wird, arbeiten beide Methoden nun direkt mit der aktuellen Position des Helden, da diese in diesem Fall unabhängig von dessen Blickrichtung ist. 

fixes #2263 