### PR TITLE
Escaperoom: add weight to PetriNet Arcs

### DIFF
--- a/escapeRoom/src/petriNet/PlaceComponent.java
+++ b/escapeRoom/src/petriNet/PlaceComponent.java
@@ -25,9 +25,34 @@ public class PlaceComponent implements Component {
     return tokenCounter;
   }
 
+  /**
+   * Adds token to this place.
+   *
+   * @param amount of token to add.
+   */
+  public void produce(int amount) {
+    tokenCounter += amount;
+  }
+
   /** Adds one token to this place. */
   public void produce() {
     tokenCounter++;
+  }
+
+  /**
+   * Removes token from this place.
+   *
+   * <p>It is the caller's responsibility to ensure that the counter does not become negative.
+   *
+   * @param amount amount of token to consume.
+   * @return true if a token was consumed, false otherwise.
+   */
+  public boolean consume(int amount) {
+    if (tokenCounter >= amount) {
+      tokenCounter -= amount;
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -38,10 +63,6 @@ public class PlaceComponent implements Component {
    * @return true if a token was consumed, false otherwise.
    */
   public boolean consume() {
-    if (tokenCounter > 0) {
-      tokenCounter--;
-      return true;
-    }
-    return false;
+    return consume(1);
   }
 }

--- a/escapeRoom/test/petriNet/PetriNetSystemTest.java
+++ b/escapeRoom/test/petriNet/PetriNetSystemTest.java
@@ -475,4 +475,86 @@ public class PetriNetSystemTest {
     assertEquals(0, p1.tokenCount(), "No new input tokens, so transition should not fire again");
     assertEquals(1, p2.tokenCount(), "Output should remain unchanged");
   }
+
+  /** Tests that a transition consumes multiple tokens from an input place based on its weight. */
+  @Test
+  void testTransitionConsumesWeightedTokens() {
+    PlaceComponent input = new PlaceComponent();
+    input.produce(3);
+    PlaceComponent output = new PlaceComponent();
+
+    TransitionComponent transition = new TransitionComponent();
+
+    PetriNetSystem.addInputArc(transition, input, 2);
+    PetriNetSystem.addOutputArc(transition, output);
+
+    PetriNetSystem system = new PetriNetSystem();
+    system.execute();
+
+    assertEquals(1, input.tokenCount(), "Input should have 1 token left after consuming 2");
+    assertEquals(1, output.tokenCount(), "Output should have 1 token produced");
+  }
+
+  /**
+   * Tests that a transition does not fire if the input place has fewer tokens than required by
+   * weight.
+   */
+  @Test
+  void testTransitionNotEnabledWhenInsufficientTokens() {
+    PlaceComponent input = new PlaceComponent();
+    input.produce();
+    PlaceComponent output = new PlaceComponent();
+
+    TransitionComponent transition = new TransitionComponent();
+
+    PetriNetSystem.addInputArc(transition, input, 2);
+    PetriNetSystem.addOutputArc(transition, output);
+
+    PetriNetSystem system = new PetriNetSystem();
+    system.execute();
+
+    assertEquals(1, input.tokenCount(), "Input should still have 1 token (not enough to fire)");
+    assertEquals(0, output.tokenCount(), "Output should have 0 tokens (transition not enabled)");
+  }
+
+  /** Tests that a transition produces multiple tokens in an output place based on its weight. */
+  @Test
+  void testTransitionProducesWeightedTokens() {
+    PlaceComponent input = new PlaceComponent();
+    input.produce(2);
+    PlaceComponent output = new PlaceComponent();
+
+    TransitionComponent transition = new TransitionComponent();
+
+    PetriNetSystem.addInputArc(transition, input, 2);
+    PetriNetSystem.addOutputArc(transition, output, 3);
+
+    PetriNetSystem system = new PetriNetSystem();
+    system.execute();
+
+    assertEquals(0, input.tokenCount(), "Input should have 0 tokens left after consuming 2");
+    assertEquals(3, output.tokenCount(), "Output should have 3 tokens produced");
+  }
+
+  /** Tests that adding an output arc with a weight of 0 throws an exception. */
+  @Test
+  void testAddOutputArcWithZeroWeightThrows() {
+    TransitionComponent transition = new TransitionComponent();
+    PlaceComponent place = new PlaceComponent();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PetriNetSystem.addOutputArc(transition, place, 0),
+        "Weight 0 should not be allowed");
+  }
+
+  /** Tests that adding an output arc with a negative weight throws an exception. */
+  @Test
+  void testAddOutputArcWithNegativeWeightThrows() {
+    TransitionComponent transition = new TransitionComponent();
+    PlaceComponent place = new PlaceComponent();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PetriNetSystem.addOutputArc(transition, place, -1),
+        "Negative weight should not be allowed");
+  }
 }

--- a/escapeRoom/test/petriNet/PlaceComponentTest.java
+++ b/escapeRoom/test/petriNet/PlaceComponentTest.java
@@ -55,4 +55,46 @@ public class PlaceComponentTest {
     assertEquals(0, place.tokenCount(), "Counter should still be 0");
     assertFalse(b);
   }
+
+  /** Tests that producing multiple tokens increases the counter by the specified amount. */
+  @Test
+  void testProduceMultipleTokens() {
+    place.produce(3);
+    assertEquals(3, place.tokenCount(), "Counter should be 3 after producing 3 tokens");
+    place.produce(2);
+    assertEquals(5, place.tokenCount(), "Counter should be 5 after producing 2 more tokens");
+  }
+
+  /**
+   * Tests that consuming multiple tokens decreases the counter by the specified amount when enough
+   * tokens are available.
+   */
+  @Test
+  void testConsumeMultipleTokensSuccess() {
+    place.produce(5);
+    boolean result = place.consume(3);
+    assertTrue(result, "Consume should succeed when enough tokens are available");
+    assertEquals(2, place.tokenCount(), "Counter should be 2 after consuming 3 tokens from 5");
+  }
+
+  /** Tests that consuming more tokens than available fails and does not change the counter. */
+  @Test
+  void testConsumeMultipleTokensFail() {
+    place.produce(2);
+    boolean result = place.consume(5);
+    assertFalse(result, "Consume should fail when not enough tokens are available");
+    assertEquals(2, place.tokenCount(), "Counter should remain unchanged when consume fails");
+  }
+
+  /**
+   * Tests that consuming the exact number of available tokens succeeds and leaves the counter at
+   * zero.
+   */
+  @Test
+  void testConsumeExactAmount() {
+    place.produce(4);
+    boolean result = place.consume(4);
+    assertTrue(result, "Consume should succeed when consuming all available tokens");
+    assertEquals(0, place.tokenCount(), "Counter should be 0 after consuming all tokens");
+  }
 }


### PR DESCRIPTION
Erweitert PR #2337.
Dort hatte ich die Bedingung eingebaut, dass eine Transition immer nur ein Token pro Place konsumieren bzw. produzieren kann.
Diese Bedingung ist Unsinn und schränkt nur ein.
Dieser PR ergänzt die Arcs im Petri-Netz um Weights.