### PR TITLE
Dungeon: reload level on hero death; use DeathAnimation if possible

### DIFF
--- a/advancedDungeon/src/produsAdvanced/level/AdvancedBerryLevel.java
+++ b/advancedDungeon/src/produsAdvanced/level/AdvancedBerryLevel.java
@@ -120,7 +120,12 @@ public class AdvancedBerryLevel extends AdvancedLevel {
             new Berry(isToxic),
             Game.randomTile(LevelElement.FLOOR).get().coordinate().toCenteredPoint());
     berry.name("Berry");
-    HealthComponent health = new HealthComponent(999, (entity -> {}));
+    HealthComponent health =
+        new HealthComponent(
+            999,
+            (entity -> {
+              Game.remove(entity);
+            }));
     berry.add(health);
     makeInvincible(berry);
     berry.add(new CollideComponent());

--- a/blockly/src/level/produs/Level011.java
+++ b/blockly/src/level/produs/Level011.java
@@ -114,6 +114,7 @@ public class Level011 extends BlocklyLevel {
         .onDeath(
             entity -> {
               DialogUtils.showTextPopup("NEEEEEEEEEEEEEEEEIN! ICH WERDE MICH RÄCHEN!", "SIEG!");
+              Game.remove(entity);
             });
     door1 = (DoorTile) Game.tileAT(new Coordinate(4, 9));
     door2 = (DoorTile) Game.tileAT(new Coordinate(14, 8));

--- a/blockly/src/level/produs/Level022.java
+++ b/blockly/src/level/produs/Level022.java
@@ -70,6 +70,7 @@ public class Level022 extends BlocklyLevel {
               // todo we shouldnt just end the game, we need a real end screen
               DialogUtils.showTextPopup(
                   "NEEEEEEEEEEEEEEEEIN! ICH WERDE MICH RÄCHEN!", "SIEG!", Game::exit);
+              Game.remove(entity);
             });
     Game.allTiles(LevelElement.PIT)
         .forEach(

--- a/devDungeon/src/level/devlevel/TutorialLevel.java
+++ b/devDungeon/src/level/devlevel/TutorialLevel.java
@@ -79,7 +79,14 @@ public class TutorialLevel extends DevDungeonLevel {
       throw new RuntimeException("Failed to create tutorial monster");
     }
     DoorTile mobDoor = (DoorTile) tileAt(customPoints().get(5));
-    mob.fetch(HealthComponent.class).ifPresent(hc -> hc.onDeath((e) -> mobDoor.open()));
+    mob.fetch(HealthComponent.class)
+        .ifPresent(
+            hc ->
+                hc.onDeath(
+                    entity -> {
+                      mobDoor.open();
+                      Game.remove(entity);
+                    }));
     Entity chest;
     Entity chest2;
     try {

--- a/devDungeon/src/systems/DevHealthSystem.java
+++ b/devDungeon/src/systems/DevHealthSystem.java
@@ -52,7 +52,7 @@ public class DevHealthSystem extends HealthSystem {
         .map(this::activateDeathAnimation)
         .filter(this::isDeathAnimationFinished)
         .filter(this::shouldDie) // ignore entities that should not die
-        .forEach(this::removeDeadEntities);
+        .forEach(this::triggerOnDeath);
   }
 
   @Override

--- a/devDungeon/src/utils/EntityUtils.java
+++ b/devDungeon/src/utils/EntityUtils.java
@@ -246,6 +246,7 @@ public class EntityUtils {
                         ((ExitTile) Game.currentLevel().endTile().orElseThrow())
                             .open(); // open exit when chort dies
                         onBossDeath.accept(e);
+                        Game.remove(e);
                       }));
       return bossMob;
     } catch (RuntimeException e) {

--- a/dungeon/src/contrib/components/HealthComponent.java
+++ b/dungeon/src/contrib/components/HealthComponent.java
@@ -6,6 +6,7 @@ import contrib.utils.components.health.Damage;
 import contrib.utils.components.health.DamageType;
 import core.Component;
 import core.Entity;
+import core.Game;
 import core.utils.logging.CustomLogLevel;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +39,6 @@ public final class HealthComponent implements Component {
   private int maximalHealthpoints;
   private int currentHealthpoints;
   private @Null Entity lastCause = null;
-
   private boolean godMode = false;
 
   /**
@@ -58,10 +58,11 @@ public final class HealthComponent implements Component {
   /**
    * Create a HealthComponent with default values.
    *
-   * <p>The maximum health points are set to 1, and the onDeath function is empty.
+   * <p>The maximum health points are set to 1, and the onDeath function will remove the entity from
+   * the game.
    */
   public HealthComponent() {
-    this(1, onDeath -> {});
+    this(1, entity -> Game.remove(entity));
   }
 
   /**

--- a/dungeon/src/contrib/components/HealthComponent.java
+++ b/dungeon/src/contrib/components/HealthComponent.java
@@ -32,6 +32,7 @@ import java.util.logging.Logger;
  * <p>To determine the last cause of damage, the {@link #lastDamageCause()} method can be used.
  */
 public final class HealthComponent implements Component {
+  private static final Consumer<Entity> REMOVE_DEAD_ENTITY = Game::remove;
   private final List<Damage> damageToGet;
   private BiConsumer<Entity, Damage> onHit = (entity, damage) -> {};
   private Consumer<Entity> onDeath;
@@ -56,13 +57,25 @@ public final class HealthComponent implements Component {
   }
 
   /**
+   * Create a new HealthComponent.
+   *
+   * <p>onDeath function will remove the entity from * the game.
+   *
+   * @param maximalHitPoints Maximum amount of health points; currentHitPoints cannot be greater
+   *     than that
+   */
+  public HealthComponent(int maximalHitPoints) {
+    this(maximalHitPoints, REMOVE_DEAD_ENTITY);
+  }
+
+  /**
    * Create a HealthComponent with default values.
    *
    * <p>The maximum health points are set to 1, and the onDeath function will remove the entity from
    * the game.
    */
   public HealthComponent() {
-    this(1, entity -> Game.remove(entity));
+    this(1, REMOVE_DEAD_ENTITY);
   }
 
   /**

--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -62,6 +62,8 @@ public final class HeroFactory {
               public void execute() {
                 hero.fetch(HealthComponent.class)
                     .ifPresent(hc -> hc.currentHealthpoints(hc.maximalHealthpoints()));
+                // reset the animation queue
+                hero.fetch(DrawComponent.class).ifPresent(dc -> dc.deQueueAll());
                 DungeonLoader.reloadCurrentLevel();
               }
             });

--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -17,6 +17,7 @@ import core.Entity;
 import core.Game;
 import core.components.*;
 import core.level.Tile;
+import core.level.loader.DungeonLoader;
 import core.level.utils.LevelUtils;
 import core.utils.*;
 import core.utils.components.MissingComponentException;
@@ -52,8 +53,18 @@ public final class HeroFactory {
       new Skill(new FireballSkill(SkillTools::cursorPositionAsPoint), FIREBALL_COOL_DOWN);
 
   private static Consumer<Entity> HERO_DEATH =
-      (entity) -> {
-        DialogUtils.showTextPopup("You died!", "Game Over", Game::exit);
+      (hero) -> {
+        DialogUtils.showTextPopup(
+            "You died!",
+            "Game Over",
+            new IVoidFunction() {
+              @Override
+              public void execute() {
+                hero.fetch(HealthComponent.class)
+                    .ifPresent(hc -> hc.currentHealthpoints(hc.maximalHealthpoints()));
+                DungeonLoader.reloadCurrentLevel();
+              }
+            });
       };
 
   /**

--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -53,21 +53,17 @@ public final class HeroFactory {
       new Skill(new FireballSkill(SkillTools::cursorPositionAsPoint), FIREBALL_COOL_DOWN);
 
   private static Consumer<Entity> HERO_DEATH =
-      (hero) -> {
-        DialogUtils.showTextPopup(
-            "You died!",
-            "Game Over",
-            new IVoidFunction() {
-              @Override
-              public void execute() {
+      (hero) ->
+          DialogUtils.showTextPopup(
+              "You died!",
+              "Game Over",
+              () -> {
                 hero.fetch(HealthComponent.class)
                     .ifPresent(hc -> hc.currentHealthpoints(hc.maximalHealthpoints()));
                 // reset the animation queue
-                hero.fetch(DrawComponent.class).ifPresent(dc -> dc.deQueueAll());
+                hero.fetch(DrawComponent.class).ifPresent(DrawComponent::deQueueAll);
                 DungeonLoader.reloadCurrentLevel();
-              }
-            });
-      };
+              });
 
   /**
    * The default speed of the hero.
@@ -187,8 +183,7 @@ public final class HeroFactory {
             CollideComponent.DEFAULT_COLLIDER);
     col.onHold(
         (you, other, direction) -> {
-          if (other.isPresent(KineticComponent.class))
-            resolveCollisionWithMomentum(hero, other, direction);
+          if (other.isPresent(KineticComponent.class)) resolveCollisionWithMomentum(hero, other);
         });
     hero.add(col);
 
@@ -256,18 +251,14 @@ public final class HeroFactory {
     // UI controls
     pc.registerCallback(
         KeyboardConfig.INVENTORY_OPEN.value(),
-        (entity) -> {
-          toggleInventory(entity, pc, ic);
-        },
+        (entity) -> toggleInventory(entity, pc, ic),
         false,
         true);
 
     if (ENABLE_MOUSE_MOVEMENT) {
       pc.registerCallback(
           KeyboardConfig.MOUSE_INVENTORY_TOGGLE.value(),
-          (entity) -> {
-            toggleInventory(entity, pc, ic);
-          },
+          (entity) -> toggleInventory(entity, pc, ic),
           false,
           true);
     }
@@ -453,8 +444,7 @@ public final class HeroFactory {
         .findFirst();
   }
 
-  private static void resolveCollisionWithMomentum(
-      Entity hero, Entity other, Direction collisionDirection) {
+  private static void resolveCollisionWithMomentum(Entity hero, Entity other) {
     Optional<VelocityComponent> optVc1 = hero.fetch(VelocityComponent.class);
     Optional<VelocityComponent> optVc2 = other.fetch(VelocityComponent.class);
 

--- a/dungeon/src/contrib/entities/MonsterFactory.java
+++ b/dungeon/src/contrib/entities/MonsterFactory.java
@@ -196,6 +196,7 @@ public final class MonsterFactory {
         (e, who) -> {
           playDeathSoundIfNearby(deathSound, e);
           new DropItemsInteraction().accept(e, who);
+          Game.remove(e);
         };
     monster.add(new HealthComponent(health, (e) -> onDeath.accept(e, null)));
 

--- a/dungeon/src/contrib/systems/HealthSystem.java
+++ b/dungeon/src/contrib/systems/HealthSystem.java
@@ -5,7 +5,6 @@ import contrib.utils.components.draw.AdditionalAnimations;
 import contrib.utils.components.health.DamageType;
 import contrib.utils.components.health.IHealthObserver;
 import core.Entity;
-import core.Game;
 import core.System;
 import core.components.DrawComponent;
 import java.util.ArrayList;
@@ -17,7 +16,8 @@ import java.util.stream.Stream;
 
 /**
  * The HealthSystem offsets the damage to be done to all entities with the HealthComponent. Triggers
- * the death of an entity when the health-points have fallen below 0.
+ * the {@link HealthComponent#triggerOnDeath(Entity)} of an entity when the health-points have
+ * fallen below 0.
  *
  * <p>Entities with the {@link HealthComponent} and {@link DrawComponent} will be processed by this
  * system.
@@ -50,7 +50,7 @@ public class HealthSystem extends System {
     deadOrAlive.get(true).stream()
         .map(this::activateDeathAnimation)
         .filter(this::isDeathAnimationFinished)
-        .forEach(this::removeDeadEntities);
+        .forEach(this::triggerOnDeath);
   }
 
   protected HSData applyDamage(final HSData hsd) {
@@ -131,12 +131,9 @@ public class HealthSystem extends System {
     observers.remove(observer);
   }
 
-  protected void removeDeadEntities(final HSData hsd) {
-    // Entity appears to be dead, so let's clean up the mess
-    hsd.hc.triggerOnDeath(hsd.e);
+  protected void triggerOnDeath(final HSData hsd) {
     observers.forEach(observer -> observer.onHealthEvent(hsd, IHealthObserver.HealthEvent.DEATH));
-
-    Game.remove(hsd.e);
+    hsd.hc.triggerOnDeath(hsd.e);
   }
 
   /**

--- a/dungeon/src/core/components/DrawComponent.java
+++ b/dungeon/src/core/components/DrawComponent.java
@@ -306,6 +306,11 @@ public final class DrawComponent implements Component {
     animationQueue.keySet().removeIf(e -> e.priority() == prio);
   }
 
+  /** Remove all animations from the animation queue. */
+  public void deQueueAll() {
+    animationQueue.clear();
+  }
+
   /**
    * Get the Animation at the given path.
    *

--- a/dungeon/test/contrib/systems/HealthSystemTest.java
+++ b/dungeon/test/contrib/systems/HealthSystemTest.java
@@ -34,7 +34,7 @@ public class HealthSystemTest {
   public void updateEntityDies() throws IOException {
     Game.removeAllEntities();
     Entity entity = new Entity();
-    Consumer<Entity> onDeath = Mockito.mock(Consumer.class);
+    Consumer<Entity> onDeath = entity1 -> Game.remove(entity1);
     DrawComponent ac = new DrawComponent(ANIMATION_PATH);
     HealthComponent component = new HealthComponent(1, onDeath);
     entity.add(ac);


### PR DESCRIPTION
Bisher hat das `HealthSystem` alle Entitäten die hp<=0 haben automatisch gelöscht.
Diese Implikation habe ich entfernt. Das entfernen der Entität muss jetzt expliziet im `onDeath` callback implementiert werden.
Das erlaubt es, im Callback des Heldentot, via `DungeonLoader` das aktuelle Level neu zu laden. 
Dabei wird
* eine neue Instanz der Level-Manger Klasse erstellt und daher `onFirstTick` des Levels erneut ausgeführt
    * das Level wird dadurch in Ausgangsposition zurück gesetzt (Monster, Items, Kisten, Türen etc.)
* Die HP des Helden wieder auf sein maximum gesetzt
* Die Animation Queue des Helden geleert
* Das Inventar des Helden wird **nicht** reseted.
* Die Blickrichtung des Helden wird **nicht** reseted, das kann bei Bedarf in der
* Es werden **keine** statics aufgeräumt oder Level spezifische Aktionen rückgängig gemacht. Das sollte in der `onFirstTick` des Levels passieren (vgl Blockly)


 `onFristTick` des levels gemacht werden (vgl Blockly)

Außerdem habe ich die Deathanimation "korrekt" implementiert, da gab es vorher keinen Check welche Animation abgespielt werden soll. (@viddie vermutlich für dich interessant bzw. musst du wieder anpacken, richtig?)
"Richtig" da die Animation looped, sieht etwas albern aus, aber das Problem sitzt tiefer und solange @viddie System nicht drine ist, pack ich das nicht an. 

https://github.com/user-attachments/assets/d2edcecd-3a65-4c71-ba4e-0dc42587ad9f



* Entfernt in `HeroFactoy#resolveCollisionWithMomentum` einen nicht genutzten Prameter (IDE sieht alles)