### PR TITLE
Dungeon: refactor ProtectOnApproach for clearer apply() method behavior

### DIFF
--- a/dungeon/src/contrib/utils/components/ai/transition/ProtectOnApproach.java
+++ b/dungeon/src/contrib/utils/components/ai/transition/ProtectOnApproach.java
@@ -29,7 +29,7 @@ public final class ProtectOnApproach implements Function<Entity, Boolean> {
   /**
    * If protecting entity isn't in fight mode yet, check if player is in range of the protected
    * entity.
-   *
+   * Once the entity enters fight mode, it stays in that state permanently.
    * @param entity Entity that is protecting.
    * @return true when the entity is in fight mode, else false.
    */

--- a/dungeon/src/contrib/utils/components/ai/transition/ProtectOnApproach.java
+++ b/dungeon/src/contrib/utils/components/ai/transition/ProtectOnApproach.java
@@ -28,8 +28,8 @@ public final class ProtectOnApproach implements Function<Entity, Boolean> {
 
   /**
    * If protecting entity isn't in fight mode yet, check if player is in range of the protected
-   * entity.
-   * Once the entity enters fight mode, it stays in that state permanently.
+   * entity. Once the entity enters fight mode, it stays in that state permanently.
+   *
    * @param entity Entity that is protecting.
    * @return true when the entity is in fight mode, else false.
    */

--- a/dungeon/src/contrib/utils/components/ai/transition/ProtectOnApproach.java
+++ b/dungeon/src/contrib/utils/components/ai/transition/ProtectOnApproach.java
@@ -35,10 +35,9 @@ public final class ProtectOnApproach implements Function<Entity, Boolean> {
    */
   @Override
   public Boolean apply(final Entity entity) {
-    if (isInFight) return true;
-
-    isInFight = LevelUtils.playerInRange(toProtect, range);
-
+    if (!isInFight) {
+      isInFight = LevelUtils.playerInRange(toProtect, range);
+    }
     return isInFight;
   }
 }


### PR DESCRIPTION
Die Methode prüft, ob der Spieler in der Nähe ist. Wenn das einmal der Fall ist, wird isInFight auf true gesetzt. Die Figur bleibt dann im Kampfmodus – auch wenn der Spieler später wieder weggeht.
Das ist so gewollt und steht jetzt klar in der JavaDoc. Die Methode gibt es nur noch eine Stelle, wo sie endet. Dadurch ist sie besser zu verstehen und leichter zu testen.

