### PR TITLE
Dungeon: fix catapults

### DIFF
--- a/dungeon/src/contrib/components/CatapultableComponent.java
+++ b/dungeon/src/contrib/components/CatapultableComponent.java
@@ -14,9 +14,41 @@ import java.util.function.Consumer;
  *       AI).
  *   <li>{@code reactivate} called when the catapulting process ends (e.g., to restore behavior).
  * </ul>
- *
- * @param deactivate a function that will be called to deactivate the entity
- * @param reactivate a function that will be called to reactivate the entity
  */
-public record CatapultableComponent(Consumer<Entity> deactivate, Consumer<Entity> reactivate)
-    implements Component {}
+public class CatapultableComponent implements Component {
+
+  private final Consumer<Entity> deactivate;
+  private final Consumer<Entity> reactivate;
+  private boolean flying = false;
+
+  /**
+   * Create a new Component.
+   *
+   * @param deactivate a function that will be called to deactivate the entity
+   * @param reactivate a function that will be called to reactivate the entity
+   */
+  public CatapultableComponent(Consumer<Entity> deactivate, Consumer<Entity> reactivate) {
+    this.deactivate = deactivate;
+    this.reactivate = reactivate;
+  }
+
+  public Consumer<Entity> deactivate() {
+    return deactivate;
+  }
+
+  public Consumer<Entity> reactivate() {
+    return reactivate;
+  }
+
+  public void flies() {
+    flying = true;
+  }
+
+  public void lands() {
+    flying = false;
+  }
+
+  public boolean isFlying() {
+    return flying;
+  }
+}

--- a/dungeon/src/contrib/components/CatapultableComponent.java
+++ b/dungeon/src/contrib/components/CatapultableComponent.java
@@ -7,13 +7,9 @@ import java.util.function.Consumer;
 /**
  * Marks an entity as catapultable, meaning it can be launched upon collision with a catapult.
  *
- * <p>This component provides two hooks:
+ * <p>This component provides hooks to manage the entity’s behavior during the catapult process.
  *
- * <ul>
- *   <li>{@code deactivate} called when the entity is being catapulted (e.g., to disable controls or
- *       AI).
- *   <li>{@code reactivate} called when the catapulting process ends (e.g., to restore behavior).
- * </ul>
+ * <p>The component also tracks whether the entity is currently flying.
  */
 public class CatapultableComponent implements Component {
 
@@ -22,32 +18,50 @@ public class CatapultableComponent implements Component {
   private boolean flying = false;
 
   /**
-   * Create a new Component.
+   * Creates a new CatapultableComponent.
    *
-   * @param deactivate a function that will be called to deactivate the entity
-   * @param reactivate a function that will be called to reactivate the entity
+   * @param deactivate a function that will be called to deactivate the entity when catapulting
+   *     starts
+   * @param reactivate a function that will be called to reactivate the entity when catapulting ends
    */
   public CatapultableComponent(Consumer<Entity> deactivate, Consumer<Entity> reactivate) {
     this.deactivate = deactivate;
     this.reactivate = reactivate;
   }
 
+  /**
+   * Returns the function to deactivate the entity.
+   *
+   * @return a Consumer called when catapulting starts
+   */
   public Consumer<Entity> deactivate() {
     return deactivate;
   }
 
+  /**
+   * Returns the function to reactivate the entity.
+   *
+   * @return a Consumer called when catapulting ends
+   */
   public Consumer<Entity> reactivate() {
     return reactivate;
   }
 
+  /** Marks the entity as flying. */
   public void flies() {
     flying = true;
   }
 
+  /** Marks the entity as landed. */
   public void lands() {
     flying = false;
   }
 
+  /**
+   * Returns whether the entity is currently flying.
+   *
+   * @return true if the entity is in the air, false otherwise
+   */
   public boolean isFlying() {
     return flying;
   }

--- a/dungeon/src/contrib/entities/MiscFactory.java
+++ b/dungeon/src/contrib/entities/MiscFactory.java
@@ -291,7 +291,10 @@ public final class MiscFactory {
     TriConsumer<Entity, Entity, Direction> action =
         (you, other, direction) -> {
           if (!other.isPresent(CatapultableComponent.class)) return;
-          if (other.fetch(CatapultableComponent.class).map(CatapultableComponent::isFlying).orElse(false)) return;
+          if (other
+              .fetch(CatapultableComponent.class)
+              .map(CatapultableComponent::isFlying)
+              .orElse(false)) return;
           other
               .fetch(VelocityComponent.class)
               .ifPresent(

--- a/dungeon/src/contrib/entities/MiscFactory.java
+++ b/dungeon/src/contrib/entities/MiscFactory.java
@@ -291,7 +291,7 @@ public final class MiscFactory {
     TriConsumer<Entity, Entity, Direction> action =
         (you, other, direction) -> {
           if (!other.isPresent(CatapultableComponent.class)) return;
-          if (other.fetch(CatapultableComponent.class).get().isFlying()) return;
+          if (other.fetch(CatapultableComponent.class).map(CatapultableComponent::isFlying).orElse(false)) return;
           other
               .fetch(VelocityComponent.class)
               .ifPresent(

--- a/dungeon/src/contrib/systems/FallingSystem.java
+++ b/dungeon/src/contrib/systems/FallingSystem.java
@@ -1,5 +1,6 @@
 package contrib.systems;
 
+import contrib.components.FlyComponent;
 import contrib.components.HealthComponent;
 import contrib.utils.EntityUtils;
 import contrib.utils.components.Debugger;
@@ -51,6 +52,8 @@ public class FallingSystem extends System {
             .fetch(PositionComponent.class)
             .map(PositionComponent::position)
             .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
+    if (entity.isPresent(FlyComponent.class)) return false;
+
     Tile currentTile = Game.tileAT(entityPosition);
     if (currentTile instanceof PitTile pitTile) {
       return pitTile.isOpen();


### PR DESCRIPTION
Es gab mehrere kleine Probleme mit den Katapulten

* Das Fallingsystem hat nicht geprüft, ob eine entität fliegen kann. `canEnterOpenPits` im VelocityComponent sagt nur, ob ich das Tile betreten kann, schützt mich aber nicht vorm Absturz. Ab jetzt können Entitäten mit den `FlyComponent` über Pits drüber fliegen.
* Wenn ich von einem Katapult auf ein anderes Katapult gesprungen bin, speicherte das zweite Katapult mein temporäres VelocityComponent vom erste Flug als "mein default" ab und gibts mir das am Ende zurück. Das `CatapultableComponent`trackt jetzt, ob ich grade am fliegen bin und wenn ja, kann ich nicht wieder katapultiert werden. 
Das bedeutet auch erstmal, dass man nicht direkt von einem Katapult auf das andere fliegen kann. Etwas schade, aber vermjtlich für unser Design auch nicht tragisch. 