### PR TITLE
Dungeon: Split Player components and system to InputSystem

### DIFF
--- a/advancedDungeon/src/aiAdvanced/starter/ComparePathfindingStarter.java
+++ b/advancedDungeon/src/aiAdvanced/starter/ComparePathfindingStarter.java
@@ -26,8 +26,8 @@ import core.level.loader.DungeonLoader;
 import core.level.utils.Coordinate;
 import core.level.utils.LevelElement;
 import core.systems.CameraSystem;
+import core.systems.InputSystem;
 import core.systems.LevelSystem;
-import core.systems.PlayerSystem;
 import core.utils.Point;
 import core.utils.Tuple;
 import core.utils.Vector2;
@@ -75,7 +75,7 @@ public class ComparePathfindingStarter {
 
           Game.system(
               LevelSystem.class, ls -> ls.onEndTile(ComparePathfindingStarter::loadNextLevel));
-          Game.remove(PlayerSystem.class);
+          Game.remove(InputSystem.class);
           loadNextLevel();
 
           // Wait for Level to Load

--- a/advancedDungeon/src/aiAdvanced/starter/PathfinderStarter.java
+++ b/advancedDungeon/src/aiAdvanced/starter/PathfinderStarter.java
@@ -13,7 +13,7 @@ import contrib.utils.CheckPatternPainter;
 import core.Entity;
 import core.Game;
 import core.components.CameraComponent;
-import core.components.PlayerComponent;
+import core.components.InputComponent;
 import core.level.loader.DungeonLoader;
 import core.level.utils.Coordinate;
 import core.systems.LevelSystem;
@@ -86,10 +86,10 @@ public class PathfinderStarter {
           Game.hero()
               .ifPresent(
                   hero -> {
-                    hero.fetch(PlayerComponent.class)
+                    hero.fetch(InputComponent.class)
                         .ifPresent(
-                            pc -> {
-                              pc.registerCallback(
+                            ic -> {
+                              ic.registerCallback(
                                   KeyboardConfig.SELECT_DFS.value(),
                                   caller -> {
                                     selectPathfindingAlgorithm(
@@ -97,7 +97,7 @@ public class PathfinderStarter {
                                         false,
                                         hero);
                                   });
-                              pc.registerCallback(
+                              ic.registerCallback(
                                   KeyboardConfig.SELECT_BFS.value(),
                                   caller -> {
                                     selectPathfindingAlgorithm(
@@ -105,7 +105,7 @@ public class PathfinderStarter {
                                         false,
                                         hero);
                                   });
-                              pc.registerCallback(
+                              ic.registerCallback(
                                   KeyboardConfig.SELECT_SUS_ALGO.value(),
                                   caller -> {
                                     selectPathfindingAlgorithm(
@@ -166,7 +166,7 @@ public class PathfinderStarter {
     hero.remove(CameraComponent.class);
     Game.add(hero);
 
-    hero.fetch(PlayerComponent.class).ifPresent(PlayerComponent::removeCallbacks);
+    hero.fetch(InputComponent.class).ifPresent(InputComponent::removeCallbacks);
   }
 
   /**

--- a/advancedDungeon/src/produsAdvanced/abstraction/Hero.java
+++ b/advancedDungeon/src/produsAdvanced/abstraction/Hero.java
@@ -14,6 +14,7 @@ import contrib.utils.components.interaction.InteractionTool;
 import contrib.utils.components.skill.SkillTools;
 import core.Entity;
 import core.Game;
+import core.components.InputComponent;
 import core.components.PlayerComponent;
 import core.components.VelocityComponent;
 import core.level.Tile;
@@ -58,7 +59,7 @@ public class Hero {
 
     if (!AdvancedDungeon.DEBUG_MODE) {
       // Entfernt alle bisherigen Tastenzuweisungen
-      heroInstance.fetch(PlayerComponent.class).ifPresent(PlayerComponent::removeCallbacks);
+      heroInstance.fetch(InputComponent.class).ifPresent(InputComponent::removeCallbacks);
     }
     this.fireballSkill = fireballSkill;
     // uncap max hero speed
@@ -77,12 +78,12 @@ public class Hero {
   public void setController(PlayerController controller) {
     if (controller == null) return;
     String[] mousebuttons = {"LMB", "RMB", "MMB"};
-    hero.fetch(PlayerComponent.class)
+    hero.fetch(InputComponent.class)
         .ifPresent(
-            pc -> {
+            ic -> {
               for (int key = 0; key <= Input.Keys.MAX_KEYCODE; key++) {
                 int finalKey = key;
-                pc.registerCallback(
+                ic.registerCallback(
                     key,
                     entity -> {
                       try {
@@ -96,7 +97,7 @@ public class Hero {
                     });
               }
               // Callback zum Schließen von UI-Dialogen
-              HeroFactory.registerCloseUI(pc);
+              HeroFactory.registerCloseUI(ic);
             });
   }
 

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -13,8 +13,8 @@ import core.System;
 import core.components.PlayerComponent;
 import core.game.ECSManagment;
 import core.level.loader.DungeonLoader;
+import core.systems.InputSystem;
 import core.systems.LevelSystem;
-import core.systems.PlayerSystem;
 import core.systems.PositionSystem;
 import core.utils.Tuple;
 import core.utils.Vector2;
@@ -123,7 +123,7 @@ public class Client {
           Crafting.loadRecipes();
 
           if (KEYBOARD_DEACTIVATION) {
-            Game.remove(PlayerSystem.class);
+            Game.remove(InputSystem.class);
           }
 
           LevelSystem levelSystem = (LevelSystem) ECSManagment.systems().get(LevelSystem.class);

--- a/blockly/src/entities/HeroTankControlledFactory.java
+++ b/blockly/src/entities/HeroTankControlledFactory.java
@@ -3,7 +3,7 @@ package entities;
 import client.Client;
 import contrib.entities.EntityFactory;
 import core.Entity;
-import core.components.PlayerComponent;
+import core.components.InputComponent;
 import core.components.PositionComponent;
 import core.components.VelocityComponent;
 import core.configuration.KeyboardConfig;
@@ -28,26 +28,25 @@ public class HeroTankControlledFactory {
    */
   public static Entity newTankControlledHero() throws IOException {
     Entity hero = EntityFactory.newHero();
-    PlayerComponent pc =
-        hero.fetch(PlayerComponent.class)
-            .orElseThrow(() -> MissingComponentException.build(hero, PlayerComponent.class));
+
+    InputComponent ic = hero.fetch(InputComponent.class).orElse(new InputComponent());
 
     // Remove any original movement controls
-    pc.removeCallback(KeyboardConfig.MOVEMENT_UP.value());
-    pc.removeCallback(KeyboardConfig.MOVEMENT_DOWN.value());
-    pc.removeCallback(KeyboardConfig.MOVEMENT_LEFT.value());
-    pc.removeCallback(KeyboardConfig.MOVEMENT_RIGHT.value());
+    ic.removeCallback(KeyboardConfig.MOVEMENT_UP.value());
+    ic.removeCallback(KeyboardConfig.MOVEMENT_DOWN.value());
+    ic.removeCallback(KeyboardConfig.MOVEMENT_LEFT.value());
+    ic.removeCallback(KeyboardConfig.MOVEMENT_RIGHT.value());
 
     // Add tank controls
-    pc.registerCallback(
+    ic.registerCallback(
         KeyboardConfig.MOVEMENT_UP.value(), HeroTankControlledFactory::moveEntityInFacingDirection);
 
     // Add rotation controls
-    pc.registerCallback(
+    ic.registerCallback(
         KeyboardConfig.MOVEMENT_LEFT.value(),
         (entity) -> BlocklyCommands.rotate(Direction.LEFT),
         false);
-    pc.registerCallback(
+    ic.registerCallback(
         KeyboardConfig.MOVEMENT_RIGHT.value(),
         (entity) -> BlocklyCommands.rotate(Direction.RIGHT),
         false);

--- a/dungeon/src/contrib/components/InteractionComponent.java
+++ b/dungeon/src/contrib/components/InteractionComponent.java
@@ -2,14 +2,15 @@ package contrib.components;
 
 import core.Component;
 import core.Entity;
+import core.systems.InputSystem;
 import java.util.function.BiConsumer;
 
 /**
  * Allows interaction with the associated entity.
  *
  * <p>An interaction can be triggered using {@link #triggerInteraction(Entity, Entity)}. This
- * happens in the {@link core.systems.PlayerSystem} if the player presses the corresponding button
- * on the keyboard and is in the interaction range of this component.
+ * happens in the {@link InputSystem} if the player presses the corresponding button on the keyboard
+ * and is in the interaction range of this component.
  *
  * <p>What happens during an interaction is defined by the {@link BiConsumer} {@link
  * #onInteraction}.

--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -110,9 +110,9 @@ public final class HeroFactory {
    *
    * <p>The Entity is not added to the game yet.
    *
-   * <p>It will have a {@link CameraComponent}, {@link core.components.PlayerComponent}. {@link
-   * PositionComponent}, {@link VelocityComponent}, {@link core.components.DrawComponent}, {@link
-   * contrib.components.CollideComponent} and {@link HealthComponent}.
+   * <p>It will have a {@link CameraComponent}, {@link PlayerComponent}{, {@link PlayerComponent},
+   * {@link PositionComponent}, {@link VelocityComponent}, {@link DrawComponent}, {@link
+   * CollideComponent} and {@link HealthComponent}.
    *
    * @return A new Entity.
    * @throws IOException if the animation could not been loaded.
@@ -126,9 +126,9 @@ public final class HeroFactory {
    *
    * <p>The Entity is not added to the game yet.
    *
-   * <p>It will have a {@link CameraComponent}, {@link core.components.PlayerComponent}. {@link
-   * PositionComponent}, {@link VelocityComponent}, {@link core.components.DrawComponent}, {@link
-   * contrib.components.CollideComponent} and {@link HealthComponent}.
+   * <p>It will have a {@link CameraComponent}, {@link PlayerComponent}, {@link InputComponent}
+   * {@link PositionComponent}, {@link VelocityComponent}, {@link DrawComponent}, {@link
+   * CollideComponent} and {@link HealthComponent}.
    *
    * @param deathCallback function that will be executed if the hero dies
    * @return A new Entity.
@@ -136,6 +136,8 @@ public final class HeroFactory {
    */
   public static Entity newHero(Consumer<Entity> deathCallback) throws IOException {
     Entity hero = new Entity("hero");
+    PlayerComponent pc = new PlayerComponent();
+    hero.add(pc);
     CameraComponent cc = new CameraComponent();
     hero.add(cc);
     PositionComponent poc = new PositionComponent();
@@ -187,29 +189,31 @@ public final class HeroFactory {
         });
     hero.add(col);
 
-    PlayerComponent pc = new PlayerComponent();
+    InputComponent inputComp = new InputComponent();
     hero.add(
         new CatapultableComponent(
-            entity -> pc.deactivateControls(true), entity -> pc.deactivateControls(false)));
-    hero.add(pc);
-    InventoryComponent ic = new InventoryComponent(DEFAULT_INVENTORY_SIZE);
-    hero.add(ic);
+            entity -> inputComp.deactivateControls(true),
+            entity -> inputComp.deactivateControls(false)));
+    hero.add(inputComp);
+    InventoryComponent invComp = new InventoryComponent(DEFAULT_INVENTORY_SIZE);
+    hero.add(invComp);
 
     // hero movement
-    registerMovement(pc, core.configuration.KeyboardConfig.MOVEMENT_UP.value(), Vector2.of(0, 1));
     registerMovement(
-        pc, core.configuration.KeyboardConfig.MOVEMENT_DOWN.value(), Vector2.of(0, -1));
+        inputComp, core.configuration.KeyboardConfig.MOVEMENT_UP.value(), Vector2.of(0, 1));
     registerMovement(
-        pc, core.configuration.KeyboardConfig.MOVEMENT_RIGHT.value(), Vector2.of(1, 0));
+        inputComp, core.configuration.KeyboardConfig.MOVEMENT_DOWN.value(), Vector2.of(0, -1));
     registerMovement(
-        pc, core.configuration.KeyboardConfig.MOVEMENT_LEFT.value(), Vector2.of(-1, 0));
+        inputComp, core.configuration.KeyboardConfig.MOVEMENT_RIGHT.value(), Vector2.of(1, 0));
+    registerMovement(
+        inputComp, core.configuration.KeyboardConfig.MOVEMENT_LEFT.value(), Vector2.of(-1, 0));
 
     if (ENABLE_MOUSE_MOVEMENT) {
       // Mouse Left Click
-      registerMouseLeftClick(pc);
+      registerMouseLeftClick(inputComp);
 
       // Mouse Movement (Right Click)
-      pc.registerCallback(
+      inputComp.registerCallback(
           KeyboardConfig.MOUSE_MOVE.value(),
           innerHero -> {
             // Small adjustment to get the correct tile
@@ -249,23 +253,23 @@ public final class HeroFactory {
     }
 
     // UI controls
-    pc.registerCallback(
+    inputComp.registerCallback(
         KeyboardConfig.INVENTORY_OPEN.value(),
-        (entity) -> toggleInventory(entity, pc, ic),
+        (entity) -> toggleInventory(entity, pc, invComp),
         false,
         true);
 
     if (ENABLE_MOUSE_MOVEMENT) {
-      pc.registerCallback(
+      inputComp.registerCallback(
           KeyboardConfig.MOUSE_INVENTORY_TOGGLE.value(),
-          (entity) -> toggleInventory(entity, pc, ic),
+          (entity) -> toggleInventory(entity, pc, invComp),
           false,
           true);
     }
 
-    registerCloseUI(pc);
+    registerCloseUI(inputComp);
 
-    pc.registerCallback(
+    inputComp.registerCallback(
         KeyboardConfig.INTERACT_WORLD.value(),
         entity -> {
           UIComponent uiComponent = entity.fetch(UIComponent.class).orElse(null);
@@ -281,7 +285,7 @@ public final class HeroFactory {
         false);
 
     // skills
-    pc.registerCallback(
+    inputComp.registerCallback(
         KeyboardConfig.FIRST_SKILL.value(), heroEntity -> HERO_SKILL.execute(heroEntity));
 
     return hero;
@@ -292,10 +296,10 @@ public final class HeroFactory {
    *
    * <p>This will close the topmost UI dialog that has the close key configured to close it.
    *
-   * @param pc The PlayerComponent of the hero.
+   * @param ic The {@link InputComponent} of the hero.
    */
-  public static void registerCloseUI(PlayerComponent pc) {
-    pc.registerCallback(
+  public static void registerCloseUI(InputComponent ic) {
+    ic.registerCallback(
         KeyboardConfig.CLOSE_UI.value(),
         (e) -> {
           var firstUI =
@@ -349,8 +353,8 @@ public final class HeroFactory {
     }
   }
 
-  private static void registerMovement(PlayerComponent pc, int key, Vector2 direction) {
-    pc.registerCallback(
+  private static void registerMovement(InputComponent ic, int key, Vector2 direction) {
+    ic.registerCallback(
         key,
         entity -> {
           VelocityComponent vc =
@@ -376,12 +380,12 @@ public final class HeroFactory {
         });
   }
 
-  private static void registerMouseLeftClick(PlayerComponent pc) {
+  private static void registerMouseLeftClick(InputComponent ic) {
     if (!Objects.equals(
         KeyboardConfig.MOUSE_FIRST_SKILL.value(), KeyboardConfig.MOUSE_INTERACT_WORLD.value())) {
-      pc.registerCallback(
+      ic.registerCallback(
           KeyboardConfig.MOUSE_FIRST_SKILL.value(), hero -> HERO_SKILL.execute(hero), true, false);
-      pc.registerCallback(
+      ic.registerCallback(
           KeyboardConfig.MOUSE_INTERACT_WORLD.value(),
           HeroFactory::handleInteractWithClosestInteractable,
           false,
@@ -389,7 +393,7 @@ public final class HeroFactory {
     } else {
       // If interact and skill are the same, only one callback can be used, so we only interact if
       // interaction is possible
-      pc.registerCallback(
+      ic.registerCallback(
           KeyboardConfig.MOUSE_INTERACT_WORLD.value(),
           (hero) -> {
             Point mousePosition = SkillTools.cursorPositionAsPoint();

--- a/dungeon/src/contrib/item/concreteItem/ItemWoodenBow.java
+++ b/dungeon/src/contrib/item/concreteItem/ItemWoodenBow.java
@@ -9,7 +9,7 @@ import contrib.utils.components.skill.Skill;
 import contrib.utils.components.skill.SkillTools;
 import core.Entity;
 import core.Game;
-import core.components.PlayerComponent;
+import core.components.InputComponent;
 import core.components.PositionComponent;
 import core.level.elements.tile.FloorTile;
 import core.utils.Point;
@@ -45,10 +45,10 @@ public class ItemWoodenBow extends Item {
             inventoryComponent -> {
               if (inventoryComponent.add(this)) {
                 collector
-                    .fetch(PlayerComponent.class)
+                    .fetch(InputComponent.class)
                     .ifPresent(
-                        pc ->
-                            pc.registerCallback(
+                        ic ->
+                            ic.registerCallback(
                                 KeyboardConfig.SECOND_SKILL.value(),
                                 collectorEntity -> {
                                   inventoryComponent
@@ -70,8 +70,8 @@ public class ItemWoodenBow extends Item {
   @Override
   public boolean drop(final Point position) {
     Game.hero()
-        .flatMap(hero -> hero.fetch(PlayerComponent.class))
-        .ifPresent(pc -> pc.removeCallback(KeyboardConfig.SECOND_SKILL.value()));
+        .flatMap(hero -> hero.fetch(InputComponent.class))
+        .ifPresent(ic -> ic.removeCallback(KeyboardConfig.SECOND_SKILL.value()));
 
     if (Game.tileAT(position) instanceof FloorTile) {
       Game.add(WorldItemBuilder.buildWorldItem(this, position));

--- a/dungeon/src/core/components/InputComponent.java
+++ b/dungeon/src/core/components/InputComponent.java
@@ -1,0 +1,154 @@
+package core.components;
+
+import core.Component;
+import core.Entity;
+import core.systems.InputSystem;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * This component stores pairs of keystroke codes with an associated callback function. The mappings
+ * can be added or changed via {@link #registerCallback} and removed via {@link
+ * #removeCallback(int)}. The codes for the buttons originate from {@link
+ * com.badlogic.gdx.Input.Keys}.
+ *
+ * <p>It is used by the {@link InputSystem} to process input events for the player.
+ */
+public class InputComponent implements Component {
+
+  private final Map<Integer, InputData> callbacks;
+  private boolean deactivate = false;
+
+  /** Create a new InputComponent. */
+  public InputComponent() {
+    callbacks = new HashMap<>();
+  }
+
+  /**
+   * Enables or disables the controls.
+   *
+   * @param deactivate true to disable player controls; false to enable them
+   */
+  public void deactivateControls(boolean deactivate) {
+    this.deactivate = deactivate;
+  }
+
+  /**
+   * Returns whether the controls are currently deactivated.
+   *
+   * @return true if controls are disabled; false if they are active
+   */
+  public boolean deactivateControls() {
+    return this.deactivate;
+  }
+
+  /**
+   * Registers a new callback for a key.
+   *
+   * <p>If a callback is already registered on this key, the old callback will be replaced.
+   *
+   * <p>The callback will be executed repeatedly while the key is pressed. Use {@link
+   * #registerCallback(int, Consumer, boolean)} to change this behavior.
+   *
+   * @param key The integer value of the key on which the callback should be executed.
+   * @param callback The {@link Consumer} that contains the callback to execute if the key is
+   *     pressed.
+   * @return {@code Optional<Consumer<Entity>>} The old callback, if one was existing. Can be null.
+   * @see com.badlogic.gdx.Gdx#input
+   */
+  public Optional<Consumer<Entity>> registerCallback(int key, final Consumer<Entity> callback) {
+    Consumer<Entity> oldCallback = null;
+    if (callbacks.containsKey(key)) {
+      oldCallback = callbacks.get(key).callback();
+    }
+    callbacks.put(key, new InputComponent.InputData(true, callback));
+    return Optional.ofNullable(oldCallback);
+  }
+
+  /**
+   * Registers a new callback for a key.
+   *
+   * <p>If a callback is already registered on this key, the old callback will be replaced.
+   *
+   * @param key The integer value of the key on which the callback should be executed.
+   * @param callback The {@link Consumer} that contains the callback to execute if the key is
+   *     pressed.
+   * @param repeat If the callback should be executed repeatedly while the key is pressed.
+   * @param pauseable If the callback should be executed while the game is paused.
+   * @return {@code Optional<Consumer<Entity>>} The old callback, if one was existing. Can be null.
+   */
+  public Optional<Consumer<Entity>> registerCallback(
+      int key, final Consumer<Entity> callback, boolean repeat, boolean pauseable) {
+    Consumer<Entity> oldCallback = null;
+    if (callbacks.containsKey(key)) {
+      oldCallback = callbacks.get(key).callback();
+    }
+    callbacks.put(key, new InputComponent.InputData(repeat, callback, pauseable));
+    return Optional.ofNullable(oldCallback);
+  }
+
+  /**
+   * Registers a new pauseable callback for a key.
+   *
+   * <p>If a callback is already registered on this key, the old callback will be replaced.
+   *
+   * <p>This method exists for compatibility reasons. Use {@link #registerCallback(int, Consumer,
+   * boolean, boolean)} instead.
+   *
+   * @param key The integer value of the key on which the callback should be executed.
+   * @param callback The {@link Consumer} that contains the callback to execute if the key is
+   *     pressed.
+   * @param repeat If the callback should be executed repeatedly while the key is pressed.
+   * @return {@code Optional<Consumer<Entity>>} The old callback, if one was existing. Can be null.
+   */
+  public Optional<Consumer<Entity>> registerCallback(
+      int key, final Consumer<Entity> callback, boolean repeat) {
+    return this.registerCallback(key, callback, repeat, false);
+  }
+
+  /**
+   * Removes the registered callback on the given key.
+   *
+   * @param key The integer value of the key.
+   * @see com.badlogic.gdx.Gdx#input
+   */
+  public void removeCallback(int key) {
+    callbacks.remove(key);
+  }
+
+  /** Removes all registered callbacks. */
+  public void removeCallbacks() {
+    callbacks.clear();
+  }
+
+  /**
+   * Gets the Key Configuration Map.
+   *
+   * @return A copy of the callback map.
+   */
+  public Map<Integer, InputData> callbacks() {
+    return new HashMap<>(callbacks);
+  }
+
+  /**
+   * Stores information for a Key Press Callback.
+   *
+   * @param repeat If the callback should be executed repeatedly while the key is pressed.
+   * @param callback The {@link Consumer} that contains the callback to execute if the key is
+   *     pressed.
+   * @param pauseable If the callback should be executed while the game is paused.
+   */
+  public record InputData(boolean repeat, Consumer<Entity> callback, boolean pauseable) {
+    /**
+     * WTF? .
+     *
+     * @param repeat foo
+     * @param callback foo
+     */
+    public InputData(boolean repeat, Consumer<Entity> callback) {
+      this(repeat, callback, false);
+    }
+  }
+}

--- a/dungeon/src/core/components/PlayerComponent.java
+++ b/dungeon/src/core/components/PlayerComponent.java
@@ -2,120 +2,21 @@ package core.components;
 
 import com.badlogic.gdx.Input;
 import core.Component;
-import core.Entity;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Consumer;
+import core.systems.InputSystem;
 
 /**
  * Marks an entity as playable by the player.
  *
- * <p>This component stores pairs of keystroke codes with an associated callback function. The
- * mappings can be added or changed via {@link #registerCallback} and removed via {@link
- * #removeCallback}. The codes for the buttons originate from {@link Input.Keys}.
+ * <p>This component keeps track of the number of open dialogs in the game. It provides methods to
+ * increment and decrement the dialog counter, as well as a method to check if any dialogs are
+ * currently open.
  *
  * @see Input.Keys
- * @see core.systems.PlayerSystem
+ * @see InputSystem
  */
 public final class PlayerComponent implements Component {
 
-  private final Map<Integer, InputData> callbacks;
   private int openDialogs = 0;
-  private boolean deactivate = false;
-
-  /** Create a new PlayerComponent. */
-  public PlayerComponent() {
-    callbacks = new HashMap<>();
-  }
-
-  /**
-   * Registers a new callback for a key.
-   *
-   * <p>If a callback is already registered on this key, the old callback will be replaced.
-   *
-   * <p>The callback will be executed repeatedly while the key is pressed. Use {@link
-   * #registerCallback(int, Consumer, boolean)} to change this behavior.
-   *
-   * @param key The integer value of the key on which the callback should be executed.
-   * @param callback The {@link Consumer} that contains the callback to execute if the key is
-   *     pressed.
-   * @return {@code Optional<Consumer<Entity>>} The old callback, if one was existing. Can be null.
-   * @see com.badlogic.gdx.Gdx#input
-   */
-  public Optional<Consumer<Entity>> registerCallback(int key, final Consumer<Entity> callback) {
-    Consumer<Entity> oldCallback = null;
-    if (callbacks.containsKey(key)) {
-      oldCallback = callbacks.get(key).callback();
-    }
-    callbacks.put(key, new InputData(true, callback));
-    return Optional.ofNullable(oldCallback);
-  }
-
-  /**
-   * Registers a new callback for a key.
-   *
-   * <p>If a callback is already registered on this key, the old callback will be replaced.
-   *
-   * @param key The integer value of the key on which the callback should be executed.
-   * @param callback The {@link Consumer} that contains the callback to execute if the key is
-   *     pressed.
-   * @param repeat If the callback should be executed repeatedly while the key is pressed.
-   * @param pauseable If the callback should be executed while the game is paused.
-   * @return {@code Optional<Consumer<Entity>>} The old callback, if one was existing. Can be null.
-   */
-  public Optional<Consumer<Entity>> registerCallback(
-      int key, final Consumer<Entity> callback, boolean repeat, boolean pauseable) {
-    Consumer<Entity> oldCallback = null;
-    if (callbacks.containsKey(key)) {
-      oldCallback = callbacks.get(key).callback();
-    }
-    callbacks.put(key, new InputData(repeat, callback, pauseable));
-    return Optional.ofNullable(oldCallback);
-  }
-
-  /**
-   * Registers a new pauseable callback for a key.
-   *
-   * <p>If a callback is already registered on this key, the old callback will be replaced.
-   *
-   * <p>This method exists for compatibility reasons. Use {@link #registerCallback(int, Consumer,
-   * boolean, boolean)} instead.
-   *
-   * @param key The integer value of the key on which the callback should be executed.
-   * @param callback The {@link Consumer} that contains the callback to execute if the key is
-   *     pressed.
-   * @param repeat If the callback should be executed repeatedly while the key is pressed.
-   * @return {@code Optional<Consumer<Entity>>} The old callback, if one was existing. Can be null.
-   */
-  public Optional<Consumer<Entity>> registerCallback(
-      int key, final Consumer<Entity> callback, boolean repeat) {
-    return this.registerCallback(key, callback, repeat, false);
-  }
-
-  /**
-   * Removes the registered callback on the given key.
-   *
-   * @param key The integer value of the key.
-   * @see com.badlogic.gdx.Gdx#input
-   */
-  public void removeCallback(int key) {
-    callbacks.remove(key);
-  }
-
-  /** Removes all registered callbacks. */
-  public void removeCallbacks() {
-    callbacks.clear();
-  }
-
-  /**
-   * Gets the Key Configuration Map.
-   *
-   * @return A copy of the callback map.
-   */
-  public Map<Integer, InputData> callbacks() {
-    return new HashMap<>(callbacks);
-  }
 
   /** Increases the dialogue counter by 1. */
   public void incrementOpenDialogs() {
@@ -134,43 +35,5 @@ public final class PlayerComponent implements Component {
    */
   public boolean openDialogs() {
     return openDialogs > 0;
-  }
-
-  /**
-   * Stores information for a Key Press Callback.
-   *
-   * @param repeat If the callback should be executed repeatedly while the key is pressed.
-   * @param callback The {@link Consumer} that contains the callback to execute if the key is
-   *     pressed.
-   * @param pauseable If the callback should be executed while the game is paused.
-   */
-  public record InputData(boolean repeat, Consumer<Entity> callback, boolean pauseable) {
-    /**
-     * WTF? .
-     *
-     * @param repeat foo
-     * @param callback foo
-     */
-    public InputData(boolean repeat, Consumer<Entity> callback) {
-      this(repeat, callback, false);
-    }
-  }
-
-  /**
-   * Enables or disables the player controls.
-   *
-   * @param deactivate true to disable player controls; false to enable them
-   */
-  public void deactivateControls(boolean deactivate) {
-    this.deactivate = deactivate;
-  }
-
-  /**
-   * Returns whether the player controls are currently deactivated.
-   *
-   * @return true if controls are disabled; false if they are active
-   */
-  public boolean deactivateControls() {
-    return this.deactivate;
   }
 }

--- a/dungeon/src/core/game/GameLoop.java
+++ b/dungeon/src/core/game/GameLoop.java
@@ -268,6 +268,6 @@ public final class GameLoop extends ScreenAdapter {
     ECSManagment.add(new VelocitySystem());
     ECSManagment.add(new FrictionSystem());
     ECSManagment.add(new MoveSystem());
-    ECSManagment.add(new PlayerSystem());
+    ECSManagment.add(new InputSystem());
   }
 }

--- a/dungeon/test/core/components/PlayerComponentTest.java
+++ b/dungeon/test/core/components/PlayerComponentTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.Test;
 public class PlayerComponentTest {
 
   private static final int counter = 0;
-  private PlayerComponent playableComponent;
+  private InputComponent inputComponent;
 
   /** WTF? . */
   @BeforeEach
   public void setup() {
-    playableComponent = new PlayerComponent();
+    inputComponent = new InputComponent();
   }
 
   /** WTF? . */
@@ -28,7 +28,7 @@ public class PlayerComponentTest {
           @Override
           public void accept(Entity entity) {}
         };
-    assertTrue(playableComponent.registerCallback(1, function).isEmpty());
+    assertTrue(inputComponent.registerCallback(1, function).isEmpty());
   }
 
   /** WTF? . */
@@ -43,7 +43,7 @@ public class PlayerComponentTest {
           @Override
           public void accept(Entity entity) {}
         };
-    playableComponent.registerCallback(1, function).get();
-    assertEquals(function, playableComponent.registerCallback(1, newfunction).get());
+    inputComponent.registerCallback(1, function).get();
+    assertEquals(function, inputComponent.registerCallback(1, newfunction).get());
   }
 }


### PR DESCRIPTION
Dieser PR splittet die Player- und Input-Logik, benennt das Input-System um und aktualisiert Javadoc.

- `PlayerComponent` dient jetzt nur noch als Marker und speichert offene Dialoge; `InputComponent` verwaltet Input-Callbacks.
- `HeroFactory` hat nun beide Komponenten.
- `PlayerSystem`, heißt nun `InputSystem`; JavaDoc angepasst/ergänzt.
- `InputSystem`-Refactor: Feld `running` zu `paused` umbenannt, um die Logik besser verstehen.