### PR TITLE
Dungeon: Hotfix Game.randomTilePoint() – Endlosschleife/StackOverflow behoben

### DIFF
--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -630,7 +630,7 @@ public final class Game {
    * @return Position of the Tile as Point or an empty Optional if there is no tile of that type.
    */
   public static Optional<Point> randomTilePoint(final LevelElement elementTyp) {
-    return currentLevel().flatMap(level -> randomTilePoint(elementTyp));
+    return currentLevel().flatMap(level -> level.randomTilePoint(elementTyp));
   }
 
   /**


### PR DESCRIPTION

### Beschreibung

**Problem**
Beim Wechsel von einem Level zum anderen stürzte das Spiel sofort ab.
Die Ursache war ein `StackOverflowError` in der Methode

```java
public static Optional<Point> randomTilePoint(final LevelElement elementTyp)
```

In der alten Version rief sich die Methode selbst immer wieder über `Game.randomTilePoint(...)` auf → Endlosschleife → Crash.

---

**Lösung**
Der Aufruf wurde korrigiert, sodass nun die Implementierung des aktuellen Levels verwendet wird:

```java
return currentLevel().flatMap(level -> level.randomTilePoint(elementTyp));
```

Damit wird die Anfrage korrekt an das aktuelle Level delegiert, ohne Endlosschleife.

---

**Tests/Checkliste:**

* [x] Builds laufen (`./gradlew clean build`)
* [x] Keine API-Änderungen

---

**Ergebnis**

* Spiel läuft wieder stabil
* Levelwechsel funktioniert fehlerfrei
* Keine Auswirkungen auf andere Methoden


