### PR TITLE
Dungeon: refactor `MeleeAI`

### DIFF
--- a/devDungeon/src/entities/MonsterType.java
+++ b/devDungeon/src/entities/MonsterType.java
@@ -9,7 +9,7 @@ import contrib.entities.MonsterDeathSound;
 import contrib.entities.MonsterFactory;
 import contrib.entities.MonsterIdleSound;
 import contrib.hud.DialogUtils;
-import contrib.utils.components.ai.fight.CollideAI;
+import contrib.utils.components.ai.fight.AIChaseBehaviour;
 import contrib.utils.components.ai.fight.RangeAI;
 import contrib.utils.components.ai.idle.PatrolWalk;
 import contrib.utils.components.ai.idle.RadiusWalk;
@@ -67,7 +67,7 @@ public enum MonsterType {
       2.5f,
       0.33f,
       MonsterDeathSound.LOWER_PITCH,
-      () -> new CollideAI(0.5f),
+      () -> new AIChaseBehaviour(0.5f),
       () -> new RadiusWalk(2f, 2),
       () -> new RangeTransition(5),
       7,
@@ -103,7 +103,7 @@ public enum MonsterType {
       3.5f,
       0.33f,
       MonsterDeathSound.LOW_PITCH,
-      () -> new CollideAI(1.0f),
+      () -> new AIChaseBehaviour(1.0f),
       () -> new RadiusWalk(3f, 4),
       () -> new RangeTransition(6),
       10,
@@ -118,7 +118,7 @@ public enum MonsterType {
       3.0f,
       0.1f,
       MonsterDeathSound.LOWER_PITCH,
-      () -> new CollideAI(0.5f),
+      () -> new AIChaseBehaviour(0.5f),
       () -> new RadiusWalk(3f, 2),
       () -> new RangeTransition(5),
       5,
@@ -154,7 +154,7 @@ public enum MonsterType {
       7.5f,
       0.0f,
       MonsterDeathSound.NONE,
-      () -> new CollideAI(1.0f),
+      () -> new AIChaseBehaviour(1.0f),
       () -> (entity) -> {}, // Stand still if not fighting
       () -> new RangeTransition(5, true),
       1,
@@ -169,7 +169,7 @@ public enum MonsterType {
       3.5f,
       0.0f,
       MonsterDeathSound.LOWER_PITCH,
-      () -> new CollideAI(0.5f),
+      () -> new AIChaseBehaviour(0.5f),
       () -> entity -> {}, // no idle needed
       () -> (entity) -> true, // Always fight
       30, // one hit kill
@@ -184,7 +184,7 @@ public enum MonsterType {
       3.25f,
       0.1f,
       MonsterDeathSound.BASIC,
-      () -> new CollideAI(0.5f),
+      () -> new AIChaseBehaviour(0.5f),
       () -> new RadiusWalk(3f, 2),
       () -> new RangeTransition(7),
       3,
@@ -199,7 +199,7 @@ public enum MonsterType {
       4.0f,
       0.05f,
       MonsterDeathSound.HIGH_PITCH,
-      () -> new CollideAI(1f),
+      () -> new AIChaseBehaviour(1f),
       () -> new RadiusWalk(2f, 1),
       () -> new RangeTransition(4),
       1,

--- a/dungeon/src/contrib/components/AIComponent.java
+++ b/dungeon/src/contrib/components/AIComponent.java
@@ -1,7 +1,7 @@
 package contrib.components;
 
 import contrib.systems.AISystem;
-import contrib.utils.components.ai.fight.CollideAI;
+import contrib.utils.components.ai.fight.AIChaseBehaviour;
 import contrib.utils.components.ai.idle.PatrolWalk;
 import contrib.utils.components.ai.idle.RadiusWalk;
 import contrib.utils.components.ai.transition.RangeTransition;
@@ -55,10 +55,10 @@ public final class AIComponent implements Component {
    * Create an AIComponent with default behavior.
    *
    * <p>The default behavior uses {@link RadiusWalk} as the idle behavior, {@link RangeTransition}
-   * as the transition function, and {@link CollideAI} as the fight behavior.
+   * as the transition function, and {@link AIChaseBehaviour} as the fight behavior.
    */
   public AIComponent() {
-    this(new CollideAI(2f), new RadiusWalk(5, 2), new RangeTransition(5f));
+    this(new AIChaseBehaviour(2f), new RadiusWalk(5, 2), new RangeTransition(5f));
   }
 
   /**

--- a/dungeon/src/contrib/entities/AIFactory.java
+++ b/dungeon/src/contrib/entities/AIFactory.java
@@ -2,7 +2,7 @@ package contrib.entities;
 
 import contrib.components.AIComponent;
 import contrib.components.HealthComponent;
-import contrib.utils.components.ai.fight.CollideAI;
+import contrib.utils.components.ai.fight.AIChaseBehaviour;
 import contrib.utils.components.ai.fight.MeleeAI;
 import contrib.utils.components.ai.fight.RangeAI;
 import contrib.utils.components.ai.idle.PatrolWalk;
@@ -103,7 +103,7 @@ public final class AIFactory {
     int index = RANDOM.nextInt(0, 3);
 
     return switch (index) {
-      case 0 -> new CollideAI(RANDOM.nextFloat(RUSH_RANGE_LOW, RUSH_RANGE_HIGH));
+      case 0 -> new AIChaseBehaviour(RANDOM.nextFloat(RUSH_RANGE_LOW, RUSH_RANGE_HIGH));
       case 1 ->
           new RangeAI(
               RANDOM.nextFloat(ATTACK_RANGE_LOW, ATTACK_RANGE_HIGH),

--- a/dungeon/src/contrib/entities/AIFactory.java
+++ b/dungeon/src/contrib/entities/AIFactory.java
@@ -111,6 +111,7 @@ public final class AIFactory {
               new Skill(new FireballSkill(SkillTools::heroPositionAsPoint), FIREBALL_COOL_DOWN));
       default ->
           new MeleeAI(
+              RANDOM.nextFloat(RUSH_RANGE_LOW, RUSH_RANGE_HIGH),
               1f,
               new Skill(new FireballSkill(SkillTools::heroPositionAsPoint), FIREBALL_COOL_DOWN));
     };

--- a/dungeon/src/contrib/entities/AIFactory.java
+++ b/dungeon/src/contrib/entities/AIFactory.java
@@ -3,7 +3,7 @@ package contrib.entities;
 import contrib.components.AIComponent;
 import contrib.components.HealthComponent;
 import contrib.utils.components.ai.fight.AIChaseBehaviour;
-import contrib.utils.components.ai.fight.MeleeAI;
+import contrib.utils.components.ai.fight.AIMeleeBehaviour;
 import contrib.utils.components.ai.fight.RangeAI;
 import contrib.utils.components.ai.idle.PatrolWalk;
 import contrib.utils.components.ai.idle.RadiusWalk;
@@ -110,7 +110,7 @@ public final class AIFactory {
               RANDOM.nextFloat(DISTANCE_LOW, DISTANCE_HIGH),
               new Skill(new FireballSkill(SkillTools::heroPositionAsPoint), FIREBALL_COOL_DOWN));
       default ->
-          new MeleeAI(
+          new AIMeleeBehaviour(
               RANDOM.nextFloat(RUSH_RANGE_LOW, RUSH_RANGE_HIGH),
               1f,
               new Skill(new FireballSkill(SkillTools::heroPositionAsPoint), FIREBALL_COOL_DOWN));

--- a/dungeon/src/contrib/utils/components/Debugger.java
+++ b/dungeon/src/contrib/utils/components/Debugger.java
@@ -171,7 +171,8 @@ public class Debugger {
       monster.add(new HealthComponent());
       monster.add(new CollideComponent());
       monster.add(
-          new AIComponent(new AIChaseBehaviour(1), new RadiusWalk(5, 1), new SelfDefendTransition()));
+          new AIComponent(
+              new AIChaseBehaviour(1), new RadiusWalk(5, 1), new SelfDefendTransition()));
 
       Game.add(monster);
       // Log that the monster was spawned

--- a/dungeon/src/contrib/utils/components/Debugger.java
+++ b/dungeon/src/contrib/utils/components/Debugger.java
@@ -7,7 +7,7 @@ import contrib.components.HealthComponent;
 import contrib.components.UIComponent;
 import contrib.configuration.KeyboardConfig;
 import contrib.hud.dialogs.TextDialog;
-import contrib.utils.components.ai.fight.CollideAI;
+import contrib.utils.components.ai.fight.AIChaseBehaviour;
 import contrib.utils.components.ai.idle.RadiusWalk;
 import contrib.utils.components.ai.transition.SelfDefendTransition;
 import contrib.utils.components.skill.SkillTools;
@@ -171,7 +171,7 @@ public class Debugger {
       monster.add(new HealthComponent());
       monster.add(new CollideComponent());
       monster.add(
-          new AIComponent(new CollideAI(1), new RadiusWalk(5, 1), new SelfDefendTransition()));
+          new AIComponent(new AIChaseBehaviour(1), new RadiusWalk(5, 1), new SelfDefendTransition()));
 
       Game.add(monster);
       // Log that the monster was spawned

--- a/dungeon/src/contrib/utils/components/ai/fight/AIChaseBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIChaseBehaviour.java
@@ -49,7 +49,7 @@ public class AIChaseBehaviour implements Consumer<Entity> {
   private void handlePlayerNotInChaseRange(final Entity entity) {
     if (timeSinceLastUpdate >= delay) {
       path = LevelUtils.calculatePathToHero(entity);
-      timeSinceLastUpdate--;
+      timeSinceLastUpdate = 0;
     }
     timeSinceLastUpdate++;
     AIUtils.move(entity, path);

--- a/dungeon/src/contrib/utils/components/ai/fight/AIChaseBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIChaseBehaviour.java
@@ -11,8 +11,8 @@ import java.util.function.Consumer;
 /**
  * Implements a fight AI. The entity attacks the player if the player is colliding with the entity.
  */
-public class CollideAI implements Consumer<Entity> {
-  private final float rushRange;
+public class AIChaseBehaviour implements Consumer<Entity> {
+  private final float chaseRange;
   private final int delay = Game.frameRate();
   private int timeSinceLastUpdate = delay;
   private GraphPath<Tile> path;
@@ -21,15 +21,15 @@ public class CollideAI implements Consumer<Entity> {
    * Attacks the player by colliding if he is within the given range. Otherwise, it will move
    * towards the player.
    *
-   * @param rushRange Range in which the faster collide logic should be executed.
+   * @param chaseRange Range in which the faster collide logic should be executed.
    */
-  public CollideAI(final float rushRange) {
-    this.rushRange = rushRange;
+  public AIChaseBehaviour(final float chaseRange) {
+    this.chaseRange = chaseRange;
   }
 
   @Override
   public void accept(final Entity entity) {
-    if (LevelUtils.playerInRange(entity, rushRange)) {
+    if (LevelUtils.playerInRange(entity, chaseRange)) {
       // the faster pathing once a certain range is reached
       path = LevelUtils.calculatePathToHero(entity);
       AIUtils.move(entity, path);

--- a/dungeon/src/contrib/utils/components/ai/fight/AIChaseBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIChaseBehaviour.java
@@ -11,7 +11,9 @@ import java.util.function.Consumer;
 /**
  * AI behavior for entities that chase and attack the player.
  *
- * <p>The entity will attempt to move towards the player and attack, if the player is within a specified range.
+ * <p>The entity will attempt to move towards the player and attack, if the player is within a
+ * specified range.
+ *
  * <p>Otherwise, it will continue to follow the last calculated path towards the player.
  */
 public class AIChaseBehaviour implements Consumer<Entity> {
@@ -23,7 +25,7 @@ public class AIChaseBehaviour implements Consumer<Entity> {
   /**
    * Creates a new AIChaseBehaviour with the given chase range.
    *
-   * @param chaseRange The distance within which the entity will attempt to attack the player directly.
+   * @param chaseRange The distance within which the entity will attempt to chase the player.
    */
   public AIChaseBehaviour(final float chaseRange) {
     this.chaseRange = chaseRange;
@@ -39,9 +41,9 @@ public class AIChaseBehaviour implements Consumer<Entity> {
   }
 
   private void handlePlayerInChaseRange(final Entity entity) {
-      path = LevelUtils.calculatePathToHero(entity);
-      AIUtils.move(entity, path);
-      timeSinceLastUpdate = delay;
+    path = LevelUtils.calculatePathToHero(entity);
+    AIUtils.move(entity, path);
+    timeSinceLastUpdate = delay;
   }
 
   private void handlePlayerNotInChaseRange(final Entity entity) {

--- a/dungeon/src/contrib/utils/components/ai/fight/AIChaseBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIChaseBehaviour.java
@@ -9,7 +9,10 @@ import core.level.utils.LevelUtils;
 import java.util.function.Consumer;
 
 /**
- * Implements a fight AI. The entity attacks the player if the player is colliding with the entity.
+ * AI behavior for entities that chase and attack the player.
+ *
+ * <p>The entity will attempt to move towards the player and attack, if the player is within a specified range.
+ * <p>Otherwise, it will continue to follow the last calculated path towards the player.
  */
 public class AIChaseBehaviour implements Consumer<Entity> {
   private final float chaseRange;
@@ -18,10 +21,9 @@ public class AIChaseBehaviour implements Consumer<Entity> {
   private GraphPath<Tile> path;
 
   /**
-   * Attacks the player by colliding if he is within the given range. Otherwise, it will move
-   * towards the player.
+   * Creates a new AIChaseBehaviour with the given chase range.
    *
-   * @param chaseRange Range in which the faster collide logic should be executed.
+   * @param chaseRange The distance within which the entity will attempt to attack the player directly.
    */
   public AIChaseBehaviour(final float chaseRange) {
     this.chaseRange = chaseRange;
@@ -29,19 +31,35 @@ public class AIChaseBehaviour implements Consumer<Entity> {
 
   @Override
   public void accept(final Entity entity) {
+    updateChase(entity);
+  }
+
+  /**
+   * Updates the chase behavior for the given entity.
+   *
+   * <p>If the player is within the specified chase range, recalculates the path and moves the entity towards the player,
+   * returning true.
+   *
+   * <p>Otherwise, updates the path at a fixed interval and continues moving the entity along the last path,
+   * returning false.
+   *
+   * @param entity The entity whose chase behavior should be updated.
+   * @return true if the player is within chase range and the entity should attack, false otherwise.
+   */
+  public boolean updateChase(final Entity entity) {
     if (LevelUtils.playerInRange(entity, chaseRange)) {
-      // the faster pathing once a certain range is reached
       path = LevelUtils.calculatePathToHero(entity);
       AIUtils.move(entity, path);
       timeSinceLastUpdate = delay;
+      return true;
     } else {
-      // check if new pathing update
       if (timeSinceLastUpdate >= delay) {
         path = LevelUtils.calculatePathToHero(entity);
         timeSinceLastUpdate = -1;
       }
       timeSinceLastUpdate++;
       AIUtils.move(entity, path);
+      return false;
     }
   }
 }

--- a/dungeon/src/contrib/utils/components/ai/fight/AIChaseBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIChaseBehaviour.java
@@ -31,35 +31,25 @@ public class AIChaseBehaviour implements Consumer<Entity> {
 
   @Override
   public void accept(final Entity entity) {
-    updateChase(entity);
+    if (LevelUtils.playerInRange(entity, chaseRange)) {
+      handlePlayerInChaseRange(entity);
+    } else {
+      handlePlayerNotInChaseRange(entity);
+    }
   }
 
-  /**
-   * Updates the chase behavior for the given entity.
-   *
-   * <p>If the player is within the specified chase range, recalculates the path and moves the entity towards the player,
-   * returning true.
-   *
-   * <p>Otherwise, updates the path at a fixed interval and continues moving the entity along the last path,
-   * returning false.
-   *
-   * @param entity The entity whose chase behavior should be updated.
-   * @return true if the player is within chase range and the entity should attack, false otherwise.
-   */
-  public boolean updateChase(final Entity entity) {
-    if (LevelUtils.playerInRange(entity, chaseRange)) {
+  private void handlePlayerInChaseRange(final Entity entity) {
       path = LevelUtils.calculatePathToHero(entity);
       AIUtils.move(entity, path);
       timeSinceLastUpdate = delay;
-      return true;
-    } else {
-      if (timeSinceLastUpdate >= delay) {
-        path = LevelUtils.calculatePathToHero(entity);
-        timeSinceLastUpdate = -1;
-      }
-      timeSinceLastUpdate++;
-      AIUtils.move(entity, path);
-      return false;
+  }
+
+  private void handlePlayerNotInChaseRange(final Entity entity) {
+    if (timeSinceLastUpdate >= delay) {
+      path = LevelUtils.calculatePathToHero(entity);
+      timeSinceLastUpdate--;
     }
+    timeSinceLastUpdate++;
+    AIUtils.move(entity, path);
   }
 }

--- a/dungeon/src/contrib/utils/components/ai/fight/AIMeleeBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIMeleeBehaviour.java
@@ -8,14 +8,14 @@ import java.util.function.Consumer;
 
 /**
  * Implements a fight AI. The entity attacks the player if he is in a given range. When the entity
- * is not in range but in fight mode, the entity will be moving to ward the player.
+ * is not in range but in fight mode, the entity will be moving towards the player.
  *
  * @see ISkillUser
  */
-public class MeleeAI implements Consumer<Entity>, ISkillUser {
+public class AIMeleeBehaviour implements Consumer<Entity>, ISkillUser {
+  private final AIChaseBehaviour chaseBehaviour;
   private final float attackRange;
   private Skill fightSkill;
-  private final AIChaseBehaviour chaseBehaviour;
 
   /**
    * Attacks the player if he is within the given range. Otherwise, it will move towards the player.
@@ -24,7 +24,7 @@ public class MeleeAI implements Consumer<Entity>, ISkillUser {
    * @param attackRange Range in which the attack skill should be executed.
    * @param fightSkill Skill to be used when an attack is performed.
    */
-  public MeleeAI(float chaseRange, float attackRange, Skill fightSkill) {
+  public AIMeleeBehaviour(float chaseRange, float attackRange, Skill fightSkill) {
     this.chaseBehaviour = new AIChaseBehaviour(chaseRange);
     this.attackRange = attackRange;
     this.fightSkill = fightSkill;

--- a/dungeon/src/contrib/utils/components/ai/fight/MeleeAI.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/MeleeAI.java
@@ -1,12 +1,8 @@
 package contrib.utils.components.ai.fight;
 
-import com.badlogic.gdx.ai.pfa.GraphPath;
-import contrib.utils.components.ai.AIUtils;
 import contrib.utils.components.skill.ISkillUser;
 import contrib.utils.components.skill.Skill;
 import core.Entity;
-import core.Game;
-import core.level.Tile;
 import core.level.utils.LevelUtils;
 import java.util.function.Consumer;
 
@@ -18,33 +14,28 @@ import java.util.function.Consumer;
  */
 public class MeleeAI implements Consumer<Entity>, ISkillUser {
   private final float attackRange;
-  private final int delay = Game.frameRate();
   private Skill fightSkill;
-  private int timeSinceLastUpdate = 0;
-  private GraphPath<Tile> path;
+  private final AIChaseBehaviour chaseBehaviour;
 
   /**
    * Attacks the player if he is within the given range. Otherwise, it will move towards the player.
    *
+   * @param chaseRange Range in which the entity will chase the player.
    * @param attackRange Range in which the attack skill should be executed.
    * @param fightSkill Skill to be used when an attack is performed.
    */
-  public MeleeAI(final float attackRange, final Skill fightSkill) {
+  public MeleeAI(float chaseRange, float attackRange, Skill fightSkill) {
+    this.chaseBehaviour = new AIChaseBehaviour(chaseRange);
     this.attackRange = attackRange;
     this.fightSkill = fightSkill;
   }
 
   @Override
-  public void accept(final Entity entity) {
+  public void accept(Entity entity) {
     if (LevelUtils.playerInRange(entity, attackRange)) {
       useSkill(fightSkill, entity);
     } else {
-      if (path == null || timeSinceLastUpdate >= delay) {
-        path = LevelUtils.calculatePathToHero(entity);
-        timeSinceLastUpdate = -1;
-      }
-      timeSinceLastUpdate++;
-      AIUtils.move(entity, path);
+      chaseBehaviour.accept(entity);
     }
   }
 

--- a/dungeon/src/contrib/utils/components/skill/ISkillUser.java
+++ b/dungeon/src/contrib/utils/components/skill/ISkillUser.java
@@ -1,11 +1,12 @@
 package contrib.utils.components.skill;
 
+import contrib.utils.components.ai.fight.AIMeleeBehaviour;
 import core.Entity;
 
 /**
  * Interface for skill users. It defines methods to use a skill and to get and set a skill.
  *
- * <p>It is used by the {@link contrib.utils.components.ai.fight.MeleeAI MeleeAI} and {@link
+ * <p>It is used by the {@link AIMeleeBehaviour MeleeAI} and {@link
  * contrib.utils.components.ai.fight.RangeAI RangeAI} classes to use a skill when an attack is
  * performed.
  */

--- a/dungeon/test/contrib/utils/components/ai/ProtectOnApproachTest.java
+++ b/dungeon/test/contrib/utils/components/ai/ProtectOnApproachTest.java
@@ -1,7 +1,7 @@
 package contrib.utils.components.ai;
 
 import contrib.components.AIComponent;
-import contrib.utils.components.ai.fight.CollideAI;
+import contrib.utils.components.ai.fight.AIChaseBehaviour;
 import contrib.utils.components.ai.idle.RadiusWalk;
 import contrib.utils.components.ai.transition.ProtectOnApproach;
 import contrib.utils.components.ai.transition.RangeTransition;
@@ -28,7 +28,7 @@ public class ProtectOnApproachTest {
 
     // Add AI Component
     AIComponent protectedAI =
-        new AIComponent(new CollideAI(0.2f), new RadiusWalk(0, 50), new RangeTransition(2));
+        new AIComponent(new AIChaseBehaviour(0.2f), new RadiusWalk(0, 50), new RangeTransition(2));
     entity.add(protectedAI);
 
     // Add Position Component
@@ -40,7 +40,7 @@ public class ProtectOnApproachTest {
     // Add AI Component
     entityAI =
         new AIComponent(
-            new CollideAI(0.2f), new RadiusWalk(0, 50), new ProtectOnApproach(2f, protectedEntity));
+            new AIChaseBehaviour(0.2f), new RadiusWalk(0, 50), new ProtectOnApproach(2f, protectedEntity));
     entity.add(entityAI);
 
     // Add Position Component

--- a/dungeon/test/contrib/utils/components/ai/ProtectOnApproachTest.java
+++ b/dungeon/test/contrib/utils/components/ai/ProtectOnApproachTest.java
@@ -40,7 +40,9 @@ public class ProtectOnApproachTest {
     // Add AI Component
     entityAI =
         new AIComponent(
-            new AIChaseBehaviour(0.2f), new RadiusWalk(0, 50), new ProtectOnApproach(2f, protectedEntity));
+            new AIChaseBehaviour(0.2f),
+            new RadiusWalk(0, 50),
+            new ProtectOnApproach(2f, protectedEntity));
     entity.add(entityAI);
 
     // Add Position Component


### PR DESCRIPTION
Die Klasse hatte folgendes Problem:

- Die Verfolgungslogik war bereits in der selben Art und Weise in der Klasse `AIChaseBehaviour` (alter Name: `CollideAI`) vorhanden.

Deswegen habe ich die Logik an `AIChaseBehaviour` delegiert, um Code-Duplizierung zu vermeiden.
Zusätzlich habe ich den Klassennamen `MeleeAI` in `AIMeleeBehaviour` umbenannt, um eine Namensvereinheitlichung zu gewährleisten und die Funktionalität der Klasse besser zu beschreiben.