### PR TITLE
Dungeon: Folge-PR zu #2275 — Projektweite Minimal-Anpassung an Game.tileAT(...) auf Optional<Tile> (keine Logikänderungen)

### DIFF
--- a/advancedDungeon/src/aiAdvanced/pathfinding/AStarPathFinding.java
+++ b/advancedDungeon/src/aiAdvanced/pathfinding/AStarPathFinding.java
@@ -54,8 +54,8 @@ public class AStarPathFinding extends PathfindingLogic {
    */
   private double heuristicCost(Coordinate from, Coordinate to) {
     // Create temporary Tile objects to use with TileHeuristic
-    Tile fromTile = Game.tileAT(from);
-    Tile toTile = Game.tileAT(to);
+    Tile fromTile = Game.tileAT(from).orElse(null);
+    Tile toTile = Game.tileAT(to).orElse(null);
 
     return heuristic.estimate(fromTile, toTile);
   }

--- a/advancedDungeon/src/aiAdvanced/pathfinding/AStarPathFinding.java
+++ b/advancedDungeon/src/aiAdvanced/pathfinding/AStarPathFinding.java
@@ -141,8 +141,8 @@ public class AStarPathFinding extends PathfindingLogic {
    */
   private double connectionCost(Coordinate from, Coordinate to) {
     // Create temporary Tile objects
-    Tile fromTile = Game.tileAT(from);
-    Tile toTile = Game.tileAT(to);
+    Tile fromTile = Game.tileAT(from).orElse(null);
+    Tile toTile = Game.tileAT(to).orElse(null);
 
     // Create a TileConnection between the tiles and get its cost
     TileConnection connection = new TileConnection(fromTile, toTile);

--- a/advancedDungeon/src/aiAdvanced/pathfinding/AStarPathFinding.java
+++ b/advancedDungeon/src/aiAdvanced/pathfinding/AStarPathFinding.java
@@ -57,7 +57,6 @@ public class AStarPathFinding extends PathfindingLogic {
     Tile fromTile = Game.tileAT(from).orElse(null);
     Tile toTile = Game.tileAT(to).orElse(null);
 
-
     return heuristic.estimate(fromTile, toTile);
   }
 

--- a/advancedDungeon/src/aiAdvanced/pathfinding/AStarPathFinding.java
+++ b/advancedDungeon/src/aiAdvanced/pathfinding/AStarPathFinding.java
@@ -57,6 +57,7 @@ public class AStarPathFinding extends PathfindingLogic {
     Tile fromTile = Game.tileAT(from).orElse(null);
     Tile toTile = Game.tileAT(to).orElse(null);
 
+
     return heuristic.estimate(fromTile, toTile);
   }
 

--- a/advancedDungeon/src/aiAdvanced/pathfinding/PathfindingVisualizer.java
+++ b/advancedDungeon/src/aiAdvanced/pathfinding/PathfindingVisualizer.java
@@ -171,7 +171,7 @@ public class PathfindingVisualizer {
    * @param blockToColor A tuple containing the node and its tile state
    */
   private static void colorTile(Tuple<Coordinate, TileState> blockToColor) {
-    Tile tile = Game.tileAT(blockToColor.a());
+    Tile tile = Game.tileAT(blockToColor.a()).orElse(null);
     if (tile == null) {
       return;
     }

--- a/advancedDungeon/src/produsAdvanced/abstraction/Hero.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/Hero.java
@@ -178,7 +178,7 @@ public class Hero {
    */
   public Berry getBerryAt(Point point) {
     if (point == null) return null;
-    Tile t = Game.tileAT(point);
+    Tile t = Game.tileAT(point).orElse(null);
     if (t == null) return null;
     return (Berry)
         Game.entityAtTile(t)

--- a/advancedDungeon/src/produsAdvanced/abstraction/Hero.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/Hero.java
@@ -215,7 +215,9 @@ public class Hero {
    */
   public void destroyItemAt(Point point) {
     if (point == null) return;
-    Game.entityAtTile(Game.tileAT(point))
+    Tile tile = Game.tileAT(point).orElse(null);
+    if (tile == null) return;
+    Game.entityAtTile(tile)
         .filter(e -> e.isPresent(ItemComponent.class))
         .findFirst()
         .ifPresent(Game::remove);

--- a/advancedDungeon/src/produsAdvanced/level/AdvancedControlLevel3.java
+++ b/advancedDungeon/src/produsAdvanced/level/AdvancedControlLevel3.java
@@ -84,8 +84,8 @@ public class AdvancedControlLevel3 extends AdvancedLevel {
     Game.add(lever1);
     Game.add(lever2);
     Game.add(lever3);
-    door1 = (DoorTile) Game.tileAT(customPoints().get(3));
-    door2 = (DoorTile) Game.tileAT(customPoints().get(4));
+    door1 = (DoorTile) Game.tileAT(customPoints().get(3)).orElse(null);
+    door2 = (DoorTile) Game.tileAT(customPoints().get(4)).orElse(null);
     door1.close();
     door2.close();
     customPoints().remove(0);

--- a/advancedDungeon/src/produsAdvanced/level/ArrayCreateLevel.java
+++ b/advancedDungeon/src/produsAdvanced/level/ArrayCreateLevel.java
@@ -303,14 +303,14 @@ public class ArrayCreateLevel extends AdvancedLevel {
   }
 
   private void closeDoor(Point position) {
-    Tile tile = Game.tileAT(position);
+    Tile tile = Game.tileAT(position).orElse(null);
     if (tile instanceof DoorTile) {
       ((DoorTile) tile).close();
     }
   }
 
   private void openDoor(Point position) {
-    Tile tile = Game.tileAT(position);
+    Tile tile = Game.tileAT(position).orElse(null);
     if (tile instanceof DoorTile) {
       ((DoorTile) tile).open();
     }

--- a/advancedDungeon/src/produsAdvanced/level/ArrayIterateLevel.java
+++ b/advancedDungeon/src/produsAdvanced/level/ArrayIterateLevel.java
@@ -153,14 +153,14 @@ public class ArrayIterateLevel extends AdvancedLevel {
   }
 
   private void closeDoor(Point position) {
-    Tile tile = Game.tileAT(position);
+    Tile tile = Game.tileAT(position).orElse(null);
     if (tile instanceof DoorTile) {
       ((DoorTile) tile).close();
     }
   }
 
   private void openDoor(Point position) {
-    Tile tile = Game.tileAT(position);
+    Tile tile = Game.tileAT(position).orElse(null);
     if (tile instanceof DoorTile) {
       ((DoorTile) tile).open();
     }

--- a/advancedDungeon/src/produsAdvanced/level/ArrayRemoveLevel.java
+++ b/advancedDungeon/src/produsAdvanced/level/ArrayRemoveLevel.java
@@ -305,14 +305,14 @@ public class ArrayRemoveLevel extends AdvancedLevel {
   }
 
   private void closeDoor(Point position) {
-    Tile tile = Game.tileAT(position);
+    Tile tile = Game.tileAT(position).orElse(null);
     if (tile instanceof DoorTile) {
       ((DoorTile) tile).close();
     }
   }
 
   private void openDoor(Point position) {
-    Tile tile = Game.tileAT(position);
+    Tile tile = Game.tileAT(position).orElse(null);
     if (tile instanceof DoorTile) {
       ((DoorTile) tile).open();
     }

--- a/blockly/src/level/produs/Level003.java
+++ b/blockly/src/level/produs/Level003.java
@@ -65,8 +65,11 @@ public class Level003 extends BlocklyLevel {
     Coordinate stone2C = customPoints().get(1);
     Game.add(MiscFactory.stone(stone1C.toCenteredPoint()));
     Game.add(MiscFactory.stone(stone2C.toCenteredPoint()));
-    DoorTile door = (DoorTile) Game.tileAT(new Coordinate(0, 5));
-    door.close();
+
+    Game.tileAT(new Coordinate(0, 5))
+      .filter(t -> t instanceof DoorTile)
+      .map(t -> (DoorTile) t)
+      .ifPresent(DoorTile::close);
   }
 
   @Override

--- a/blockly/src/level/produs/Level003.java
+++ b/blockly/src/level/produs/Level003.java
@@ -67,9 +67,9 @@ public class Level003 extends BlocklyLevel {
     Game.add(MiscFactory.stone(stone2C.toCenteredPoint()));
 
     Game.tileAT(new Coordinate(0, 5))
-      .filter(t -> t instanceof DoorTile)
-      .map(t -> (DoorTile) t)
-      .ifPresent(DoorTile::close);
+        .filter(t -> t instanceof DoorTile)
+        .map(t -> (DoorTile) t)
+        .ifPresent(DoorTile::close);
   }
 
   @Override

--- a/blockly/src/level/produs/Level004.java
+++ b/blockly/src/level/produs/Level004.java
@@ -70,9 +70,9 @@ public class Level004 extends BlocklyLevel {
     LevelManagementUtils.centerHero();
     LevelManagementUtils.heroViewDirection(Direction.RIGHT);
     LevelManagementUtils.zoomDefault();
-    door1 = (DoorTile) Game.tileAT(new Coordinate(8, 3));
+    door1 = (DoorTile) Game.tileAT(new Coordinate(8, 3)).orElse(null);
     door1.close();
-    door2 = (DoorTile) Game.tileAT(new Coordinate(16, 3));
+    door2 = (DoorTile) Game.tileAT(new Coordinate(16, 3)).orElse(null);
     door1.close();
     door2.close();
     Entity s1 = LeverFactory.createLever(customPoints().get(0).toCenteredPoint());

--- a/blockly/src/level/produs/Level006.java
+++ b/blockly/src/level/produs/Level006.java
@@ -84,7 +84,7 @@ public class Level006 extends BlocklyLevel {
     switch2 =
         s2.fetch(LeverComponent.class)
             .orElseThrow(() -> MissingComponentException.build(s2, LeverComponent.class));
-    door = (DoorTile) Game.tileAT(new Coordinate(5, 12));
+    door = (DoorTile) Game.tileAT(new Coordinate(5, 12)).orElse(null);
     door.close();
   }
 

--- a/blockly/src/level/produs/Level007.java
+++ b/blockly/src/level/produs/Level007.java
@@ -90,10 +90,10 @@ public class Level007 extends BlocklyLevel {
     Game.add(s3);
     Game.add(s4);
 
-    door1 = (DoorTile) Game.tileAT(new Coordinate(10, 7));
-    door2 = (DoorTile) Game.tileAT(new Coordinate(4, 7));
-    door3 = (DoorTile) Game.tileAT(new Coordinate(7, 4));
-    door4 = (DoorTile) Game.tileAT(new Coordinate(7, 10));
+    door1 = (DoorTile) Game.tileAT(new Coordinate(10, 7)).orElse(null);
+    door2 = (DoorTile) Game.tileAT(new Coordinate(4, 7)).orElse(null);
+    door3 = (DoorTile) Game.tileAT(new Coordinate(7, 4)).orElse(null);
+    door4 = (DoorTile) Game.tileAT(new Coordinate(7, 10)).orElse(null);
     door1.close();
     door2.close();
     door3.close();

--- a/blockly/src/level/produs/Level008.java
+++ b/blockly/src/level/produs/Level008.java
@@ -99,16 +99,16 @@ public class Level008 extends BlocklyLevel {
     Game.add(s4);
     Game.add(s5);
 
-    door1 = (DoorTile) Game.tileAT(new Coordinate(7, 15));
+    door1 = (DoorTile) Game.tileAT(new Coordinate(7, 15)).orElse(null);
     door1.close();
 
-    door2 = (DoorTile) Game.tileAT(new Coordinate(12, 17));
+    door2 = (DoorTile) Game.tileAT(new Coordinate(12, 17)).orElse(null);
     door2.close();
-    door3 = (DoorTile) Game.tileAT(new Coordinate(12, 12));
+    door3 = (DoorTile) Game.tileAT(new Coordinate(12, 12)).orElse(null);
     door3.close();
-    door4 = (DoorTile) Game.tileAT(new Coordinate(10, 9));
+    door4 = (DoorTile) Game.tileAT(new Coordinate(10, 9)).orElse(null);
     door4.close();
-    door5 = (DoorTile) Game.tileAT(new Coordinate(8, 5));
+    door5 = (DoorTile) Game.tileAT(new Coordinate(8, 5)).orElse(null);
     door5.close();
 
     Game.add(MiscFactory.stone(customPoints().get(0).toCenteredPoint()));

--- a/blockly/src/level/produs/Level011.java
+++ b/blockly/src/level/produs/Level011.java
@@ -115,8 +115,8 @@ public class Level011 extends BlocklyLevel {
             entity -> {
               DialogUtils.showTextPopup("NEEEEEEEEEEEEEEEEIN! ICH WERDE MICH RÄCHEN!", "SIEG!");
             });
-    door1 = (DoorTile) Game.tileAT(new Coordinate(4, 9));
-    door2 = (DoorTile) Game.tileAT(new Coordinate(14, 8));
+    door1 = (DoorTile) Game.tileAT(new Coordinate(4, 9)).orElse(null);
+    door2 = (DoorTile) Game.tileAT(new Coordinate(14, 8)).orElse(null);
     door1.close();
     door2.close();
   }

--- a/blockly/src/level/produs/Level015.java
+++ b/blockly/src/level/produs/Level015.java
@@ -93,7 +93,7 @@ public class Level015 extends BlocklyLevel {
 
     DoorTile[] doors = new DoorTile[coords.length];
     for (int i = 0; i < coords.length; i++) {
-      doors[i] = (DoorTile) Game.tileAT(coords[i]);
+      doors[i] = (DoorTile) Game.tileAT(coords[i]).orElse(null);
     }
 
     for (int i = 0; i < doors.length; i++) {

--- a/blockly/src/level/produs/Level021.java
+++ b/blockly/src/level/produs/Level021.java
@@ -73,7 +73,7 @@ public class Level021 extends BlocklyLevel {
     customPoints()
         .forEach(
             coordinate -> {
-              Tile t = Game.tileAT(coordinate);
+              Tile t = Game.tileAT(coordinate).orElse(null);
               if (t instanceof PitTile pt) {
                 pt.timeToOpen(22000);
                 pt.close();

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -146,9 +146,9 @@ public class BlocklyCommands {
     Tile inDirection;
 
     if (direction == Direction.NONE) {
-      inDirection = Game.tileAT(pc.position());
+      inDirection = Game.tileAT(pc.position()).orElse(null);
     } else {
-      inDirection = Game.tileAT(pc.position(), pc.viewDirection().applyRelative(direction));
+      inDirection = Game.tileAT(pc.position(), pc.viewDirection().applyRelative(direction)).orElse(null);
     }
 
     Game.entityAtTile(inDirection)

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -302,7 +302,7 @@ public class BlocklyCommands {
   public static boolean isNearTile(LevelElement tileElement, final Direction direction) {
     // Check the tile the hero is standing on
     if (direction == Direction.NONE) {
-      Tile checkTile = Game.tileAT(EntityUtils.getHeroCoordinate());
+      Tile checkTile = Game.tileAT(EntityUtils.getHeroCoordinate()).orElse(null);
       return checkTile.levelElement() == tileElement;
     }
     return targetTile(direction).map(tile -> tile.levelElement() == tileElement).orElse(false);

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -386,7 +386,7 @@ public class BlocklyCommands {
         dir ->
             Optional.ofNullable(EntityUtils.getHeroCoordinate())
                 .map(coord -> coord.translate(dir))
-                .map(Game::tileAT);
+                .flatMap(Game::tileAT); // <— statt .map(...)
 
     // calculate direction to check relative to hero's view direction
     return Optional.ofNullable(EntityUtils.getHeroViewDirection())

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -422,7 +422,7 @@ public class BlocklyCommands {
               .fetch(VelocityComponent.class)
               .orElseThrow(() -> MissingComponentException.build(entity, VelocityComponent.class));
 
-      Tile targetTile = Game.tileAT(pc.position(), direction);
+      Tile targetTile = Game.tileAT(pc.position(), direction).orElse(null);
       if (targetTile == null
           || (!targetTile.isAccessible() && !(targetTile instanceof PitTile))
           || Game.entityAtTile(targetTile).anyMatch(e -> e.isPresent(BlockComponent.class))) {
@@ -463,7 +463,7 @@ public class BlocklyCommands {
       ec.vc.currentVelocity(Vector2.ZERO);
       ec.vc.clearForces();
       // check the position-tile via new request in case a new level was loaded
-      Tile endTile = Game.tileAT(ec.pc.position());
+      Tile endTile = Game.tileAT(ec.pc.position()).orElse(null);
       if (endTile != null) ec.pc.position(endTile); // snap to grid
     }
   }

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -79,7 +79,7 @@ public class BlocklyCommands {
     GraphPath<Tile> pathToExit = LevelUtils.calculatePath(pc.coordinate(), exitTile.coordinate());
 
     for (Tile nextTile : pathToExit) {
-      Tile currentTile = Game.tileAT(pc.position());
+      Tile currentTile = Game.tileAT(pc.position()).orElse(null);
       if (currentTile != nextTile) {
         Direction viewDirection = EntityUtils.getViewDirection(hero);
         Direction targetDirection = currentTile.directionTo(nextTile)[0];

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -261,14 +261,14 @@ public class BlocklyCommands {
         hero.fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(hero, PositionComponent.class));
     Direction viewDirection = heroPC.viewDirection();
-    Tile inFront = Game.tileAT(heroPC.position(), viewDirection);
+    Tile inFront = Game.tileAT(heroPC.position(), viewDirection).orElse(null);
     Tile checkTile;
     Direction moveDirection;
     if (push) {
-      checkTile = Game.tileAT(inFront.position(), viewDirection);
+      checkTile = Game.tileAT(inFront.position(), viewDirection).orElse(null);
       moveDirection = viewDirection;
     } else {
-      checkTile = Game.tileAT(heroPC.position(), viewDirection.opposite());
+      checkTile = Game.tileAT(heroPC.position(), viewDirection.opposite()).orElse(null);
       moveDirection = viewDirection.opposite();
     }
     if (!checkTile.isAccessible()

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -171,7 +171,7 @@ public class BlocklyCommands {
     Game.hero()
         .ifPresent(
             hero ->
-                Game.entityAtTile(Game.tileAT(EntityUtils.getHeroCoordinate()))
+                Game.entityAtTile(Game.tileAT(EntityUtils.getHeroCoordinate()).orElse(null))
                     .filter(e -> e.isPresent(BlocklyItemComponent.class))
                     .forEach(
                         item ->

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -148,7 +148,8 @@ public class BlocklyCommands {
     if (direction == Direction.NONE) {
       inDirection = Game.tileAT(pc.position()).orElse(null);
     } else {
-      inDirection = Game.tileAT(pc.position(), pc.viewDirection().applyRelative(direction)).orElse(null);
+      inDirection =
+          Game.tileAT(pc.position(), pc.viewDirection().applyRelative(direction)).orElse(null);
     }
 
     Game.entityAtTile(inDirection)

--- a/blockly/src/utils/BlocklyCommands.java
+++ b/blockly/src/utils/BlocklyCommands.java
@@ -320,7 +320,7 @@ public class BlocklyCommands {
       Class<? extends Component> componentClass, final Direction direction) {
     // Check if there is a component on the tile the hero is standing on
     if (direction == Direction.NONE) {
-      Tile checkTile = Game.tileAT(EntityUtils.getHeroCoordinate());
+      Tile checkTile = Game.tileAT(EntityUtils.getHeroCoordinate()).orElse(null);
       return Game.entityAtTile(checkTile).anyMatch(e -> e.isPresent(componentClass));
     }
     return targetTile(direction)

--- a/devDungeon/src/systems/FogOfWarSystem.java
+++ b/devDungeon/src/systems/FogOfWarSystem.java
@@ -300,7 +300,7 @@ public class FogOfWarSystem extends System {
     revertTilesBackToLight(tilesOutsideView);
 
     List<Tile> visibleTiles = new ArrayList<>();
-    visibleTiles.add(Game.tileAT(heroPos));
+    visibleTiles.add(Game.tileAT(heroPos).orElse(null));
     // Cast light into the surrounding tiles
     for (int octant = 0; octant < 8; octant++) {
       visibleTiles.addAll(

--- a/devDungeon/src/systems/FogOfWarSystem.java
+++ b/devDungeon/src/systems/FogOfWarSystem.java
@@ -163,10 +163,10 @@ public class FogOfWarSystem extends System {
         } else {
           // Our light beam is touching this square; light it
           if (dx * dx + dy * dy < radius * radius) {
-            Tile tile = Game.tileAT(new Point(X, Y));
+            Tile tile = Game.tileAT(new Point(X, Y)).orElse(null);
             visibleTiles.add(tile);
           }
-          Tile tile = Game.tileAT(new Point(X, Y));
+          Tile tile = Game.tileAT(new Point(X, Y)).orElse(null);
           if (tile == null) {
             continue;
           }

--- a/devDungeon/src/systems/FogOfWarSystem.java
+++ b/devDungeon/src/systems/FogOfWarSystem.java
@@ -275,7 +275,7 @@ public class FogOfWarSystem extends System {
           entity
               .fetch(PositionComponent.class)
               .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-      Tile tile = Game.tileAT(pc.position());
+      Tile tile = Game.tileAT(pc.position()).orElse(null);
       if (!darkenedTiles.containsKey(tile) || tile.tintColor() >= HIDE_ENTITY_THRESHOLD) {
         DrawComponent dc =
             entity

--- a/devDungeon/src/utils/EntityUtils.java
+++ b/devDungeon/src/utils/EntityUtils.java
@@ -46,7 +46,7 @@ public class EntityUtils {
    * @see MonsterType
    */
   public static Entity spawnMonster(MonsterType monsterType, Point position) {
-    Tile tile = Game.tileAT(position);
+    Tile tile = Game.tileAT(position).orElse(null);
     if (tile == null || !tile.isAccessible()) {
       LOGGER.warning(
           "Cannot spawn monster at "

--- a/devDungeon/src/utils/EntityUtils.java
+++ b/devDungeon/src/utils/EntityUtils.java
@@ -70,7 +70,7 @@ public class EntityUtils {
    * @see MonsterType
    */
   public static Entity spawnMonster(MonsterType monsterType, Coordinate coordinate) {
-    Tile tile = Game.tileAT(coordinate);
+    Tile tile = Game.tileAT(coordinate).orElse(null);
     if (tile == null || !tile.isAccessible()) {
       LOGGER.warning(
           "Cannot spawn monster at "

--- a/dungeon/src/contrib/components/PathComponent.java
+++ b/dungeon/src/contrib/components/PathComponent.java
@@ -47,7 +47,7 @@ public class PathComponent implements Component {
     }
     this.path = new DefaultGraphPath<>();
     for (Coordinate coordinate : path) {
-      Tile tile = Game.tileAT(coordinate);
+      Tile tile = Game.tileAT(coordinate).orElse(null);
       if (tile == null) {
         throw new IllegalArgumentException("Path contains an invalid coordinate: " + coordinate);
       }

--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -432,7 +432,7 @@ public final class HeroFactory {
       throws MissingComponentException {
     pos = pos.translate(Vector2.of(-0.5f, -0.25f));
 
-    Tile mouseTile = Game.tileAT(pos);
+    Tile mouseTile = Game.tileAT(pos).orElse(null);
     if (mouseTile == null) return Optional.empty();
 
     return Game.entityAtTile(mouseTile)

--- a/dungeon/src/contrib/item/Item.java
+++ b/dungeon/src/contrib/item/Item.java
@@ -8,6 +8,7 @@ import contrib.entities.WorldItemBuilder;
 import contrib.item.concreteItem.*;
 import core.Entity;
 import core.Game;
+import core.level.Tile;
 import core.level.elements.tile.FloorTile;
 import core.utils.Point;
 import core.utils.components.draw.Animation;
@@ -16,8 +17,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.logging.Logger;
-
-import core.level.Tile;
 
 /**
  * Abstract class that represents every item in the game.

--- a/dungeon/src/contrib/item/Item.java
+++ b/dungeon/src/contrib/item/Item.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.logging.Logger;
 
+import core.level.Tile;
+
 /**
  * Abstract class that represents every item in the game.
  *
@@ -288,7 +290,8 @@ public class Item implements CraftingIngredient, CraftingResult {
    * @return Whether the item was dropped successfully.
    */
   public boolean drop(final Point position) {
-    if (Game.tileAT(position) instanceof FloorTile) {
+    Tile tile = Game.tileAT(position).orElse(null);
+    if (tile instanceof FloorTile) {
       Game.add(WorldItemBuilder.buildWorldItem(this, position));
       return true;
     }

--- a/dungeon/src/contrib/systems/BlockSystem.java
+++ b/dungeon/src/contrib/systems/BlockSystem.java
@@ -42,7 +42,7 @@ public final class BlockSystem extends System {
       entity -> {
         BSData data = buildDataObject(entity);
         oldPositions.put(data.pc, data.pc.position());
-        ((DungeonLevel) Game.currentLevel()).removeFromPathfinding(Game.tileAT(data.pc.position())).;
+        ((DungeonLevel) Game.currentLevel()).removeFromPathfinding(Game.tileAT(data.pc.position()).orElse(null));
       };
 
   /** Creates a new BlockSystem. */

--- a/dungeon/src/contrib/systems/BlockSystem.java
+++ b/dungeon/src/contrib/systems/BlockSystem.java
@@ -35,14 +35,14 @@ public final class BlockSystem extends System {
       entity -> {
         BSData data = buildDataObject(entity);
         oldPositions.remove(data.pc);
-        ((DungeonLevel) Game.currentLevel()).addToPathfinding(Game.tileAT(data.pc.position()));
+        ((DungeonLevel) Game.currentLevel()).addToPathfinding(Game.tileAT(data.pc.position()).orElse(null));
       };
 
   private final Consumer<Entity> onAdd =
       entity -> {
         BSData data = buildDataObject(entity);
         oldPositions.put(data.pc, data.pc.position());
-        ((DungeonLevel) Game.currentLevel()).removeFromPathfinding(Game.tileAT(data.pc.position()));
+        ((DungeonLevel) Game.currentLevel()).removeFromPathfinding(Game.tileAT(data.pc.position())).;
       };
 
   /** Creates a new BlockSystem. */

--- a/dungeon/src/contrib/systems/BlockSystem.java
+++ b/dungeon/src/contrib/systems/BlockSystem.java
@@ -35,14 +35,16 @@ public final class BlockSystem extends System {
       entity -> {
         BSData data = buildDataObject(entity);
         oldPositions.remove(data.pc);
-        ((DungeonLevel) Game.currentLevel()).addToPathfinding(Game.tileAT(data.pc.position()).orElse(null));
+        ((DungeonLevel) Game.currentLevel())
+            .addToPathfinding(Game.tileAT(data.pc.position()).orElse(null));
       };
 
   private final Consumer<Entity> onAdd =
       entity -> {
         BSData data = buildDataObject(entity);
         oldPositions.put(data.pc, data.pc.position());
-        ((DungeonLevel) Game.currentLevel()).removeFromPathfinding(Game.tileAT(data.pc.position()).orElse(null));
+        ((DungeonLevel) Game.currentLevel())
+            .removeFromPathfinding(Game.tileAT(data.pc.position()).orElse(null));
       };
 
   /** Creates a new BlockSystem. */

--- a/dungeon/src/contrib/systems/BlockSystem.java
+++ b/dungeon/src/contrib/systems/BlockSystem.java
@@ -77,8 +77,8 @@ public final class BlockSystem extends System {
     Point currentP = data.pc.position();
     Point oldP = oldPositions.get(data.pc);
     if (currentP.equals(oldP)) return;
-    ((DungeonLevel) Game.currentLevel()).addToPathfinding(Game.tileAT(oldP));
-    ((DungeonLevel) Game.currentLevel()).removeFromPathfinding(Game.tileAT(currentP));
+    ((DungeonLevel) Game.currentLevel()).addToPathfinding(Game.tileAT(oldP).orElse(null));
+    ((DungeonLevel) Game.currentLevel()).removeFromPathfinding(Game.tileAT(currentP).orElse(null));
     oldPositions.put(data.pc, currentP);
   }
 

--- a/dungeon/src/contrib/systems/FallingSystem.java
+++ b/dungeon/src/contrib/systems/FallingSystem.java
@@ -51,7 +51,7 @@ public class FallingSystem extends System {
             .fetch(PositionComponent.class)
             .map(PositionComponent::position)
             .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-    Tile currentTile = Game.tileAT(entityPosition);
+    Tile currentTile = Game.tileAT(entityPosition).orElse(null);
     if (currentTile instanceof PitTile pitTile) {
       return pitTile.isOpen();
     }

--- a/dungeon/src/contrib/systems/FogSystem.java
+++ b/dungeon/src/contrib/systems/FogSystem.java
@@ -289,7 +289,7 @@ public class FogSystem extends System {
     revertTilesBackToLight(tilesOutsideView);
 
     List<Tile> visibleTiles = new ArrayList<>();
-    visibleTiles.add(Game.tileAT(heroPos));
+    visibleTiles.add(Game.tileAT(heroPos).orElse(null));
     // Cast light into the surrounding tiles
     for (int octant = 0; octant < 8; octant++) {
       visibleTiles.addAll(

--- a/dungeon/src/contrib/systems/FogSystem.java
+++ b/dungeon/src/contrib/systems/FogSystem.java
@@ -161,10 +161,10 @@ public class FogSystem extends System {
         } else {
           // Our light beam is touching this square; light it
           if (dx * dx + dy * dy < radius * radius) {
-            Tile tile = Game.tileAT(new Point(X, Y));
+            Tile tile = Game.tileAT(new Point(X, Y)).orElse(null);
             visibleTiles.add(tile);
           }
-          Tile tile = Game.tileAT(new Point(X, Y));
+          Tile tile = Game.tileAT(new Point(X, Y)).orElse(null);
           if (tile == null) {
             continue;
           }

--- a/dungeon/src/contrib/systems/FogSystem.java
+++ b/dungeon/src/contrib/systems/FogSystem.java
@@ -264,7 +264,7 @@ public class FogSystem extends System {
           entity
               .fetch(PositionComponent.class)
               .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-      Tile tile = Game.tileAT(pc.position());
+      Tile tile = Game.tileAT(pc.position()).orElse(null);
       if (!darkenedTiles.containsKey(tile) || tile.tintColor() >= HIDE_ENTITY_THRESHOLD) {
         DrawComponent dc =
             entity

--- a/dungeon/src/contrib/systems/PitSystem.java
+++ b/dungeon/src/contrib/systems/PitSystem.java
@@ -43,7 +43,7 @@ public class PitSystem extends System {
         .forEach(
             entity -> {
               PositionComponent positionComponent = getPositionComponent(entity);
-              Tile currentTile = Game.tileAT(positionComponent.position());
+              Tile currentTile = Game.tileAT(positionComponent.position()).orElse(null);
 
               if (currentTile instanceof PitTile pitTile) {
                 // camera focus point entity should not trigger pit

--- a/dungeon/src/contrib/utils/LevelUtils.java
+++ b/dungeon/src/contrib/utils/LevelUtils.java
@@ -47,7 +47,7 @@ public class LevelUtils {
    * @return true if the tile at the given coordinate is accessible, false otherwise.
    */
   public static boolean isWalkable(Coordinate coord) {
-    Tile tile = Game.tileAT(coord);
+    Tile tile = Game.tileAT(coord).orElse(null);
     return tile != null && tile.isAccessible();
   }
 

--- a/dungeon/src/contrib/utils/components/Debugger.java
+++ b/dungeon/src/contrib/utils/components/Debugger.java
@@ -125,7 +125,7 @@ public class Debugger {
 
       // Attempt to teleport to targetLocation
       LOGGER.log(CustomLogLevel.DEBUG, "Trying to teleport to " + targetLocation);
-      Tile t = Game.tileAT(targetLocation);
+      Tile t = Game.tileAT(targetLocation).orElse(null);
       if (t == null || !t.isAccessible()) {
         LOGGER.info("Cannot teleport to non-existing or non-accessible tile");
         return;

--- a/dungeon/src/contrib/utils/components/Debugger.java
+++ b/dungeon/src/contrib/utils/components/Debugger.java
@@ -151,7 +151,7 @@ public class Debugger {
     // Get the tile at the given position
     Tile tile = null;
     try {
-      tile = Game.tileAT(position);
+      tile = Game.tileAT(position).orElse(null);
     } catch (NullPointerException ex) {
       LOGGER.info(ex.getMessage());
     }

--- a/dungeon/src/contrib/utils/components/Debugger.java
+++ b/dungeon/src/contrib/utils/components/Debugger.java
@@ -78,7 +78,7 @@ public class Debugger {
                 endTile.translate(Direction.RIGHT),
               };
               for (Coordinate neighborTile : neighborTiles) {
-                Tile neighbor = Game.tileAT(neighborTile);
+                Tile neighbor = Game.tileAT(neighborTile).orElse(null);
                 if (neighbor.isAccessible()) {
                   TELEPORT(neighbor);
                   return;

--- a/dungeon/src/contrib/utils/components/ai/AIUtils.java
+++ b/dungeon/src/contrib/utils/components/ai/AIUtils.java
@@ -34,7 +34,7 @@ public final class AIUtils {
         entity
             .fetch(VelocityComponent.class)
             .orElseThrow(() -> MissingComponentException.build(entity, VelocityComponent.class));
-    Tile currentTile = Game.tileAT(pc.position());
+    Tile currentTile = Game.tileAT(pc.position()).orElse(null);
     int i = 0;
     Tile nextTile = null;
     while (nextTile == null && i < path.getCount()) {

--- a/dungeon/src/contrib/utils/components/ai/AIUtils.java
+++ b/dungeon/src/contrib/utils/components/ai/AIUtils.java
@@ -94,7 +94,7 @@ public final class AIUtils {
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
     boolean onPath = false;
-    Tile currentTile = Game.tileAT(pc.position());
+    Tile currentTile = Game.tileAT(pc.position()).orElse(null);
     for (Tile tile : path) {
       if (currentTile == tile) {
         onPath = true;

--- a/dungeon/src/contrib/utils/components/ai/AIUtils.java
+++ b/dungeon/src/contrib/utils/components/ai/AIUtils.java
@@ -78,7 +78,7 @@ public final class AIUtils {
         entity
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-    return path.getCount() == 0 || LevelUtils.lastTile(path).equals(Game.tileAT(pc.position()));
+    return path.getCount() == 0 || LevelUtils.lastTile(path).equals(Game.tileAT(pc.position()).orElse(null));
   }
 
   /**

--- a/dungeon/src/contrib/utils/components/ai/AIUtils.java
+++ b/dungeon/src/contrib/utils/components/ai/AIUtils.java
@@ -78,7 +78,8 @@ public final class AIUtils {
         entity
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-    return path.getCount() == 0 || LevelUtils.lastTile(path).equals(Game.tileAT(pc.position()).orElse(null));
+    return path.getCount() == 0
+        || LevelUtils.lastTile(path).equals(Game.tileAT(pc.position()).orElse(null));
   }
 
   /**

--- a/dungeon/src/contrib/utils/components/ai/idle/PatrolWalk.java
+++ b/dungeon/src/contrib/utils/components/ai/idle/PatrolWalk.java
@@ -9,7 +9,6 @@ import core.level.Tile;
 import core.level.utils.LevelUtils;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -19,18 +18,19 @@ import java.util.function.Consumer;
 /**
  * Implements an idle AI behavior allowing an entity to patrol between tiles on a map.
  *
- * <p>
- * The patrol area is determined by a circular radius around the entity's current position.
- * At initialization, a set of unique, accessible checkpoints is selected within this radius.
- * The entity then moves between these checkpoints using one of the following patrol modes:
- * <ul>
- *   <li>{@code RANDOM}: Move to a randomly chosen checkpoint each time.</li>
- *   <li>{@code LOOP}: Move sequentially through all checkpoints and repeat from the beginning.</li>
- *   <li>{@code BACK_AND_FORTH}: Move forward through the list, then reverse direction upon reaching the end.</li>
- * </ul>
- * <p>
+ * <p>The patrol area is determined by a circular radius around the entity's current position. At
+ * initialization, a set of unique, accessible checkpoints is selected within this radius. The
+ * entity then moves between these checkpoints using one of the following patrol modes:
  *
- * The AI also includes a configurable pause time at each checkpoint before proceeding to the next.
+ * <ul>
+ *   <li>{@code RANDOM}: Move to a randomly chosen checkpoint each time.
+ *   <li>{@code LOOP}: Move sequentially through all checkpoints and repeat from the beginning.
+ *   <li>{@code BACK_AND_FORTH}: Move forward through the list, then reverse direction upon reaching
+ *       the end.
+ * </ul>
+ *
+ * <p>The AI also includes a configurable pause time at each checkpoint before proceeding to the
+ * next.
  */
 public final class PatrolWalk implements Consumer<Entity> {
 
@@ -50,17 +50,16 @@ public final class PatrolWalk implements Consumer<Entity> {
   /**
    * Constructs a new PatrolWalk behavior instance.
    *
-   * <p>This idle AI behavior moves an entity between a set of accessible checkpoints
-   * within a defined radius around its initial position. The movement pattern depends
-   * on the selected patrol mode and includes a randomized pause at each checkpoint.
+   * <p>This idle AI behavior moves an entity between a set of accessible checkpoints within a
+   * defined radius around its initial position. The movement pattern depends on the selected patrol
+   * mode and includes a randomized pause at each checkpoint.
    *
-   * @param radius            The maximum distance (in tiles) from the entity's position
-   *                          used to select accessible checkpoint tiles.
+   * @param radius The maximum distance (in tiles) from the entity's position used to select
+   *     accessible checkpoint tiles.
    * @param numberCheckpoints The number of unique checkpoints to generate within the radius.
-   * @param pauseTimeMillis   The maximum wait time (in milliseconds) at each checkpoint.
-   *                          The actual pause duration is randomly selected between 0 and this value.
-   * @param mode              The patrol mode defining the movement pattern
-   *                          (e.g., RANDOM, LOOP, BACK_AND_FORTH).
+   * @param pauseTimeMillis The maximum wait time (in milliseconds) at each checkpoint. The actual
+   *     pause duration is randomly selected between 0 and this value.
+   * @param mode The patrol mode defining the movement pattern (e.g., RANDOM, LOOP, BACK_AND_FORTH).
    */
   public PatrolWalk(float radius, int numberCheckpoints, int pauseTimeMillis, final MODE mode) {
     this.radius = radius;
@@ -72,9 +71,9 @@ public final class PatrolWalk implements Consumer<Entity> {
   /**
    * Initializes a list of accessible patrol checkpoints around the entity’s current position.
    *
-   * <p>This method attempts to retrieve the PositionComponent of the entity.
-   * It checks whether the entity is standing on a valid tile, collects accessible tiles
-   * within a defined radius, and randomly selects unique patrol checkpoints.
+   * <p>This method attempts to retrieve the PositionComponent of the entity. It checks whether the
+   * entity is standing on a valid tile, collects accessible tiles within a defined radius, and
+   * randomly selects unique patrol checkpoints.
    *
    * @param entity The entity around whose position patrol checkpoints are generated.
    * @return {@code true} if at least one valid checkpoint was found, {@code false} otherwise.
@@ -85,8 +84,10 @@ public final class PatrolWalk implements Consumer<Entity> {
     initialized = true;
 
     // Retrieve position of the entity
-    PositionComponent position = entity.fetch(PositionComponent.class)
-      .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
+    PositionComponent position =
+        entity
+            .fetch(PositionComponent.class)
+            .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
     Point center = position.position(); // Current position as Point(x, y)
 
     // Get the tile under the entity (may be empty if outside level)
@@ -100,8 +101,8 @@ public final class PatrolWalk implements Consumer<Entity> {
     // Randomly select unique tiles as patrol checkpoints
     int maxTries = 0;
     while (checkpoints.size() < numberCheckpoints
-      && accessibleTiles.size() != checkpoints.size()
-      && maxTries < 1000) {
+        && accessibleTiles.size() != checkpoints.size()
+        && maxTries < 1000) {
 
       // Pick a random tile from accessible candidates
       Tile t = accessibleTiles.get(RANDOM.nextInt(accessibleTiles.size()));
@@ -171,14 +172,15 @@ public final class PatrolWalk implements Consumer<Entity> {
    * @return The PositionComponent.
    */
   private PositionComponent getPositionComponent(Entity entity) {
-    return entity.fetch(PositionComponent.class)
-      .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
+    return entity
+        .fetch(PositionComponent.class)
+        .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
   }
 
   /**
    * Handles the current path if it's still in progress.
    *
-   * @param entity   The entity moving along the path.
+   * @param entity The entity moving along the path.
    * @param position The entity's position component.
    * @return true if the entity is currently moving on a path.
    */
@@ -228,13 +230,14 @@ public final class PatrolWalk implements Consumer<Entity> {
   /**
    * Updates the path if the entity has deviated from it.
    *
-   * @param entity   The target entity.
+   * @param entity The target entity.
    * @param position The current position component of the entity.
    */
   private void updatePathIfRequired(Entity entity, PositionComponent position) {
     if (AIUtils.pathLeft(entity, currentPath)) {
-      currentPath = LevelUtils.calculatePath(
-        position.position(), checkpoints.get(currentCheckpoint).position());
+      currentPath =
+          LevelUtils.calculatePath(
+              position.position(), checkpoints.get(currentCheckpoint).position());
     }
   }
 
@@ -260,13 +263,14 @@ public final class PatrolWalk implements Consumer<Entity> {
       case BACK_AND_FORTH -> updateCheckpointBackAndForth();
     }
 
-    currentPath = LevelUtils.calculatePath(
-      position.position(), checkpoints.get(currentCheckpoint).position());
+    currentPath =
+        LevelUtils.calculatePath(
+            position.position(), checkpoints.get(currentCheckpoint).position());
   }
 
   /**
-   * Updates the checkpoint index for BACK_AND_FORTH mode.
-   * Reverses direction when reaching either end of the checkpoint list.
+   * Updates the checkpoint index for BACK_AND_FORTH mode. Reverses direction when reaching either
+   * end of the checkpoint list.
    */
   private void updateCheckpointBackAndForth() {
     if (forward) {
@@ -284,9 +288,7 @@ public final class PatrolWalk implements Consumer<Entity> {
     }
   }
 
-  /**
-   * Enum representing the patrol mode to use when selecting the next checkpoint.
-   */
+  /** Enum representing the patrol mode to use when selecting the next checkpoint. */
   public enum MODE {
     /** Select a random checkpoint. */
     RANDOM,

--- a/dungeon/src/contrib/utils/components/ai/idle/PatrolWalk.java
+++ b/dungeon/src/contrib/utils/components/ai/idle/PatrolWalk.java
@@ -9,16 +9,26 @@ import core.level.Tile;
 import core.level.utils.LevelUtils;
 import core.utils.Point;
 import core.utils.components.MissingComponentException;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.function.Consumer;
 
 /**
- * Implements an idle AI that lets the entity walk a specific path.
- *
- * <p>There are different modes. The entity can walk to random checkpoints, looping the same path or
- * walking the path back and forth.
+ * Implements an idle AI behavior allowing an entity to patrol between tiles on a map.
+ * <p>
+ * The patrol area is determined by a circular radius around the entity's current position.
+ * At initialization, a set of unique, accessible checkpoints is selected within this radius.
+ * The entity then moves between these checkpoints using one of the following patrol modes:
+ * <ul>
+ *   <li>{@code RANDOM}: Move to a randomly chosen checkpoint each time.</li>
+ *   <li>{@code LOOP}: Move sequentially through all checkpoints and repeat from the beginning.</li>
+ *   <li>{@code BACK_AND_FORTH}: Move forward through the list, then reverse direction upon reaching the end.</li>
+ * </ul>
+ * <p>
+ * The AI also includes a configurable pause time at each checkpoint before proceeding to the next.
  */
 public final class PatrolWalk implements Consumer<Entity> {
 
@@ -28,6 +38,7 @@ public final class PatrolWalk implements Consumer<Entity> {
   private final int pauseFrames;
   private final float radius;
   private final MODE mode;
+
   private GraphPath<Tile> currentPath;
   private boolean initialized = false;
   private boolean forward = true;
@@ -35,136 +46,253 @@ public final class PatrolWalk implements Consumer<Entity> {
   private int currentCheckpoint = 0;
 
   /**
-   * WTF? (erster Satz kurze Beschreibung) .
+   * Constructs a new PatrolWalk behavior instance.
    *
-   * <p>Walks a random pattern in a radius around the entity. The checkpoints will be chosen
-   * randomly at first idle. After being initialized, the checkpoints won't change anymore, only the
-   * order may be.
+   * <p>This idle AI behavior moves an entity between a set of accessible checkpoints
+   * within a defined radius around its initial position. The movement pattern depends
+   * on the selected patrol mode and includes a randomized pause at each checkpoint.
    *
-   * @param radius Max distance from the entity to walk.
-   * @param numberCheckpoints Number of checkpoints to walk to.
-   * @param pauseTime Max time in milliseconds to wait on a checkpoint. The actual time is a random
-   *     number between 0 and this value.
-   * @param mode WTF? .
+   * @param radius            The maximum distance (in tiles) from the entity's position
+   *                          used to select accessible checkpoint tiles.
+   * @param numberCheckpoints The number of unique checkpoints to generate within the radius.
+   * @param pauseTimeMillis   The maximum wait time (in milliseconds) at each checkpoint.
+   *                          The actual pause duration is randomly selected between 0 and this value.
+   * @param mode              The patrol mode defining the movement pattern
+   *                          (e.g., RANDOM, LOOP, BACK_AND_FORTH).
    */
-  public PatrolWalk(float radius, int numberCheckpoints, int pauseTime, final MODE mode) {
+  public PatrolWalk(float radius, int numberCheckpoints, int pauseTimeMillis, final MODE mode) {
     this.radius = radius;
     this.numberCheckpoints = numberCheckpoints;
-    this.pauseFrames = pauseTime / (1000 / Game.frameRate());
+    this.pauseFrames = pauseTimeMillis / (1000 / Game.frameRate());
     this.mode = mode;
   }
 
-  private void init(final Entity entity) {
+  /**
+   * Initializes a list of accessible patrol checkpoints around the entity’s current position.
+   *
+   * <p>This method attempts to retrieve the PositionComponent of the entity.
+   * It checks whether the entity is standing on a valid tile, collects accessible tiles
+   * within a defined radius, and randomly selects unique patrol checkpoints.
+   *
+   * @param entity The entity around whose position patrol checkpoints are generated.
+   * @return {@code true} if at least one valid checkpoint was found, {@code false} otherwise.
+   * @throws MissingComponentException if the PositionComponent is missing from the entity.
+   */
+  private boolean initializeCheckpoints(final Entity entity) {
+    // Mark initialization as started to avoid re-initializing later
     initialized = true;
-    PositionComponent position =
-        entity
-            .fetch(PositionComponent.class)
-            .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-    Point center = position.position();
-    Tile tile = Game.tileAT(position.position());
 
-    if (tile == null) {
-      return;
-    }
+    // Retrieve position of the entity
+    PositionComponent position = entity.fetch(PositionComponent.class)
+      .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
+    Point center = position.position(); // Current position as Point(x, y)
 
+    // Get the tile under the entity (may be empty if outside level)
+    Optional<Tile> tileOpt = Game.tileAT(center);
+    if (tileOpt.isEmpty()) return false; // Abort if entity stands on invalid tile
+
+    // Get all accessible tiles around the position within a certain radius
     List<Tile> accessibleTiles = LevelUtils.accessibleTilesInRange(center, radius);
+    if (accessibleTiles.isEmpty()) return false; // Abort if nothing reachable
 
-    if (accessibleTiles.isEmpty()) {
-      return;
-    }
-
+    // Randomly select unique tiles as patrol checkpoints
     int maxTries = 0;
-    while (this.checkpoints.size() < numberCheckpoints
-        || accessibleTiles.size() == this.checkpoints.size()
-        || maxTries >= 1000) {
+    while (checkpoints.size() < numberCheckpoints
+      && accessibleTiles.size() != checkpoints.size()
+      && maxTries < 1000) {
+
+      // Pick a random tile from accessible candidates
       Tile t = accessibleTiles.get(RANDOM.nextInt(accessibleTiles.size()));
-      if (!this.checkpoints.contains(t)) {
-        this.checkpoints.add(t);
+
+      // Only add it if not already part of the list (unique checkpoints)
+      if (!checkpoints.contains(t)) {
+        checkpoints.add(t);
       }
-      maxTries++;
+
+      maxTries++; // Prevent infinite loops
     }
+
+    // Success if at least one checkpoint was found
+    return true;
   }
 
+  /**
+   * Executes the AI behavior for a given entity. Handles initialization, movement along a path,
+   * waiting at a checkpoint, and selecting the next destination based on patrol mode.
+   *
+   * @param entity The entity for which the behavior is performed.
+   */
   @Override
   public void accept(final Entity entity) {
-    if (!initialized) this.init(entity);
-    if (this.checkpoints.isEmpty()) {
+    if (!initializeIfNeeded(entity) || !hasValidCheckpoints()) return;
+
+    PositionComponent position = getPositionComponent(entity);
+
+    if (handleOngoingPath(entity, position)) return;
+    if (handleFinishedPath(entity)) return;
+    if (handleCheckpointWait()) return;
+
+    frameCounter = -1;
+    advanceToNextCheckpoint(position);
+  }
+
+  /**
+   * Ensures checkpoints are initialized if not yet initialized.
+   *
+   * @param entity The entity used to initialize the checkpoints.
+   * @return true if initialization succeeded or already completed.
+   */
+  private boolean initializeIfNeeded(Entity entity) {
+    if (!initialized) {
+      initialized = initializeCheckpoints(entity);
+    }
+    return initialized;
+  }
+
+  /**
+   * Checks whether valid checkpoints are available.
+   *
+   * @return true if at least one checkpoint is available.
+   */
+  private boolean hasValidCheckpoints() {
+    if (checkpoints.isEmpty()) {
       initialized = false;
-      return;
+      return false;
     }
-    PositionComponent position =
-        entity
-            .fetch(PositionComponent.class)
-            .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
+    return true;
+  }
 
-    if (currentPath != null && !AIUtils.pathFinished(entity, currentPath)) {
-      if (AIUtils.pathLeft(entity, currentPath)) {
-        currentPath =
-            LevelUtils.calculatePath(
-                position.position(), this.checkpoints.get(currentCheckpoint).position());
-      }
+  /**
+   * Retrieves the PositionComponent of an entity.
+   *
+   * @param entity The target entity.
+   * @return The PositionComponent.
+   */
+  private PositionComponent getPositionComponent(Entity entity) {
+    return entity.fetch(PositionComponent.class)
+      .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
+  }
+
+  /**
+   * Handles the current path if it's still in progress.
+   *
+   * @param entity   The entity moving along the path.
+   * @param position The entity's position component.
+   * @return true if the entity is currently moving on a path.
+   */
+  private boolean handleOngoingPath(Entity entity, PositionComponent position) {
+    if (isPathInProgress(entity)) {
+      updatePathIfRequired(entity, position);
       AIUtils.move(entity, currentPath);
-      return;
+      return true;
     }
+    return false;
+  }
 
-    if (currentPath != null && AIUtils.pathFinished(entity, currentPath)) {
+  /**
+   * Handles actions when the current path has just been completed.
+   *
+   * @param entity The target entity.
+   * @return true if path was completed and pause is initiated.
+   */
+  private boolean handleFinishedPath(Entity entity) {
+    if (pathJustFinished(entity)) {
       frameCounter = 0;
       currentPath = null;
-      return;
+      return true;
     }
+    return false;
+  }
 
-    if (frameCounter++ < pauseFrames && frameCounter != -1) {
-      return;
-    }
+  /**
+   * Determines whether the entity should wait at a checkpoint.
+   *
+   * @return true if the entity is still within the waiting time.
+   */
+  private boolean handleCheckpointWait() {
+    return frameCounter++ < pauseFrames && frameCounter != -1;
+  }
 
-    // HERE: (Path to checkpoint finished + pause time over) OR currentPath = null
-    this.frameCounter = -1;
+  /**
+   * Checks if the entity is still on the current path.
+   *
+   * @param entity The entity to evaluate.
+   * @return true if path is still in progress.
+   */
+  private boolean isPathInProgress(Entity entity) {
+    return currentPath != null && !AIUtils.pathFinished(entity, currentPath);
+  }
 
-    switch (mode) {
-      case RANDOM -> {
-        Random rnd = new Random();
-        currentCheckpoint = rnd.nextInt(checkpoints.size());
-        currentPath =
-            LevelUtils.calculatePath(
-                position.position(), this.checkpoints.get(currentCheckpoint).position());
-      }
-      case LOOP -> {
-        currentCheckpoint = (currentCheckpoint + 1) % checkpoints.size();
-        currentPath =
-            LevelUtils.calculatePath(
-                position.position(), this.checkpoints.get(currentCheckpoint).position());
-      }
-      case BACK_AND_FORTH -> {
-        if (forward) {
-          currentCheckpoint += 1;
-          if (currentCheckpoint == checkpoints.size()) {
-            forward = false;
-            currentCheckpoint = checkpoints.size() - 2;
-          }
-        } else {
-          currentCheckpoint -= 1;
-          if (currentCheckpoint == -1) {
-            forward = true;
-            currentCheckpoint = 1;
-          }
-        }
-        currentPath =
-            LevelUtils.calculatePath(
-                position.position(), this.checkpoints.get(currentCheckpoint).position());
-      }
-      default -> {}
+  /**
+   * Updates the path if the entity has deviated from it.
+   *
+   * @param entity   The target entity.
+   * @param position The current position component of the entity.
+   */
+  private void updatePathIfRequired(Entity entity, PositionComponent position) {
+    if (AIUtils.pathLeft(entity, currentPath)) {
+      currentPath = LevelUtils.calculatePath(
+        position.position(), checkpoints.get(currentCheckpoint).position());
     }
   }
 
-  /** WTF? . */
+  /**
+   * Checks whether the entity has just completed a path.
+   *
+   * @param entity The target entity.
+   * @return true if path is completed.
+   */
+  private boolean pathJustFinished(Entity entity) {
+    return currentPath != null && AIUtils.pathFinished(entity, currentPath);
+  }
+
+  /**
+   * Determines the next checkpoint based on patrol mode and calculates a path to it.
+   *
+   * @param position The current position component of the entity.
+   */
+  private void advanceToNextCheckpoint(PositionComponent position) {
+    switch (mode) {
+      case RANDOM -> currentCheckpoint = RANDOM.nextInt(checkpoints.size());
+      case LOOP -> currentCheckpoint = (currentCheckpoint + 1) % checkpoints.size();
+      case BACK_AND_FORTH -> updateCheckpointBackAndForth();
+    }
+
+    currentPath = LevelUtils.calculatePath(
+      position.position(), checkpoints.get(currentCheckpoint).position());
+  }
+
+  /**
+   * Updates the checkpoint index for BACK_AND_FORTH mode.
+   * Reverses direction when reaching either end of the checkpoint list.
+   */
+  private void updateCheckpointBackAndForth() {
+    if (forward) {
+      currentCheckpoint++;
+      if (currentCheckpoint == checkpoints.size()) {
+        forward = false;
+        currentCheckpoint = checkpoints.size() - 2;
+      }
+    } else {
+      currentCheckpoint--;
+      if (currentCheckpoint == -1) {
+        forward = true;
+        currentCheckpoint = 1;
+      }
+    }
+  }
+
+  /**
+   * Enum representing the patrol mode to use when selecting the next checkpoint.
+   */
   public enum MODE {
-    /** Walks to a random checkpoint. */
+    /** Select a random checkpoint. */
     RANDOM,
 
-    /** Looping the same path over and over again. */
+    /** Cycle through checkpoints sequentially. */
     LOOP,
 
-    /** Walks the path forward and then backward. */
+    /** Move forward through checkpoints and then reverse back. */
     BACK_AND_FORTH
   }
 }

--- a/dungeon/src/contrib/utils/components/ai/idle/PatrolWalk.java
+++ b/dungeon/src/contrib/utils/components/ai/idle/PatrolWalk.java
@@ -18,6 +18,7 @@ import java.util.function.Consumer;
 
 /**
  * Implements an idle AI behavior allowing an entity to patrol between tiles on a map.
+ *
  * <p>
  * The patrol area is determined by a circular radius around the entity's current position.
  * At initialization, a set of unique, accessible checkpoints is selected within this radius.
@@ -28,6 +29,7 @@ import java.util.function.Consumer;
  *   <li>{@code BACK_AND_FORTH}: Move forward through the list, then reverse direction upon reaching the end.</li>
  * </ul>
  * <p>
+ *
  * The AI also includes a configurable pause time at each checkpoint before proceeding to the next.
  */
 public final class PatrolWalk implements Consumer<Entity> {

--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -418,8 +418,8 @@ public final class Game {
    * @param point Point from where to get the tile
    * @return the tile at the given point.
    */
-  public static Tile tileAT(final Point point) {
-    return currentLevel().tileAt(point);
+  public static Optional<Tile> tileAT(final Point point) {
+    return Optional.ofNullable(currentLevel().tileAt(point));
   }
 
   /**

--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -426,8 +426,8 @@ public final class Game {
    * Get the tile at the given coordinate in the level.
    *
    * @param coordinate Coordinate from where to get the tile
-   * @return An {@link Optional} containing the tile at the specified coordinate,
-   *      or {@link Optional#empty()} if there is no tile or the coordinate is out of bounds.
+   * @return An {@link Optional} containing the tile at the specified coordinate, or {@link
+   *     Optional#empty()} if there is no tile or the coordinate is out of bounds.
    */
   public static Optional<Tile> tileAT(final Coordinate coordinate) {
     // Implemented the TODO: no more null return values
@@ -438,9 +438,9 @@ public final class Game {
    * Get the next tile in the given direction from the specified coordinate.
    *
    * @param coordinate The starting coordinate
-   * @param direction  The direction in which to find the next tile
+   * @param direction The direction in which to find the next tile
    * @return An {@link Optional} containing the tile that is the next tile from the given coordinate
-   *         in the specified direction, or {@link Optional#empty()} if there is no such tile.
+   *     in the specified direction, or {@link Optional#empty()} if there is no such tile.
    */
   public static Optional<Tile> tileAT(final Coordinate coordinate, Direction direction) {
     return tileAT(coordinate.translate(direction));
@@ -449,9 +449,10 @@ public final class Game {
   /**
    * Get the next tile in the given direction from the specified point.
    *
-   * @param point     The starting point
+   * @param point The starting point
    * @param direction The direction in which to find the next tile
-   * @return An {@link Optional} containing the tile at the given point, or an empty Optional if no tile exists.
+   * @return An {@link Optional} containing the tile at the given point, or an empty Optional if no
+   *     tile exists.
    */
   public static Optional<Tile> tileAT(final Point point, Direction direction) {
     return tileAT(point.toCoordinate(), direction);
@@ -535,10 +536,11 @@ public final class Game {
             e ->
                 tile.equals(
                     tileAT(
-                        e.fetch(PositionComponent.class)
-                            .orElseThrow(
-                                () -> MissingComponentException.build(e, PositionComponent.class))
-                            .position())
+                            e.fetch(PositionComponent.class)
+                                .orElseThrow(
+                                    () ->
+                                        MissingComponentException.build(e, PositionComponent.class))
+                                .position())
                         .orElse(null)));
   }
 

--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -426,13 +426,12 @@ public final class Game {
    * Get the tile at the given coordinate in the level.
    *
    * @param coordinate Coordinate from where to get the tile
-   * @return The tile at the specified coordinate, or null if there is no tile or the coordinate is
-   *     out of bounds.
+   * @return An {@link Optional} containing the tile at the specified coordinate,
+   *      or {@link Optional#empty()} if there is no tile or the coordinate is out of bounds.
    */
-  public static Tile tileAT(final Coordinate coordinate) {
-    // TODO: SMELL!
-    // we really shouldn't return `null` if no tile was found, but `Optional.empty()` instead!
-    return currentLevel().tileAt(coordinate);
+  public static Optional<Tile> tileAT(final Coordinate coordinate) {
+    // Implemented the TODO: no more null return values
+    return Optional.ofNullable(currentLevel().tileAt(coordinate));
   }
 
   /**

--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -449,11 +449,12 @@ public final class Game {
   /**
    * Get the next tile in the given direction from the specified point.
    *
-   * @param point The starting point
+   * @param point     The starting point
    * @param direction The direction in which to find the next tile
-   * @return The tile that is the next tile from the given point in the specified direction.
+   * @return An Optional containing the tile that is the next tile from the given point
+   *         in the specified direction, or empty if none exists.
    */
-  public static Tile tileAT(final Point point, Direction direction) {
+  public static Optional<Tile> tileAT(final Point point, Direction direction) {
     return tileAT(point.toCoordinate(), direction);
   }
 

--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -438,10 +438,11 @@ public final class Game {
    * Get the next tile in the given direction from the specified coordinate.
    *
    * @param coordinate The starting coordinate
-   * @param direction The direction in which to find the next tile
-   * @return The tile that is the next tile from the given coordinate in the specified direction.
+   * @param direction  The direction in which to find the next tile
+   * @return An {@link Optional} containing the tile that is the next tile from the given coordinate
+   *         in the specified direction, or {@link Optional#empty()} if there is no such tile.
    */
-  public static Tile tileAT(final Coordinate coordinate, Direction direction) {
+  public static Optional<Tile> tileAT(final Coordinate coordinate, Direction direction) {
     return tileAT(coordinate.translate(direction));
   }
 

--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -527,7 +527,7 @@ public final class Game {
    * @return Stream of all entities on the given tile
    */
   public static Stream<Entity> entityAtTile(final Tile check) {
-    Tile tile = Game.tileAT(check.position());
+    Tile tile = Game.tileAT(check.position()).orElse(null);
     if (tile == null) return Stream.empty();
 
     return ECSManagment.entityStream(Set.of(PositionComponent.class))
@@ -538,7 +538,8 @@ public final class Game {
                         e.fetch(PositionComponent.class)
                             .orElseThrow(
                                 () -> MissingComponentException.build(e, PositionComponent.class))
-                            .position())));
+                            .position())
+                        .orElse(null)));
   }
 
   /**

--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -451,8 +451,7 @@ public final class Game {
    *
    * @param point     The starting point
    * @param direction The direction in which to find the next tile
-   * @return An Optional containing the tile that is the next tile from the given point
-   *         in the specified direction, or empty if none exists.
+   * @return An {@link Optional} containing the tile at the given point, or an empty Optional if no tile exists.
    */
   public static Optional<Tile> tileAT(final Point point, Direction direction) {
     return tileAT(point.toCoordinate(), direction);

--- a/dungeon/src/core/level/utils/LevelUtils.java
+++ b/dungeon/src/core/level/utils/LevelUtils.java
@@ -383,10 +383,8 @@ public final class LevelUtils {
       Coordinate topLeft, Coordinate bottomRight, boolean visible) {
     for (int x = topLeft.x(); x <= bottomRight.x(); x++) {
       for (int y = bottomRight.y(); y <= topLeft.y(); y++) {
-        Tile tile = Game.tileAT(new Coordinate(x, y));
-        if (tile != null) {
-          tile.visible(visible);
-        }
+        Game.tileAT(new Coordinate(x, y))
+          .ifPresent(tile -> tile.visible(visible));
       }
     }
   }

--- a/dungeon/src/core/level/utils/LevelUtils.java
+++ b/dungeon/src/core/level/utils/LevelUtils.java
@@ -169,7 +169,7 @@ public final class LevelUtils {
     Set<Tile> tiles = new HashSet<>();
     // BFS queue
     Queue<Tile> tileQueue = new ArrayDeque<>();
-    Tile start = Game.tileAT(center);
+    Tile start = Game.tileAT(center).orElse(null); // Änderung hier
     if (start != null) tileQueue.add(start);
     while (tileQueue.size() > 0) {
       Tile current = tileQueue.remove();

--- a/dungeon/src/core/level/utils/LevelUtils.java
+++ b/dungeon/src/core/level/utils/LevelUtils.java
@@ -46,8 +46,8 @@ public final class LevelUtils {
    * @return Path from the start coordinate to the end coordinate.
    */
   public static GraphPath<Tile> calculatePath(final Coordinate from, final Coordinate to) {
-    Tile fromTile = Game.tileAT(from);
-    Tile toTile = Game.tileAT(to);
+    Tile fromTile = Game.tileAT(from).orElse(null);
+    Tile toTile = Game.tileAT(to).orElse(null);
     if (fromTile == null || !fromTile.isAccessible()) return new DefaultGraphPath<>();
     if (toTile == null || !toTile.isAccessible()) return new DefaultGraphPath<>();
     return Game.findPath(fromTile, toTile);

--- a/dungeon/src/core/level/utils/LevelUtils.java
+++ b/dungeon/src/core/level/utils/LevelUtils.java
@@ -383,8 +383,7 @@ public final class LevelUtils {
       Coordinate topLeft, Coordinate bottomRight, boolean visible) {
     for (int x = topLeft.x(); x <= bottomRight.x(); x++) {
       for (int y = bottomRight.y(); y <= topLeft.y(); y++) {
-        Game.tileAT(new Coordinate(x, y))
-          .ifPresent(tile -> tile.visible(visible));
+        Game.tileAT(new Coordinate(x, y)).ifPresent(tile -> tile.visible(visible));
       }
     }
   }

--- a/dungeon/src/core/systems/FrictionSystem.java
+++ b/dungeon/src/core/systems/FrictionSystem.java
@@ -9,6 +9,8 @@ import core.components.VelocityComponent;
 import core.utils.Vector2;
 import core.utils.components.MissingComponentException;
 
+import core.level.Tile;
+
 /**
  * System that applies friction forces to entities.
  *
@@ -32,7 +34,9 @@ public class FrictionSystem extends System {
   }
 
   private void applyFriction(FSData data) {
-    float friction = Game.tileAT(data.pc.position()).friction();
+    float friction = Game.tileAT(data.pc.position())
+        .map(Tile::friction)  // Extrahiert friction() vom Tile
+        .orElse(0.0f);        // Standard-Reibungswert falls kein Tile vorhanden
     Vector2 force = data.vc().currentVelocity().scale(friction).inverse();
     if (force.isZero()) force = Vector2.ZERO;
     data.vc.applyForce("Friction", force);

--- a/dungeon/src/core/systems/FrictionSystem.java
+++ b/dungeon/src/core/systems/FrictionSystem.java
@@ -6,10 +6,9 @@ import core.Game;
 import core.System;
 import core.components.PositionComponent;
 import core.components.VelocityComponent;
+import core.level.Tile;
 import core.utils.Vector2;
 import core.utils.components.MissingComponentException;
-
-import core.level.Tile;
 
 /**
  * System that applies friction forces to entities.
@@ -34,9 +33,10 @@ public class FrictionSystem extends System {
   }
 
   private void applyFriction(FSData data) {
-    float friction = Game.tileAT(data.pc.position())
-        .map(Tile::friction)  // Extrahiert friction() vom Tile
-        .orElse(0.0f);        // Standard-Reibungswert falls kein Tile vorhanden
+    float friction =
+        Game.tileAT(data.pc.position())
+            .map(Tile::friction) // Extrahiert friction() vom Tile
+            .orElse(0.0f); // Standard-Reibungswert falls kein Tile vorhanden
     Vector2 force = data.vc().currentVelocity().scale(friction).inverse();
     if (force.isZero()) force = Vector2.ZERO;
     data.vc.applyForce("Friction", force);

--- a/dungeon/src/core/systems/LevelSystem.java
+++ b/dungeon/src/core/systems/LevelSystem.java
@@ -110,7 +110,7 @@ public final class LevelSystem extends System {
         entity
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-    Tile currentTile = Game.tileAT(pc.position());
+    Tile currentTile = Game.tileAT(pc.position()).orElse(null);
 
     if (!(currentTile instanceof DoorTile doorTile)) {
       return Optional.empty();

--- a/dungeon/src/core/systems/LevelSystem.java
+++ b/dungeon/src/core/systems/LevelSystem.java
@@ -95,7 +95,7 @@ public final class LevelSystem extends System {
         entity
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-    Tile currentTile = Game.tileAT(pc.position());
+    Tile currentTile = Game.tileAT(pc.position()).orElse(null);
     if (currentTile == null) {
       return false;
     }

--- a/dungeon/src/core/systems/MoveSystem.java
+++ b/dungeon/src/core/systems/MoveSystem.java
@@ -76,8 +76,8 @@ public class MoveSystem extends System {
       Point xMove = new Point(newPos.x(), oldPos.y());
       Point yMove = new Point(oldPos.x(), newPos.y());
 
-      boolean xAccessible = isAccessible(Game.tileAT(xMove), canEnterOpenPits);
-      boolean yAccessible = isAccessible(Game.tileAT(yMove), canEnterOpenPits);
+      boolean xAccessible = isAccessible(Game.tileAT(xMove).orElse(null), canEnterOpenPits);
+      boolean yAccessible = isAccessible(Game.tileAT(yMove).orElse(null), canEnterOpenPits);
 
       if (xAccessible) {
         if (isPathClearByStepping(oldPos, xMove, canEnterOpenPits)) data.pc.position(xMove);

--- a/dungeon/src/core/systems/MoveSystem.java
+++ b/dungeon/src/core/systems/MoveSystem.java
@@ -119,7 +119,7 @@ public class MoveSystem extends System {
 
     // Step from start to end and check each tile along the way
     for (float traveled = 0; traveled <= distance; traveled += step.length()) {
-      Tile tile = Game.tileAT(current);
+      Tile tile = Game.tileAT(current).orElse(null);
       if (!isAccessible(tile, canEnterPitTiles)) {
         return false;
       }
@@ -127,7 +127,7 @@ public class MoveSystem extends System {
     }
 
     // Ensure that the final destination tile is also checked
-    return isAccessible(Game.tileAT(to), canEnterPitTiles);
+    return isAccessible(Game.tileAT(to).orElse(null), canEnterPitTiles);
   }
 
   /**


### PR DESCRIPTION
PR ergänzt #2275

**Beschreibung:**

Dieser PR ergänzt den PR „Dungeon: refactor patrolWalk for Readability and Maintainability #2275“. Hintergrund ist die Änderung von Game.tileAT(...), die nun Optional<Tile> zurückgibt. Dadurch kam es an vielen Stellen im Code zu Kompilierungsfehlern, weil bisher ein Tile (ggf. null) erwartet wurde.

**Was ich gemacht habe:**

Ich habe im Branch tareq1337/fix-tileAT-return-optional alle betroffenen Aufrufstellen von Game.tileAT(...) so angepasst, dass sie mit Optional<Tile> arbeiten. Die Änderungen sind bewusst minimal gehalten, um bestehende Kontrollflüsse, Null-Prüfungen und Casts beizubehalten. Es wurden keine funktionalen Änderungen vorgenommen.

**Angepasste Klassen und Methoden**

**Minimal-Anpassung mit .orElse(null):**

- AIUtils.java — move, pathLeft, pathFinished; zusätzlicher privater Konstruktor
- BlockSystem.java — onAdd, onRemove, updateTiles
- HeroFactory.java — checkIfClickOnInteractable
- Debugger.java — TELEPORT_TO_END, TELEPORT(Point), SPAWN_MONSTER(Point)
- FallingSystem.java — filterFalling
- LevelSystem.java — isOnOpenEndTile, isOnDoor
- PitSystem.java — processEntities
- MoveSystem.java — updatePosition, isPathClearByStepping
- FogOfWarSystem.java — execute, castLight, revealHiddenEntities
- EntityUtils.java — spawnMonster(Point), spawnMonster(Coordinate)
- AStarPathFinding.java — heuristicCost, connectionCost
- AdvancedControlLevel3.java — onFirstTick
- ArrayCreateLevel.java, ArrayIterateLevel.java, ArrayRemoveLevel.java — openDoor, closeDoor
- PathfindingVisualizer.java — colorTile
- Level004.java, Level006.java, Level007.java, Level008.java, Level011.java, Level015.java, Level021.java — onFirstTick
- BlocklyCommands.java — mehrere Methoden wie moveToExit, interact, pickup, movePushable, isNearTile, isNearComponent, move

**Gezielte Verwendung von Optional-Methoden ohne .orElse(null):**

- FrictionSystem.java — applyFriction mit map(...) und anschließendem orElse(0.0f)
- LevelUtils.java — isWalkable(Coordinate) mit map(...) und anschließendem orElse(false)
- Level003.java — onFirstTick mit filter(...), map(...) und ifPresent(...)
- BlocklyCommands.java — targetTile(Direction) mit flatMap(...)

**Vergleich vorher/nachher:**

- Vorher: Direkter Zugriff auf Tile mit möglichem null, was nach der API-Änderung zu Fehlern geführt hat.
- Nachher: Einheitliches Entpacken mit .orElse(null) oder Nutzung von Optional-Methoden; Verhalten bleibt gleich.

**Ergebnis:**

- Projekt kompiliert fehlerfrei
- Alle bestehenden Tests laufen unverändert durch (checkstyleMain, spotlessApply, test erfolgreich)
- Verhalten im Spiel unverändert

**Empfehlung für zukünftige Anpassungen:**

.orElse(null) schrittweise durch ifPresent, map oder filter ersetzen