### PR TITLE
Dungeon: add `StateComponent`

### DIFF
--- a/dungeon/src/contrib/components/StateComponent.java
+++ b/dungeon/src/contrib/components/StateComponent.java
@@ -1,0 +1,74 @@
+package contrib.components;
+
+import core.Component;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A component that allows entities to store and manage arbitrary state values identified by String
+ * keys.
+ *
+ * <p>States are stored as key-value pairs where the key is a String identifier and the value is any
+ * Object.
+ *
+ * <p><b>Usage example:</b>
+ *
+ * <pre>{@code
+ * StateComponent stateComponent = new StateComponent();
+ *
+ * // Add an Integer state with key "score"
+ * stateComponent.add("score", 10);
+ *
+ * // Update the "score" state
+ * stateComponent.add("score", 20);
+ *
+ * // Retrieve the "score" state
+ * stateComponent.value("score").ifPresent(score -> System.out.println("Score: " + score));
+ *
+ * // Remove the "score" state
+ * stateComponent.remove("score");
+ * }</pre>
+ */
+public class StateComponent implements Component {
+  Map<String, Object> states = new HashMap<>();
+
+  /**
+   * Adds or updates the state value for the given id.
+   *
+   * @param id the identifier of the state
+   * @param obj the state value to store
+   */
+  public void add(String id, Object obj) {
+    states.put(id, obj);
+  }
+
+  /**
+   * Removes the state value associated with the given id.
+   *
+   * @param id the identifier of the state to remove
+   */
+  public void remove(String id) {
+    states.remove(id);
+  }
+
+  /**
+   * Checks if a state with the given id exists.
+   *
+   * @param id the identifier of the state
+   * @return true if the state exists, false otherwise
+   */
+  public boolean contains(String id) {
+    return states.containsKey(id);
+  }
+
+  /**
+   * Retrieves the state value associated with the given id.
+   *
+   * @param id the identifier of the state
+   * @return an Optional containing the state value if present, or empty if not found
+   */
+  public Optional<Object> value(String id) {
+    return Optional.ofNullable(states.get(id));
+  }
+}

--- a/dungeon/test/contrib/components/StateComponentTest.java
+++ b/dungeon/test/contrib/components/StateComponentTest.java
@@ -1,0 +1,71 @@
+package contrib.components;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link StateComponent}. */
+class StateComponentTest {
+
+  private StateComponent stateComponent;
+
+  @BeforeEach
+  void setUp() {
+    stateComponent = new StateComponent();
+  }
+
+  /** Tests that a newly added state can be retrieved correctly. */
+  @Test
+  void testAddAndGetValue() {
+    stateComponent.add("score", 10);
+
+    Optional<Object> value = stateComponent.value("score");
+
+    assertTrue(value.isPresent(), "Value should be present after adding");
+    assertEquals(10, value.get(), "Stored value should match the added value");
+  }
+
+  /** Tests that an existing state can be updated by adding a new value with the same key. */
+  @Test
+  void testUpdateValue() {
+    stateComponent.add("score", 10);
+    stateComponent.add("score", 20);
+
+    Optional<Object> value = stateComponent.value("score");
+
+    assertTrue(value.isPresent(), "Value should be present after update");
+    assertEquals(20, value.get(), "Value should be updated to new value");
+  }
+
+  /** Tests that contains() returns true if the state exists, false otherwise. */
+  @Test
+  void testContains() {
+    assertFalse(stateComponent.contains("score"), "Should not contain 'score' initially");
+
+    stateComponent.add("score", 10);
+
+    assertTrue(stateComponent.contains("score"), "Should contain 'score' after adding");
+  }
+
+  /** Tests that remove() deletes the state and it is no longer retrievable or contained. */
+  @Test
+  void testRemove() {
+    stateComponent.add("score", 10);
+    assertTrue(stateComponent.contains("score"), "Should contain 'score' before removal");
+
+    stateComponent.remove("score");
+
+    assertFalse(stateComponent.contains("score"), "Should not contain 'score' after removal");
+    assertTrue(stateComponent.value("score").isEmpty(), "Value should be empty after removal");
+  }
+
+  /** Tests that retrieving a non-existent state returns an empty Optional. */
+  @Test
+  void testGetNonExistentValue() {
+    Optional<Object> value = stateComponent.value("nonexistent");
+
+    assertTrue(value.isEmpty(), "Value should be empty for non-existent key");
+  }
+}


### PR DESCRIPTION
Wir kommen immer mal wieder an Momente, wo wir gerne einen einfachen Wert (z.B wie viele Helden stehen auf der Druckplatte) speichern wollen, aber kein richtigen Platz dafür haben.
Klar kann man für alles ein einzelnes Component implementieren, dieser PR versucht aber einen etwas generischeren Ansatz zu integrieren. 

Das `SateComponent` erlaubt es Objekte/Werte/States (was euch vom Wording besser gefällt) mit einem String Key in einer map abzuspeichern.

