### PR TITLE
vereinfachen: kürzerer Kampf-Check mit direktem Return

### DIFF
--- a/dungeon/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
+++ b/dungeon/src/contrib/utils/components/ai/transition/ProtectOnAttack.java
@@ -54,23 +54,12 @@ public final class ProtectOnAttack implements Function<Entity, Boolean> {
     if (setup) doSetup();
     if (isInFight) return true;
 
-    isInFight =
-        toProtect.stream()
-            .map(
-                toProtect ->
-                    toProtect
-                        .fetch(HealthComponent.class)
-                        .orElseThrow(
-                            () ->
-                                MissingComponentException.build(toProtect, HealthComponent.class)))
-            .anyMatch(
-                toProtect ->
-                    toProtect
-                        .lastDamageCause()
-                        .map(causeEntity -> causeEntity.fetch(PlayerComponent.class))
-                        .isPresent());
-
-    return isInFight;
+    return isInFight = toProtect.stream()
+      .map(e -> e.fetch(HealthComponent.class)
+        .orElseThrow(() -> MissingComponentException.build(e, HealthComponent.class)))
+      .anyMatch(health -> health.lastDamageCause()
+        .flatMap(cause -> cause.fetch(PlayerComponent.class))
+        .isPresent());
   }
 
   private void doSetup() {


### PR DESCRIPTION
Ich habe die Methode, die prüft, ob gerade ein Kampf stattfindet, etwas gekürzt. Statt mehrerer Zeilen nutze ich jetzt einen einzelnen, kurzen Stream. Die Variable isInFight bekommt ihr Ergebnis direkt beim Zurückgeben, ohne vorher noch eine eigene Zuweisung.