### PR TITLE
Dungeon: allow persistent entities

### DIFF
--- a/blockly/src/entities/HeroTankControlledFactory.java
+++ b/blockly/src/entities/HeroTankControlledFactory.java
@@ -28,7 +28,7 @@ public class HeroTankControlledFactory {
    */
   public static Entity newTankControlledHero() throws IOException {
     Entity hero = EntityFactory.newHero();
-
+    hero.persistent(true);
     InputComponent ic = hero.fetch(InputComponent.class).orElse(new InputComponent());
 
     // Remove any original movement controls

--- a/blockly/src/entities/HeroTankControlledFactory.java
+++ b/blockly/src/entities/HeroTankControlledFactory.java
@@ -28,7 +28,6 @@ public class HeroTankControlledFactory {
    */
   public static Entity newTankControlledHero() throws IOException {
     Entity hero = EntityFactory.newHero();
-    hero.persistent(true);
     InputComponent ic = hero.fetch(InputComponent.class).orElse(new InputComponent());
 
     // Remove any original movement controls

--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -136,6 +136,7 @@ public final class HeroFactory {
    */
   public static Entity newHero(Consumer<Entity> deathCallback) throws IOException {
     Entity hero = new Entity("hero");
+    hero.persistent(true);
     PlayerComponent pc = new PlayerComponent();
     hero.add(pc);
     CameraComponent cc = new CameraComponent();

--- a/dungeon/src/core/Entity.java
+++ b/dungeon/src/core/Entity.java
@@ -179,8 +179,9 @@ public final class Entity implements Comparable<Entity> {
 
   /**
    * Sets whether this entity is persistent across level loads.
-   * <p>
-   * If an entity is persistent, it will be carried over to the next level when the current level is loaded.
+   *
+   * <p>If an entity is persistent, it will be carried over to the next level when the current level
+   * is loaded.
    *
    * @param persistent true to make the entity persistent across levels, false otherwise
    */
@@ -196,7 +197,6 @@ public final class Entity implements Comparable<Entity> {
   public boolean isPersistent() {
     return this.persistent;
   }
-
 
   @Override
   public String toString() {

--- a/dungeon/src/core/Entity.java
+++ b/dungeon/src/core/Entity.java
@@ -38,6 +38,8 @@ public final class Entity implements Comparable<Entity> {
   private final HashMap<Class<? extends Component>, Component> components;
   private String name;
 
+  private boolean persistent = false;
+
   /**
    * Create a new Entity with a generated id.
    *
@@ -174,6 +176,27 @@ public final class Entity implements Comparable<Entity> {
   public String name() {
     return name;
   }
+
+  /**
+   * Sets whether this entity is persistent across level loads.
+   * <p>
+   * If an entity is persistent, it will be carried over to the next level when the current level is loaded.
+   *
+   * @param persistent true to make the entity persistent across levels, false otherwise
+   */
+  public void persistent(boolean persistent) {
+    this.persistent = persistent;
+  }
+
+  /**
+   * Checks whether this entity is persistent across level loads.
+   *
+   * @return true if the entity is persistent and will move to the next level, false otherwise
+   */
+  public boolean isPersistent() {
+    return this.persistent;
+  }
+
 
   @Override
   public String toString() {

--- a/dungeon/src/core/game/ECSManagment.java
+++ b/dungeon/src/core/game/ECSManagment.java
@@ -64,9 +64,10 @@ public final class ECSManagment {
    * <p>If necessary, the {@link System} will trigger {@link System#triggerOnAdd(Entity)} .
    *
    * @param entity the entity to add.
+   * @return added entity for chaining
    * @throws IllegalArgumentException if an entity with the same id already exists in the game.
    */
-  public static void add(Entity entity) {
+  public static Entity add(Entity entity) {
     // Prevent duplicate IDs for different entity instances
     boolean duplicateIdExists = allEntities().anyMatch(e -> e != entity && e.id() == entity.id());
     if (duplicateIdExists)
@@ -78,6 +79,7 @@ public final class ECSManagment {
 
     activeEntityStorage.forEach(f -> f.add(entity));
     LOGGER.info(entity + " will be added to the Game.");
+    return entity;
   }
 
   /**
@@ -86,11 +88,13 @@ public final class ECSManagment {
    * <p>If necessary, the {@link System}s will trigger {@link System#triggerOnAdd(Entity)} .
    *
    * @param entity the entity to remove
+   * @return removed entity for chaining
    */
-  public static void remove(Entity entity) {
+  public static Entity remove(Entity entity) {
     activeEntityStorage.forEach(f -> f.remove(entity));
     EntityIdProvider.unregister(entity.id());
     LOGGER.info(entity + " will be removed from the Game.");
+    return entity;
   }
 
   /**

--- a/dungeon/src/core/game/GameLoop.java
+++ b/dungeon/src/core/game/GameLoop.java
@@ -77,7 +77,9 @@ public final class GameLoop extends ScreenAdapter {
         } catch (MissingComponentException e) {
           LOGGER.warning(e.getMessage());
         }
-        hero.ifPresent(ECSManagment::add);
+        ECSManagment.allEntities()
+            .filter(entity -> entity.isPersistent())
+            .forEach(ECSManagment::add);
         if (firstLoad && Game.isCheckPatternEnabled())
           CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());
         PreRunConfiguration.userOnLevelLoad().accept(firstLoad);

--- a/dungeon/src/core/game/GameLoop.java
+++ b/dungeon/src/core/game/GameLoop.java
@@ -79,6 +79,7 @@ public final class GameLoop extends ScreenAdapter {
         }
         ECSManagment.allEntities()
             .filter(entity -> entity.isPersistent())
+            .map(ECSManagment::remove)
             .forEach(ECSManagment::add);
         if (firstLoad && Game.isCheckPatternEnabled())
           CheckPatternPainter.paintCheckerPattern(Game.currentLevel().layout());


### PR DESCRIPTION
Fügt ein Flag `persistant` in `Entity` hinzu.
Wenn das Flag auf True ist, wird die Entität mit in das nächste Level genommen.
Das ist grade für so unsichtbare ControllerEntitäten oder HUD geschichten praktisch. 

Achtung: Die Position wird nicht neu gesetzt. 