### PR TITLE
Dungeon: enable checkpattern as default

### DIFF
--- a/advancedDungeon/src/aiAdvanced/starter/ComparePathfindingStarter.java
+++ b/advancedDungeon/src/aiAdvanced/starter/ComparePathfindingStarter.java
@@ -15,7 +15,6 @@ import contrib.entities.MonsterIdleSound;
 import contrib.systems.EventScheduler;
 import contrib.systems.LevelTickSystem;
 import contrib.systems.PathSystem;
-import contrib.utils.CheckPatternPainter;
 import contrib.utils.components.Debugger;
 import core.Entity;
 import core.Game;
@@ -41,7 +40,6 @@ import java.util.logging.Level;
 
 /** This class starts a comparator for the pathfinding algorithms. */
 public class ComparePathfindingStarter {
-  private static final boolean DRAW_CHECKER_PATTERN = true;
   private static final Entity[] RUNNERS = new Entity[2];
 
   private static final Class<? extends PathfindingLogic> pathFindingA = BFSPathFinding.class;
@@ -61,9 +59,6 @@ public class ComparePathfindingStarter {
     configGame();
     // Set up components and level
     onSetup();
-
-    onLevelLoad();
-
     // build and start game
     Game.run();
   }
@@ -204,14 +199,6 @@ public class ComparePathfindingStarter {
             algorithms.add(Tuple.of(algo, runner));
           }
           pfs.updatePathfindingAlgorithm(algorithms.toArray(Tuple[]::new));
-        });
-  }
-
-  private static void onLevelLoad() {
-    Game.userOnLevelLoad(
-        (firstLoad) -> {
-          if (DRAW_CHECKER_PATTERN)
-            CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
         });
   }
 

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -6,7 +6,6 @@ import contrib.crafting.Crafting;
 import contrib.entities.HeroFactory;
 import contrib.systems.*;
 import contrib.systems.BlockSystem;
-import contrib.utils.CheckPatternPainter;
 import contrib.utils.components.Debugger;
 import core.Entity;
 import core.Game;
@@ -40,7 +39,6 @@ public class Client {
 
   private static final boolean DEBUG_MODE = false;
   private static final boolean KEYBOARD_DEACTIVATION = !DEBUG_MODE;
-  private static final boolean DRAW_CHECKER_PATTERN = true;
   private static volatile boolean scheduleRestart = false;
 
   private static HttpServer httpServer;
@@ -136,8 +134,6 @@ public class Client {
   private static void onLevelLoad() {
     Game.userOnLevelLoad(
         (firstLoad) -> {
-          if (DRAW_CHECKER_PATTERN)
-            CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
           BlocklyCodeRunner.instance().stopCode();
           Game.hero()
               .flatMap(e -> e.fetch(AmmunitionComponent.class))

--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -178,6 +178,25 @@ public final class Game {
   }
 
   /**
+   * Enables or disables the check pattern drawing mode.
+   *
+   * @param enabled {@code true} to draw the level with a check pattern, {@code false} to draw it
+   *     without
+   */
+  public static void enableCheckPattern(boolean enabled) {
+    PreRunConfiguration.enableCheckPattern(enabled);
+  }
+
+  /**
+   * Checks if the check pattern drawing mode is enabled.
+   *
+   * @return {@code true} if the level will be drawn with a check pattern, {@code false} otherwise
+   */
+  public static boolean isCheckPatternEnabled() {
+    return PreRunConfiguration.isCheckPatternEnabled();
+  }
+
+  /**
    * Sets the user-defined function for frame updates in the pre-run configuration.
    *
    * @param userOnFrame The new user-defined function for frame updates.

--- a/dungeon/src/core/game/GameLoop.java
+++ b/dungeon/src/core/game/GameLoop.java
@@ -78,7 +78,8 @@ public final class GameLoop extends ScreenAdapter {
           LOGGER.warning(e.getMessage());
         }
         hero.ifPresent(ECSManagment::add);
-        if (firstLoad) CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
+        if (firstLoad && Game.isCheckPatternEnabled())
+          CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
         PreRunConfiguration.userOnLevelLoad().accept(firstLoad);
       };
 

--- a/dungeon/src/core/game/GameLoop.java
+++ b/dungeon/src/core/game/GameLoop.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.Scaling;
 import com.badlogic.gdx.utils.SharedLibraryLoader;
 import com.badlogic.gdx.utils.viewport.ScalingViewport;
+import contrib.utils.CheckPatternPainter;
 import core.Entity;
 import core.Game;
 import core.System;
@@ -77,6 +78,7 @@ public final class GameLoop extends ScreenAdapter {
           LOGGER.warning(e.getMessage());
         }
         hero.ifPresent(ECSManagment::add);
+        if (firstLoad) CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
         PreRunConfiguration.userOnLevelLoad().accept(firstLoad);
       };
 

--- a/dungeon/src/core/game/PreRunConfiguration.java
+++ b/dungeon/src/core/game/PreRunConfiguration.java
@@ -32,9 +32,7 @@ public final class PreRunConfiguration {
   private static String WINDOW_TITLE = "PM-Dungeon";
   private static IPath LOGO_PATH = new SimpleIPath("logo/cat_logo_35x35.png");
   private static boolean DISABLE_AUDIO = false;
-
   private static boolean DRAW_CHECK_PATTERN = true;
-
   private static IVoidFunction userOnFrame = () -> {};
   private static IVoidFunction userOnSetup = () -> {};
   private static Consumer<Boolean> userOnLevelLoad = (b) -> {};

--- a/dungeon/src/core/game/PreRunConfiguration.java
+++ b/dungeon/src/core/game/PreRunConfiguration.java
@@ -32,6 +32,9 @@ public final class PreRunConfiguration {
   private static String WINDOW_TITLE = "PM-Dungeon";
   private static IPath LOGO_PATH = new SimpleIPath("logo/cat_logo_35x35.png");
   private static boolean DISABLE_AUDIO = false;
+
+  private static boolean DRAW_CHECK_PATTERN = true;
+
   private static IVoidFunction userOnFrame = () -> {};
   private static IVoidFunction userOnSetup = () -> {};
   private static Consumer<Boolean> userOnLevelLoad = (b) -> {};
@@ -178,6 +181,25 @@ public final class PreRunConfiguration {
    */
   public static void disableAudio(boolean disableAudio) {
     DISABLE_AUDIO = disableAudio;
+  }
+
+  /**
+   * Enables or disables the check pattern drawing mode.
+   *
+   * @param enabled {@code true} to draw the level with a check pattern, {@code false} to draw it
+   *     without
+   */
+  public static void enableCheckPattern(boolean enabled) {
+    DRAW_CHECK_PATTERN = enabled;
+  }
+
+  /**
+   * Checks if the check pattern drawing mode is enabled.
+   *
+   * @return {@code true} if the level will be drawn with a check pattern, {@code false} otherwise
+   */
+  public static boolean isCheckPatternEnabled() {
+    return DRAW_CHECK_PATTERN;
   }
 
   /**


### PR DESCRIPTION
Mit diesem PR wird das hübsche Schachmuster per default Einstellung in jedem Dungeon verwendet.
Optional kann das ganze über die Config ausgeschaltet werden. 


Ohne
<img width="573" height="333" alt="image" src="https://github.com/user-attachments/assets/78ece0a3-2260-4c66-b355-e8d4c89c1e0c" />


Mit
<img width="698" height="297" alt="image" src="https://github.com/user-attachments/assets/53894808-3cb7-400b-800f-e696d26d6b77" />

