### PR TITLE
Dungeon: always check normal file system for assets too

### DIFF
--- a/blockly/build.gradle
+++ b/blockly/build.gradle
@@ -46,6 +46,7 @@ tasks.register('buildBlocklyJar', Jar) {
     group 'jar'
     archiveBaseName = 'Blockly'
     from sourceSets.main.output
+    dependsOn project(':dungeon').tasks.named('jar') // <-- ensure dungeon.jar is built
     from project(':dungeon').sourceSets.main.output
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }

--- a/dungeon/src/core/components/DrawComponent.java
+++ b/dungeon/src/core/components/DrawComponent.java
@@ -453,8 +453,10 @@ public final class DrawComponent implements Component {
                 .getCodeSource()
                 .getLocation()
                 .getPath());
+    // if we run in a jar (or a sub-project) check the jar for the files
     if (jarFile.isFile()) loadAnimationsFromJar(path, jarFile);
-    else loadAnimationsFromIDE(path);
+    // always check the normal fileystem too
+    loadAnimationsFromFileSystem(path);
   }
 
   /**
@@ -558,11 +560,11 @@ public final class DrawComponent implements Component {
   }
 
   /**
-   * Load animations if the game is running in the IDE (or over the shell).
+   * Load animations from the normal filesystem.
    *
    * @param path Path to the animations.
    */
-  private void loadAnimationsFromIDE(final IPath path) {
+  private void loadAnimationsFromFileSystem(final IPath path) {
     URL url = DrawComponent.class.getResource("/" + path.pathString());
     if (url != null) {
       try {

--- a/escapeRoom/build.gradle
+++ b/escapeRoom/build.gradle
@@ -41,6 +41,7 @@ tasks.register('buildDemoRoom', Jar) {
     group = 'jar'
     archiveBaseName.set('EscaperoomDemo')
     archiveFileName.set('EscapeRoomDemo.jar')
+    dependsOn project(':dungeon').tasks.named('jar')
 
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 


### PR DESCRIPTION
fixes #2393 

Das Problem war, dass die Sub-Projekte eine `dungeon.jar` bauen und unser `DrawComponent` dann in den "run in jar" Case geht und im Jar nach den Assets sucht.
Das Sub-Projekt und die assets sind aber nicht Teil der jar.


Dieser PR nimmt das `else` raus. Jetzt wird IMMER das normale File-System durchsucht und wenn ich in einer Jar Laufe, dann auch die jar. 

Das funktioniert sowohl für Ausführungen der Projekte außerhalb einer Jar aber auch für Projekte in einer jar. 

Hab noch die jar Targets der EscDemo und von Blockly erweitert, die haben bisher nicht verlangt das die Dungeon.jar da ist, brauchen die aber. 