### PR TITLE
set working directory to project root for all subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ allprojects {
         dependsOn classes
         standardInput = System.in
         ignoreExitValue true
+        workingDir = rootProject.projectDir
         systemProperty 'BASELOGDIR', project.baseLogDir
         systemProperty 'BASEREFLECTIONDIR', project.baseReflectionDir
     }


### PR DESCRIPTION
Ein kleiner Fix, der sich in #2380 versteckt, den ich aber unabhängig von den Ergebnissen dort haben möchte.

Aktuell ist das `workingDir` immer das Verzeichnis, in dem sich das Start-Target befindet.
Also für `runDevDungeon` wäre das `USERSTUFF/dungeon-repo/devDungeon/`.

Ich passe hier die Top-Level `build.gradle` an, damit **alle Projekte** den Project-Root als `workingDir` verwenden.
Das vereinheitlicht zusätzlich das Verhalten, egal ob über Gradle oder über die IDE gestartet wird (IntelliJ verwendet nämlich immer das Root-Project als srcDir).
