### PR TITLE
Dungeon: Make Pressureplates mass related

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -174,6 +174,7 @@ public class Client {
     Game.add(new TintTilesSystem());
     Game.add(new EventScheduler());
     Game.add(new FogSystem());
+    Game.add(new PressurePlateSystem());
     Game.add(
         new System() {
           @Override

--- a/dungeon/src/contrib/components/PressurePlateComponent.java
+++ b/dungeon/src/contrib/components/PressurePlateComponent.java
@@ -3,47 +3,82 @@ package contrib.components;
 import core.Component;
 
 /**
- * A component that allows a pressure plate to track how many entities are currently standing on it.
+ * Component that tracks the total mass currently on a pressure plate.
  *
- * <p>The number of entities currently on the pressure plate can be queried with {@link
- * #standingCount()}, and presence can be checked with {@link #atLeastOne()}.
+ * <p>The pressure plate is considered triggered if the total mass on it meets or exceeds a
+ * configurable mass threshold.
+ *
+ * <p>Mass can be increased or decreased as entities step on or off the plate.
  */
 public class PressurePlateComponent implements Component {
 
-  /** The number of entities currently standing on the pressure plate. */
-  private int standingCount = 0;
+  /** Default mass threshold to trigger the pressure plate. */
+  public static final float DEFAULT_MASS_TRIGGER = 0.1f;
+
+  /** Total mass currently on the pressure plate. */
+  private float currentMass = 0f;
+
+  /** Mass threshold that triggers the pressure plate. */
+  private final float massTrigger;
 
   /**
-   * Increases the standing count by one. Should be called when an entity steps on the pressure
-   * plate.
-   */
-  public void increase() {
-    standingCount++;
-  }
-
-  /**
-   * Decreases the standing count by one, but never below zero. Should be called when an entity
-   * steps off the pressure plate.
-   */
-  public void decrease() {
-    if (standingCount > 0) standingCount--;
-  }
-
-  /**
-   * Returns the current number of entities standing on the pressure plate.
+   * Creates a pressure plate component with a specified mass trigger threshold.
    *
-   * @return the standing count
+   * @param massTrigger the mass threshold to trigger the plate
    */
-  public int standingCount() {
-    return standingCount;
+  public PressurePlateComponent(float massTrigger) {
+    this.massTrigger = massTrigger;
+  }
+
+  /** Creates a pressure plate component with the default mass trigger threshold. */
+  public PressurePlateComponent() {
+    this(DEFAULT_MASS_TRIGGER);
   }
 
   /**
-   * Returns whether at least one entity is standing on the pressure plate.
+   * Adds the specified mass to the pressure plate.
    *
-   * @return {@code true} if one or more entities are on the plate, {@code false} otherwise
+   * @param mass the mass to add when an entity steps onto the plate
    */
-  public boolean atLeastOne() {
-    return standingCount > 0;
+  public void increase(float mass) {
+    currentMass += mass;
+  }
+
+  /**
+   * Removes the specified mass from the pressure plate, never dropping below zero.
+   *
+   * @param mass the mass to remove when an entity steps off the plate
+   */
+  public void decrease(float mass) {
+    currentMass -= mass;
+    if (currentMass < 0f) currentMass = 0f;
+  }
+
+  /**
+   * Returns the total mass currently on the pressure plate.
+   *
+   * @return the current total mass
+   */
+  public float currentMass() {
+    return currentMass;
+  }
+
+  /**
+   * Returns the mass threshold that triggers the pressure plate.
+   *
+   * @return the mass trigger threshold
+   */
+  public float massTrigger() {
+    return massTrigger;
+  }
+
+  /**
+   * Checks whether the pressure plate is currently triggered.
+   *
+   * @return true if the current mass is greater than or equal to the trigger threshold, false
+   *     otherwise
+   */
+  public boolean isTriggered() {
+    return currentMass >= massTrigger;
   }
 }

--- a/dungeon/src/contrib/systems/PressurePlateSystem.java
+++ b/dungeon/src/contrib/systems/PressurePlateSystem.java
@@ -1,0 +1,90 @@
+package contrib.systems;
+
+import contrib.components.LeverComponent;
+import contrib.components.PressurePlateComponent;
+import core.Entity;
+import core.System;
+import core.utils.components.MissingComponentException;
+
+/**
+ * The PressurePlateSystem manages the interaction between pressure plates and levers.
+ *
+ * <p>This system processes all entities that have both {@link PressurePlateComponent} and {@link
+ * LeverComponent}. For each such entity, it checks if the pressure plate is currently triggered
+ * (i.e., the total mass on the plate meets or exceeds the trigger threshold). If triggered and the
+ * lever is off, the lever is toggled on. Conversely, if not triggered and the lever is on, it is
+ * toggled off.
+ *
+ * <p>The logic to accumulate and remove mass on the pressure plate is expected to be handled
+ * elsewhere, for example via collision event handlers.
+ *
+ * @see PressurePlateComponent
+ * @see LeverComponent
+ */
+public class PressurePlateSystem extends System {
+
+  /**
+   * Constructs a new PressurePlateSystem that processes entities with pressure plates and levers.
+   */
+  public PressurePlateSystem() {
+    super(PressurePlateComponent.class, LeverComponent.class);
+  }
+
+  /**
+   * Executes the system logic for all filtered entities.
+   *
+   * <p>For each entity with both pressure plate and lever components, toggles the lever state
+   * according to whether the pressure plate is triggered.
+   */
+  @Override
+  public void execute() {
+    filteredEntityStream().map(this::buildDataObject).forEach(this::handleData);
+  }
+
+  /**
+   * Processes the entity and its components bundled in {@link PPData}. Toggles the lever on if the
+   * pressure plate is triggered and lever is off, and toggles it off if the pressure plate is not
+   * triggered and lever is on.
+   *
+   * @param data the PPData containing the entity and its components
+   */
+  private void handleData(PPData data) {
+    boolean triggered = data.pressurePlate().isTriggered();
+    LeverComponent lever = data.lever();
+
+    if (triggered && !lever.isOn()) {
+      lever.toggle();
+    } else if (!triggered && lever.isOn()) {
+      lever.toggle();
+    }
+  }
+
+  /**
+   * Builds a data record with the entity and its required components. Throws {@link
+   * MissingComponentException} if any component is missing.
+   *
+   * @param e the entity to process
+   * @return a PPData record bundling entity and components
+   */
+  private PPData buildDataObject(Entity e) {
+    PressurePlateComponent pressurePlate =
+        e.fetch(PressurePlateComponent.class)
+            .orElseThrow(() -> MissingComponentException.build(e, PressurePlateComponent.class));
+
+    LeverComponent lever =
+        e.fetch(LeverComponent.class)
+            .orElseThrow(() -> MissingComponentException.build(e, LeverComponent.class));
+
+    return new PPData(e, pressurePlate, lever);
+  }
+
+  /**
+   * Record bundling entity and its components for processing in PressurePlateSystem.
+   *
+   * @param entity the entity
+   * @param pressurePlate the pressure plate component
+   * @param lever the lever component
+   */
+  private record PPData(
+      Entity entity, PressurePlateComponent pressurePlate, LeverComponent lever) {}
+}

--- a/dungeon/test/contrib/components/PressurePlateComponentTest.java
+++ b/dungeon/test/contrib/components/PressurePlateComponentTest.java
@@ -31,6 +31,7 @@ class PressurePlateComponentTest {
   /** Tests that increasing mass adds correctly and may trigger plate if threshold reached. */
   @Test
   void increaseMassIncrementsCurrentMass() {
+    pressurePlate = new PressurePlateComponent(1.0f);
     pressurePlate.increase(0.5f);
     assertEquals(0.5f, pressurePlate.currentMass(), 0.0001f);
     assertFalse(pressurePlate.isTriggered(), "Plate should not trigger below threshold");

--- a/dungeon/test/contrib/components/PressurePlateComponentTest.java
+++ b/dungeon/test/contrib/components/PressurePlateComponentTest.java
@@ -8,109 +8,72 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link PressurePlateComponent}.
  *
- * <p>Tests the correctness of increasing, decreasing, and querying the entity count on a pressure
- * plate.
+ * <p>Tests correctness of increasing, decreasing, and querying the total mass on a pressure plate,
+ * as well as the triggered state based on the mass threshold.
  */
 class PressurePlateComponentTest {
 
   private PressurePlateComponent pressurePlate;
 
-  /** Initializes a new PressurePlateComponent before each test. */
+  /** Initializes a new PressurePlateComponent before each test with default mass trigger. */
   @BeforeEach
   void setUp() {
     pressurePlate = new PressurePlateComponent();
   }
 
-  /** Tests that the initial standing count is zero and atLeastOne() returns false. */
+  /** Tests that initial mass is zero and pressure plate is not triggered. */
   @Test
-  void initialStandingCountIsZero() {
-    assertEquals(0, pressurePlate.standingCount(), "Initial count should be 0");
-    assertFalse(pressurePlate.atLeastOne(), "Initial atLeastOne should be false");
+  void initialMassIsZeroAndNotTriggered() {
+    assertEquals(0f, pressurePlate.currentMass(), 0.0001f, "Initial mass should be 0");
+    assertFalse(pressurePlate.isTriggered(), "Pressure plate should not be triggered initially");
   }
 
-  /**
-   * Tests that calling increase() once increments the standing count to 1 and atLeastOne() returns
-   * true.
-   */
+  /** Tests that increasing mass adds correctly and may trigger plate if threshold reached. */
   @Test
-  void increaseIncrementsCount() {
-    pressurePlate.increase();
-    assertEquals(1, pressurePlate.standingCount());
-    assertTrue(pressurePlate.atLeastOne());
+  void increaseMassIncrementsCurrentMass() {
+    pressurePlate.increase(0.5f);
+    assertEquals(0.5f, pressurePlate.currentMass(), 0.0001f);
+    assertFalse(pressurePlate.isTriggered(), "Plate should not trigger below threshold");
+
+    pressurePlate.increase(0.6f);
+    assertEquals(1.1f, pressurePlate.currentMass(), 0.0001f);
+    assertTrue(pressurePlate.isTriggered(), "Plate should trigger at or above threshold");
   }
 
-  /** Tests that multiple calls to increase() increment the count correctly. */
+  /** Tests that decreasing mass reduces current mass but not below zero. */
   @Test
-  void multipleIncreaseIncrementsCountCorrectly() {
-    pressurePlate.increase();
-    pressurePlate.increase();
-    pressurePlate.increase();
-    assertEquals(3, pressurePlate.standingCount());
-    assertTrue(pressurePlate.atLeastOne());
+  void decreaseMassReducesCurrentMassNotBelowZero() {
+    pressurePlate.increase(1.5f);
+    pressurePlate.decrease(0.4f);
+    assertEquals(1.1f, pressurePlate.currentMass(), 0.0001f);
+
+    pressurePlate.decrease(2f); // Try to decrease more than current mass
+    assertEquals(0f, pressurePlate.currentMass(), 0.0001f, "Mass should not go below zero");
+    assertFalse(pressurePlate.isTriggered(), "Plate should not trigger when mass is zero");
   }
 
-  /** Tests that decrease() reduces the count after increasing it. */
+  /** Tests that isTriggered() reflects correct triggered state based on mass threshold. */
   @Test
-  void decreaseDecrementsCount() {
-    pressurePlate.increase();
-    pressurePlate.increase();
-    pressurePlate.decrease();
-    assertEquals(1, pressurePlate.standingCount());
-    assertTrue(pressurePlate.atLeastOne());
+  void isTriggeredReflectsThresholdCorrectly() {
+    float threshold = pressurePlate.massTrigger();
+
+    pressurePlate.increase(threshold - 0.01f);
+    assertFalse(pressurePlate.isTriggered(), "Just below threshold should not trigger");
+
+    pressurePlate.increase(0.01f);
+    assertTrue(pressurePlate.isTriggered(), "At threshold should trigger");
+
+    pressurePlate.decrease(0.1f);
+    assertFalse(pressurePlate.isTriggered(), "Below threshold after decrease should not trigger");
   }
 
-  /** Tests that the standing count reaches zero and atLeastOne() becomes false. */
+  /** Tests that massTrigger() returns the configured mass threshold. */
   @Test
-  void decreaseToZero() {
-    pressurePlate.increase();
-    pressurePlate.decrease();
-    assertEquals(0, pressurePlate.standingCount());
-    assertFalse(pressurePlate.atLeastOne());
-  }
+  void massTriggerReturnsConfiguredThreshold() {
+    float defaultTrigger = PressurePlateComponent.DEFAULT_MASS_TRIGGER;
+    assertEquals(defaultTrigger, pressurePlate.massTrigger(), 0.0001f);
 
-  /** Tests that calling decrease() when count is already zero keeps it at zero. */
-  @Test
-  void decreaseDoesNotGoBelowZero() {
-    pressurePlate.decrease(); // nothing to decrease
-    assertEquals(0, pressurePlate.standingCount());
-    assertFalse(pressurePlate.atLeastOne());
-  }
-
-  /**
-   * Tests that {@link PressurePlateComponent#atLeastOne()} returns false when no entities are
-   * standing on the pressure plate.
-   */
-  @Test
-  void atLeastOneReturnsFalseWhenZero() {
-    assertFalse(pressurePlate.atLeastOne(), "atLeastOne() should return false when count is zero");
-  }
-
-  /**
-   * Tests that {@link PressurePlateComponent#atLeastOne()} returns true when one or more entities
-   * are standing on the pressure plate.
-   */
-  @Test
-  void atLeastOneReturnsTrueWhenOneOrMore() {
-    pressurePlate.increase();
-    assertTrue(
-        pressurePlate.atLeastOne(), "atLeastOne() should return true when count is one or more");
-
-    pressurePlate.increase();
-    assertTrue(
-        pressurePlate.atLeastOne(),
-        "atLeastOne() should still return true when count is greater than one");
-  }
-
-  /**
-   * Tests that {@link PressurePlateComponent#atLeastOne()} returns false after entities leave and
-   * the count decreases back to zero.
-   */
-  @Test
-  void atLeastOneReturnsFalseAfterDecreaseToZero() {
-    pressurePlate.increase();
-    pressurePlate.decrease();
-    assertFalse(
-        pressurePlate.atLeastOne(),
-        "atLeastOne() should return false after count decreases back to zero");
+    PressurePlateComponent custom = new PressurePlateComponent(5.0f);
+    assertEquals(5.0f, custom.massTrigger(), 0.0001f);
   }
 }

--- a/dungeon/test/contrib/systems/PressurePlateSystemTest.java
+++ b/dungeon/test/contrib/systems/PressurePlateSystemTest.java
@@ -1,0 +1,80 @@
+package contrib.systems;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import contrib.components.LeverComponent;
+import contrib.components.PressurePlateComponent;
+import contrib.utils.ICommand;
+import core.Entity;
+import core.Game;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link PressurePlateSystem}.
+ *
+ * <p>This test verifies that the system correctly updates the state of a {@link LeverComponent}
+ * based on the total mass present on a {@link PressurePlateComponent} attached to the same entity.
+ *
+ * <p>The tests simulate increasing and decreasing mass on the pressure plate and check if the
+ * lever's state changes accordingly after the system executes.
+ */
+public class PressurePlateSystemTest {
+
+  private Entity plate;
+  private PressurePlateSystem system;
+  private PressurePlateComponent plateComponent;
+  private LeverComponent leverComponent;
+
+  @BeforeEach
+  void setUp() {
+    plate = new Entity();
+    plateComponent = new PressurePlateComponent(2.0f); // threshold 2.0
+    leverComponent = new LeverComponent(false, ICommand.NOOP);
+    plate.add(plateComponent);
+    plate.add(leverComponent);
+    system = new PressurePlateSystem();
+    Game.add(plate);
+  }
+
+  @AfterEach
+  void cleanup() {
+    Game.removeAllEntities();
+  }
+
+  /**
+   * Tests that the {@link PressurePlateSystem} properly updates the lever state based on the
+   * pressure plate's total mass.
+   *
+   * <p>Specifically, it verifies that:
+   *
+   * <ul>
+   *   <li>The lever starts off in the "off" state.
+   *   <li>Adding mass below the pressure plate's trigger threshold keeps the lever off.
+   *   <li>Adding enough mass to meet or exceed the threshold turns the lever on.
+   *   <li>Removing mass below the threshold turns the lever back off.
+   * </ul>
+   */
+  @Test
+  void leverStateIsUpdatedBasedOnPressurePlate() {
+    system.execute();
+    assertFalse(leverComponent.isOn(), "Lever should be off initially");
+
+    // Add mass below threshold, lever remains off
+    plateComponent.increase(1.5f);
+    system.execute();
+    assertFalse(leverComponent.isOn(), "Lever should still be off");
+
+    // Add mass to exceed threshold, lever should turn on
+    plateComponent.increase(1.0f);
+    system.execute();
+    assertTrue(leverComponent.isOn(), "Lever should turn on when pressure plate is triggered");
+
+    // Remove mass, lever should turn off again
+    plateComponent.decrease(2.5f); // test floor at zero
+    system.execute();
+    assertFalse(
+        leverComponent.isOn(), "Lever should turn off when pressure plate is not triggered");
+  }
+}


### PR DESCRIPTION
Dieser PR verändert die Druckplatten so, dass sie jetzt mit der aufliegenden Masse agieren.
Im Component kann angegeben werden, ab welchem Wert eine Platte auslösen soll, also quasi wie schwer der Typ (oder die Sammlung an Typen) auf der Platte sein muss, damit sie gedrückt wird.

Das System prüft dann entsprechend und setzt das LeverComponent entsprechend auf an oder aus.

Rechts hat einen Druckwert von 0.1f, das kann Kiste oder Held alleine schaffen, links braucht es beide.
(Hab schlecht gespielt)

https://github.com/user-attachments/assets/fb1dc342-24f6-4853-80e3-8a3cdd8559cf


