### PR TITLE
Dungeon: refactor `RangeAI`

### DIFF
--- a/devDungeon/src/entities/MonsterType.java
+++ b/devDungeon/src/entities/MonsterType.java
@@ -10,7 +10,7 @@ import contrib.entities.MonsterFactory;
 import contrib.entities.MonsterIdleSound;
 import contrib.hud.DialogUtils;
 import contrib.utils.components.ai.fight.AIChaseBehaviour;
-import contrib.utils.components.ai.fight.RangeAI;
+import contrib.utils.components.ai.fight.AIRangeBehaviour;
 import contrib.utils.components.ai.idle.PatrolWalk;
 import contrib.utils.components.ai.idle.RadiusWalk;
 import contrib.utils.components.ai.transition.RangeTransition;
@@ -83,7 +83,7 @@ public enum MonsterType {
       0.1f,
       MonsterDeathSound.HIGH_PITCH,
       () ->
-          new RangeAI(
+          new AIRangeBehaviour(
               7f,
               0f,
               new Skill(
@@ -134,7 +134,7 @@ public enum MonsterType {
       0.1f,
       MonsterDeathSound.LOWER_PITCH,
       () ->
-          new RangeAI(
+          new AIRangeBehaviour(
               3f,
               0f,
               new Skill(
@@ -215,7 +215,7 @@ public enum MonsterType {
       0.25f,
       MonsterDeathSound.LOW_PITCH,
       () ->
-          new RangeAI(
+          new AIRangeBehaviour(
               9f,
               0f,
               new Skill(
@@ -253,7 +253,7 @@ public enum MonsterType {
       0.5f,
       MonsterDeathSound.LOW_PITCH,
       () ->
-          new RangeAI(
+          new AIRangeBehaviour(
               7, 6, BossAttackSkills.normalAttack((int) (AIFactory.FIREBALL_COOL_DOWN * 1.5f))),
       () -> new RadiusWalk(3f, 4),
       () -> new RangeTransition(6, true),
@@ -269,7 +269,7 @@ public enum MonsterType {
       0.0f,
       1.0f,
       MonsterDeathSound.LOWER_PITCH,
-      () -> new RangeAI(15f, 0f, BossAttackSkills.fireCone(35, 125, 12.0f, 3)),
+      () -> new AIRangeBehaviour(15f, 0f, BossAttackSkills.fireCone(35, 125, 12.0f, 3)),
       () -> entity -> {}, // no idle needed
       () -> new RangeTransition(7, true),
       10,
@@ -288,7 +288,7 @@ public enum MonsterType {
       0.0f,
       0.0f, // Custom Logic
       MonsterDeathSound.LOWER_PITCH,
-      () -> new RangeAI(17f, 0f, null),
+      () -> new AIRangeBehaviour(17f, 0f, null),
       () -> entity -> {}, // no idle needed
       () -> new RangeTransition(7, true),
       10,

--- a/devDungeon/src/level/devlevel/BossLevel.java
+++ b/devDungeon/src/level/devlevel/BossLevel.java
@@ -9,7 +9,7 @@ import contrib.item.HealthPotionType;
 import contrib.item.concreteItem.ItemPotionHealth;
 import contrib.systems.HealthSystem;
 import contrib.utils.EntityUtils;
-import contrib.utils.components.ai.fight.RangeAI;
+import contrib.utils.components.ai.fight.AIRangeBehaviour;
 import contrib.utils.components.health.IHealthObserver;
 import core.Entity;
 import core.Game;
@@ -148,11 +148,11 @@ public class BossLevel extends DevDungeonLevel implements IHealthObserver {
     AIComponent aiComp =
         boss.fetch(AIComponent.class)
             .orElseThrow(() -> MissingComponentException.build(boss, AIComponent.class));
-    if (!(aiComp.fightBehavior() instanceof RangeAI rangeAI)) return;
+    if (!(aiComp.fightBehavior() instanceof AIRangeBehaviour AIRangeBehaviour)) return;
 
     if (isBoss2ndPhase) {
       if (anyOtherMobsAlive()) {
-        rangeAI.skill(BossAttackSkills.SKILL_NONE());
+        AIRangeBehaviour.skill(BossAttackSkills.SKILL_NONE());
         return;
       } else {
         boss.remove(MagicShieldComponent.class);
@@ -164,10 +164,10 @@ public class BossLevel extends DevDungeonLevel implements IHealthObserver {
     if (System.currentTimeMillis() - lastAttackChange > getBossAttackChangeDelay()
         && isBossNormalAttacking) {
       this.lastAttackChange = System.currentTimeMillis();
-      rangeAI.skill(BossAttackSkills.getFinalBossSkill(boss));
+      AIRangeBehaviour.skill(BossAttackSkills.getFinalBossSkill(boss));
       this.isBossNormalAttacking = false;
     } else if (!isBossNormalAttacking) {
-      rangeAI.skill(BossAttackSkills.normalAttack(AIFactory.FIREBALL_COOL_DOWN));
+      AIRangeBehaviour.skill(BossAttackSkills.normalAttack(AIFactory.FIREBALL_COOL_DOWN));
       this.isBossNormalAttacking = true;
     }
   }

--- a/devDungeon/src/level/devlevel/IllusionRiddleLevel.java
+++ b/devDungeon/src/level/devlevel/IllusionRiddleLevel.java
@@ -9,7 +9,7 @@ import contrib.entities.MiscFactory;
 import contrib.item.HealthPotionType;
 import contrib.item.concreteItem.ItemPotionHealth;
 import contrib.utils.EntityUtils;
-import contrib.utils.components.ai.fight.RangeAI;
+import contrib.utils.components.ai.fight.AIRangeBehaviour;
 import core.Entity;
 import core.Game;
 import core.components.PositionComponent;
@@ -266,8 +266,8 @@ public class IllusionRiddleLevel extends DevDungeonLevel {
               mob.fetch(AIComponent.class)
                   .orElseThrow(() -> MissingComponentException.build(mob, AIComponent.class))
                   .fightBehavior();
-          if (fightAI instanceof RangeAI rangeAI) {
-            rangeAI.skill().setLastUsedToNow();
+          if (fightAI instanceof AIRangeBehaviour AIRangeBehaviour) {
+            AIRangeBehaviour.skill().setLastUsedToNow();
           }
         }
       }

--- a/dungeon/src/contrib/components/AIComponent.java
+++ b/dungeon/src/contrib/components/AIComponent.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
  * {@link PatrolWalk}.
  *
  * <p>The {@link #fightBehavior} defines the combat behaviour, e.g. attacking with a fireball skill
- * {@link contrib.utils.components.ai.fight.RangeAI}.
+ * {@link contrib.utils.components.ai.fight.AIRangeBehaviour}.
  *
  * <p>The {@link #shouldFight} defines when the entity goes into fight mode, e.g. if the player is
  * too close to the entity {@link RangeTransition}.

--- a/dungeon/src/contrib/entities/AIFactory.java
+++ b/dungeon/src/contrib/entities/AIFactory.java
@@ -5,7 +5,6 @@ import contrib.components.HealthComponent;
 import contrib.utils.components.ai.fight.AIChaseBehaviour;
 import contrib.utils.components.ai.fight.AIMeleeBehaviour;
 import contrib.utils.components.ai.fight.AIRangeBehaviour;
-import contrib.utils.components.ai.fight.MeleeAI;
 import contrib.utils.components.ai.idle.PatrolWalk;
 import contrib.utils.components.ai.idle.RadiusWalk;
 import contrib.utils.components.ai.idle.StaticRadiusWalk;

--- a/dungeon/src/contrib/entities/AIFactory.java
+++ b/dungeon/src/contrib/entities/AIFactory.java
@@ -4,7 +4,7 @@ import contrib.components.AIComponent;
 import contrib.components.HealthComponent;
 import contrib.utils.components.ai.fight.AIChaseBehaviour;
 import contrib.utils.components.ai.fight.AIMeleeBehaviour;
-import contrib.utils.components.ai.fight.RangeAI;
+import contrib.utils.components.ai.fight.AIRangeBehaviour;
 import contrib.utils.components.ai.idle.PatrolWalk;
 import contrib.utils.components.ai.idle.RadiusWalk;
 import contrib.utils.components.ai.idle.StaticRadiusWalk;
@@ -105,7 +105,7 @@ public final class AIFactory {
     return switch (index) {
       case 0 -> new AIChaseBehaviour(RANDOM.nextFloat(RUSH_RANGE_LOW, RUSH_RANGE_HIGH));
       case 1 ->
-          new RangeAI(
+          new AIRangeBehaviour(
               RANDOM.nextFloat(ATTACK_RANGE_LOW, ATTACK_RANGE_HIGH),
               RANDOM.nextFloat(DISTANCE_LOW, DISTANCE_HIGH),
               new Skill(new FireballSkill(SkillTools::heroPositionAsPoint), FIREBALL_COOL_DOWN));

--- a/dungeon/src/contrib/entities/AIFactory.java
+++ b/dungeon/src/contrib/entities/AIFactory.java
@@ -5,6 +5,7 @@ import contrib.components.HealthComponent;
 import contrib.utils.components.ai.fight.AIChaseBehaviour;
 import contrib.utils.components.ai.fight.AIMeleeBehaviour;
 import contrib.utils.components.ai.fight.AIRangeBehaviour;
+import contrib.utils.components.ai.fight.MeleeAI;
 import contrib.utils.components.ai.idle.PatrolWalk;
 import contrib.utils.components.ai.idle.RadiusWalk;
 import contrib.utils.components.ai.idle.StaticRadiusWalk;

--- a/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
@@ -27,7 +27,6 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
   private final float maxAttackRange;
   private final float minAttackRange;
   private Skill skill;
-  private GraphPath<Tile> path;
 
   /**
    * Attacks the player if he is within the given range between minAttackRange and maxAttackRange.
@@ -72,7 +71,7 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
       .flatMap(Game::positionOf)
       .ifPresent(positionHero ->
         Game.positionOf(entity).ifPresent(positionEntity -> {
-          path = findPathToSafety(entity, positionEntity, positionHero);
+          GraphPath<Tile> path = findPathToSafety(entity, positionEntity, positionHero);
           AIUtils.move(entity, path);
         })
       );
@@ -90,7 +89,7 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
   }
 
   private void moveToHero(Entity entity) {
-    path = LevelUtils.calculatePathToHero(entity);
+    GraphPath<Tile> path = LevelUtils.calculatePathToHero(entity);
     AIUtils.move(entity, path);
   }
 

--- a/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
@@ -92,20 +92,18 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
    */
   private void moveAwayFromHero(Entity entity) {
     Game.hero()
-        .flatMap(Game::positionOf)
-        .ifPresent(
+        .flatMap(Game::positionOf) // Hero-Position
+        .flatMap(
             positionHero ->
                 Game.positionOf(entity)
-                    .ifPresent(
-                        positionEntity -> {
-                          GraphPath<Tile> path =
-                              findPathToSafety(positionEntity, positionHero)
-                                  .orElseGet(
-                                      () ->
-                                          LevelUtils.calculatePathToRandomTileInRange(
-                                              entity, 2 * maxAttackRange));
-                          AIUtils.move(entity, path);
-                        }));
+                    .map(
+                        positionEntity ->
+                            findPathToSafety(positionEntity, positionHero)
+                                .orElseGet(
+                                    () ->
+                                        LevelUtils.calculatePathToRandomTileInRange(
+                                            entity, 2 * maxAttackRange))))
+        .ifPresent(path -> AIUtils.move(entity, path));
   }
 
   /**

--- a/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
@@ -65,17 +65,6 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
   }
 
   /**
-   * Checks if the entity is in range of the hero.
-   *
-   * @param entity The entity to check.
-   * @param radius The radius within which the entity should be considered in range.
-   * @return True if the entity is in range, false otherwise.
-   */
-  private boolean inRange(final Entity entity, final float radius) {
-    return LevelUtils.playerInRange(entity, radius);
-  }
-
-  /**
    * Determines the proximity of the entity to the hero.
    *
    * @param entity The entity to check.
@@ -85,6 +74,17 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
     if (inRange(entity, minAttackRange)) return Proximity.TOO_CLOSE;
     if (inRange(entity, maxAttackRange)) return Proximity.IN_RANGE;
     return Proximity.TOO_FAR;
+  }
+
+  /**
+   * Checks if the entity is in range of the hero.
+   *
+   * @param entity The entity to check.
+   * @param radius The radius within which the entity should be considered in range.
+   * @return True if the entity is in range, false otherwise.
+   */
+  private boolean inRange(final Entity entity, final float radius) {
+    return LevelUtils.playerInRange(entity, radius);
   }
 
   /**

--- a/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
@@ -103,7 +103,7 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
                 Game.positionOf(entity)
                     .map(positionEntity -> escapePath(entity, positionEntity, positionHero)))
         // Move entity if a path is found
-        .ifPresent(path -> AIUtils.move(entity, path));
+        .ifPresent(path -> AIUtils.followPath(entity, path));
   }
 
   /**
@@ -150,7 +150,7 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
    */
   private void moveToHero(Entity entity) {
     GraphPath<Tile> path = LevelUtils.calculatePathToHero(entity);
-    AIUtils.move(entity, path);
+    AIUtils.followPath(entity, path);
   }
 
   @Override

--- a/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
@@ -36,7 +36,8 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
    * @param minAttackRange Minimal distance to hero in which the attack skill should be executed.
    * @param skill Skill to be used when an attack is performed.
    */
-  public AIRangeBehaviour(final float maxAttackRange, final float minAttackRange, final Skill skill) {
+  public AIRangeBehaviour(
+      final float maxAttackRange, final float minAttackRange, final Skill skill) {
     if (maxAttackRange <= minAttackRange || minAttackRange < 0) {
       throw new IllegalArgumentException(
           "maxAttackRange must be greater than minAttackRange and minAttackRange must be 0 or greater than 0");

--- a/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
@@ -86,7 +86,7 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
   }
 
   /**
-   * Moves the entity away from the hero if it is too close.
+   * Moves the entity away from the hero if he is too close.
    *
    * @param entity The entity to move.
    */

--- a/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
@@ -16,9 +16,9 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
- * Implements a fight AI. The entity attacks the player if he is in a given maximum and minimum
- * range. When the entity is not in range but in fight mode, the entity will be moving to within
- * this range.
+* Implements a combat AI. The entity attacks the player if they are within a specified
+* minimum and maximum range. If the entity is in combat mode but the player is out of range,
+* it will move to bring the player within range.
  *
  * @see ISkillUser
  */

--- a/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
@@ -21,7 +21,7 @@ import java.util.function.Consumer;
  *
  * @see ISkillUser
  */
-public final class RangeAI implements Consumer<Entity>, ISkillUser {
+public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
 
   private final float maxAttackRange;
   private final float minAttackRange;
@@ -36,7 +36,7 @@ public final class RangeAI implements Consumer<Entity>, ISkillUser {
    * @param minAttackRange Minimal distance to hero in which the attack skill should be executed.
    * @param skill Skill to be used when an attack is performed.
    */
-  public RangeAI(final float maxAttackRange, final float minAttackRange, final Skill skill) {
+  public AIRangeBehaviour(final float maxAttackRange, final float minAttackRange, final Skill skill) {
     if (maxAttackRange <= minAttackRange || minAttackRange < 0) {
       throw new IllegalArgumentException(
           "attackRange must be greater than distance and distance must be 0 or greater than 0");

--- a/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
@@ -27,31 +27,31 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
   private enum Proximity { TOO_CLOSE, IN_RANGE, TOO_FAR }
   private final float maxAttackRange;
   private final float minAttackRange;
-  private Skill skill;
+  private Skill fightSkill;
 
   /**
    * Attacks the player if he is within the given range between minAttackRange and maxAttackRange.
    * Otherwise, it will move into that range.
    *
-   * @param maxAttackRange Maximal distance to hero in which the attack skill should be executed.
-   * @param minAttackRange Minimal distance to hero in which the attack skill should be executed.
-   * @param skill Skill to be used when an attack is performed.
+   * @param maxAttackRange Maximal distance to hero in which the fightSkill should be executed.
+   * @param minAttackRange Minimal distance to hero in which the fightSkill should be executed.
+   * @param fightSkill Skill to be used when an attack is performed.
    */
   public AIRangeBehaviour(
-      final float maxAttackRange, final float minAttackRange, final Skill skill) {
+      final float maxAttackRange, final float minAttackRange, final Skill fightSkill) {
     if (maxAttackRange <= minAttackRange || minAttackRange < 0) {
       throw new IllegalArgumentException(
           "maxAttackRange must be greater than minAttackRange and minAttackRange must be 0 or greater than 0");
     }
     this.maxAttackRange = maxAttackRange;
     this.minAttackRange = minAttackRange;
-    this.skill = skill;
+    this.fightSkill = fightSkill;
   }
 
   @Override
   public void accept(final Entity entity) {
     switch (proximity(entity)) {
-      case IN_RANGE -> useSkill(skill, entity);
+      case IN_RANGE -> useSkill(fightSkill, entity);
       case TOO_CLOSE -> moveAwayFromHero(entity);
       case TOO_FAR -> moveToHero(entity);
     }
@@ -97,20 +97,20 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
   }
 
   @Override
-  public void useSkill(Skill skill, Entity skillUser) {
-    if (skill == null) {
+  public void useSkill(Skill fightSkill, Entity skillUser) {
+    if (fightSkill == null) {
       return;
     }
-    skill.execute(skillUser);
+    fightSkill.execute(skillUser);
   }
 
   @Override
   public Skill skill() {
-    return this.skill;
+    return this.fightSkill;
   }
 
   @Override
   public void skill(Skill skill) {
-    this.skill = skill;
+    this.fightSkill = skill;
   }
 }

--- a/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
@@ -79,6 +79,33 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
     }
   }
 
+  private void moveAwayFromHero(Entity entity) {
+    Game.hero()
+      .flatMap(Game::positionOf)
+      .ifPresent(positionHero ->
+        Game.positionOf(entity).ifPresent(positionEntity -> {
+          path = findPathToSafety(entity, positionEntity, positionHero);
+          AIUtils.move(entity, path);
+        })
+      );
+  }
+
+  private GraphPath<Tile> findPathToSafety(Entity entity, Point positionEntity, Point positionHero) {
+    List<Tile> tiles = accessibleTilesInRange(positionEntity, maxAttackRange - minAttackRange);
+    for (Tile tile : tiles) {
+      Point positionNew = tile.position();
+      if (!Point.inRange(positionNew, positionHero, minAttackRange)) {
+        return LevelUtils.calculatePath(positionEntity, positionNew);
+      }
+    }
+    return LevelUtils.calculatePathToRandomTileInRange(entity, 2 * maxAttackRange);
+  }
+
+  private void moveToHero(Entity entity) {
+    path = LevelUtils.calculatePathToHero(entity);
+    AIUtils.move(entity, path);
+  }
+
   @Override
   public void useSkill(Skill skill, Entity skillUser) {
     if (skill == null) {

--- a/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
@@ -16,9 +16,9 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
-* Implements a combat AI. The entity attacks the player if they are within a specified
-* minimum and maximum range. If the entity is in combat mode but the player is out of range,
-* it will move to bring the player within range.
+ * Implements a combat AI. The entity attacks the player if they are within a specified minimum and
+ * maximum range. If the entity is in combat mode but the player is out of range, it will move to
+ * bring the player within range.
  *
  * @see ISkillUser
  */
@@ -41,6 +41,8 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
    * @param maxAttackRange Maximal distance to hero in which the fightSkill should be executed.
    * @param minAttackRange Minimal distance to hero in which the fightSkill should be executed.
    * @param fightSkill Skill to be used when an attack is performed.
+   * @throws IllegalArgumentException if maxAttackRange is not greater than minAttackRange or if
+   *     minAttackRange is less than 0.
    */
   public AIRangeBehaviour(
       final float maxAttackRange, final float minAttackRange, final Skill fightSkill) {

--- a/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/AIRangeBehaviour.java
@@ -39,7 +39,7 @@ public class AIRangeBehaviour implements Consumer<Entity>, ISkillUser {
   public AIRangeBehaviour(final float maxAttackRange, final float minAttackRange, final Skill skill) {
     if (maxAttackRange <= minAttackRange || minAttackRange < 0) {
       throw new IllegalArgumentException(
-          "attackRange must be greater than distance and distance must be 0 or greater than 0");
+          "maxAttackRange must be greater than minAttackRange and minAttackRange must be 0 or greater than 0");
     }
     this.maxAttackRange = maxAttackRange;
     this.minAttackRange = minAttackRange;

--- a/dungeon/src/contrib/utils/components/ai/fight/RangeAI.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/RangeAI.java
@@ -23,8 +23,8 @@ import java.util.function.Consumer;
  */
 public final class RangeAI implements Consumer<Entity>, ISkillUser {
 
-  private final float attackRange;
-  private final float distance;
+  private final float maxAttackRange;
+  private final float minAttackRange;
   private Skill skill;
   private GraphPath<Tile> path;
 
@@ -32,41 +32,41 @@ public final class RangeAI implements Consumer<Entity>, ISkillUser {
    * Attacks the player if he is within the given range between attackRange and distance. Otherwise,
    * it will move into that range.
    *
-   * @param attackRange Maximal distance to hero in which the attack skill should be executed.
-   * @param distance Minimal distance to hero in which the attack skill should be executed.
+   * @param maxAttackRange Maximal distance to hero in which the attack skill should be executed.
+   * @param minAttackRange Minimal distance to hero in which the attack skill should be executed.
    * @param skill Skill to be used when an attack is performed.
    */
-  public RangeAI(final float attackRange, final float distance, final Skill skill) {
-    if (attackRange <= distance || distance < 0) {
+  public RangeAI(final float maxAttackRange, final float minAttackRange, final Skill skill) {
+    if (maxAttackRange <= minAttackRange || minAttackRange < 0) {
       throw new IllegalArgumentException(
           "attackRange must be greater than distance and distance must be 0 or greater than 0");
     }
-    this.attackRange = attackRange;
-    this.distance = distance;
+    this.maxAttackRange = maxAttackRange;
+    this.minAttackRange = minAttackRange;
     this.skill = skill;
   }
 
   @Override
   public void accept(final Entity entity) {
-    boolean playerInDistanceRange = LevelUtils.playerInRange(entity, distance);
-    boolean playerInAttackRange = LevelUtils.playerInRange(entity, attackRange);
+    boolean playerInDistanceRange = LevelUtils.playerInRange(entity, minAttackRange);
+    boolean playerInAttackRange = LevelUtils.playerInRange(entity, maxAttackRange);
 
     if (playerInAttackRange) {
       if (playerInDistanceRange) {
         Point positionHero = Game.positionOf(Game.hero().orElseThrow()).orElseThrow();
         Point positionEntity = Game.positionOf(entity).orElseThrow();
-        List<Tile> tiles = accessibleTilesInRange(positionEntity, attackRange - distance);
+        List<Tile> tiles = accessibleTilesInRange(positionEntity, maxAttackRange - minAttackRange);
         boolean newPositionFound = false;
         for (Tile tile : tiles) {
           Point newPosition = tile.position();
-          if (!Point.inRange(newPosition, positionHero, distance)) {
+          if (!Point.inRange(newPosition, positionHero, minAttackRange)) {
             path = LevelUtils.calculatePath(positionEntity, newPosition);
             newPositionFound = true;
             break;
           }
         }
         if (!newPositionFound) {
-          path = LevelUtils.calculatePathToRandomTileInRange(entity, 2 * attackRange);
+          path = LevelUtils.calculatePathToRandomTileInRange(entity, 2 * maxAttackRange);
         }
         AIUtils.followPath(entity, path);
       } else {

--- a/dungeon/src/contrib/utils/components/ai/fight/RangeAI.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/RangeAI.java
@@ -29,8 +29,8 @@ public final class RangeAI implements Consumer<Entity>, ISkillUser {
   private GraphPath<Tile> path;
 
   /**
-   * Attacks the player if he is within the given range between attackRange and distance. Otherwise,
-   * it will move into that range.
+   * Attacks the player if he is within the given range between minAttackRange and maxAttackRange.
+   * Otherwise, it will move into that range.
    *
    * @param maxAttackRange Maximal distance to hero in which the attack skill should be executed.
    * @param minAttackRange Minimal distance to hero in which the attack skill should be executed.

--- a/dungeon/src/contrib/utils/components/ai/fight/RangeAI.java
+++ b/dungeon/src/contrib/utils/components/ai/fight/RangeAI.java
@@ -48,11 +48,11 @@ public final class RangeAI implements Consumer<Entity>, ISkillUser {
 
   @Override
   public void accept(final Entity entity) {
-    boolean playerInDistanceRange = LevelUtils.playerInRange(entity, minAttackRange);
-    boolean playerInAttackRange = LevelUtils.playerInRange(entity, maxAttackRange);
+    boolean playerInMinAttackRange = LevelUtils.playerInRange(entity, minAttackRange);
+    boolean playerInMaxAttackRange = LevelUtils.playerInRange(entity, maxAttackRange);
 
-    if (playerInAttackRange) {
-      if (playerInDistanceRange) {
+    if (playerInMaxAttackRange) {
+      if (playerInMinAttackRange) {
         Point positionHero = Game.positionOf(Game.hero().orElseThrow()).orElseThrow();
         Point positionEntity = Game.positionOf(entity).orElseThrow();
         List<Tile> tiles = accessibleTilesInRange(positionEntity, maxAttackRange - minAttackRange);

--- a/dungeon/src/contrib/utils/components/skill/ISkillUser.java
+++ b/dungeon/src/contrib/utils/components/skill/ISkillUser.java
@@ -7,8 +7,8 @@ import core.Entity;
 /**
  * Interface for skill users. It defines methods to use a skill and to get and set a skill.
  *
- * <p>It is used by the {@link AIMeleeBehaviour MeleeAI} and {@link AIRangeBehaviour RangeAI}
- * classes to use a skill when an attack is performed.
+ * <p>It is used by the {@link AIMeleeBehaviour AIMeleeBehaviour} and {@link AIRangeBehaviour
+ * AIRangeBehaviour} classes to use a skill when an attack is performed.
  */
 public interface ISkillUser {
 

--- a/dungeon/src/contrib/utils/components/skill/ISkillUser.java
+++ b/dungeon/src/contrib/utils/components/skill/ISkillUser.java
@@ -7,9 +7,8 @@ import core.Entity;
 /**
  * Interface for skill users. It defines methods to use a skill and to get and set a skill.
  *
- * <p>It is used by the {@link AIMeleeBehaviour MeleeAI} and {@link
- * AIRangeBehaviour RangeAI} classes to use a skill when an attack is
- * performed.
+ * <p>It is used by the {@link AIMeleeBehaviour MeleeAI} and {@link AIRangeBehaviour RangeAI}
+ * classes to use a skill when an attack is performed.
  */
 public interface ISkillUser {
 

--- a/dungeon/src/contrib/utils/components/skill/ISkillUser.java
+++ b/dungeon/src/contrib/utils/components/skill/ISkillUser.java
@@ -1,13 +1,14 @@
 package contrib.utils.components.skill;
 
 import contrib.utils.components.ai.fight.AIMeleeBehaviour;
+import contrib.utils.components.ai.fight.AIRangeBehaviour;
 import core.Entity;
 
 /**
  * Interface for skill users. It defines methods to use a skill and to get and set a skill.
  *
  * <p>It is used by the {@link AIMeleeBehaviour MeleeAI} and {@link
- * contrib.utils.components.ai.fight.RangeAI RangeAI} classes to use a skill when an attack is
+ * AIRangeBehaviour RangeAI} classes to use a skill when an attack is
  * performed.
  */
 public interface ISkillUser {


### PR DESCRIPTION
Die Klasse hatte folgende Probleme:

- Variablen Namen die Verwirrung erzeugen
- Eine unübersichtliche `accept`-Methode

Ich habe die betroffenen Variablen Namen umbenannt und die `accept`-Methode mithilfe von Helfer Methoden übersichtlicher gestaltet.

Allerdings gibt es nach wie vor ein Logik Problem: Die AI geht nicht auf Abstand, wenn der Spieler (Hero) zu nah kommt.