### PR TITLE
Dungeon: make `Item#drop` return Entity + arrows stick in wall

### DIFF
--- a/dungeon/src/contrib/item/Item.java
+++ b/dungeon/src/contrib/item/Item.java
@@ -15,6 +15,7 @@ import core.utils.components.draw.animation.Animation;
 import core.utils.logging.CustomLogLevel;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.logging.Logger;
 
@@ -288,18 +289,20 @@ public class Item implements CraftingIngredient, CraftingResult {
   }
 
   /**
-   * Called when an item should be dropped.
+   * Drops an item at the specified position and adds the created entity to the game.
    *
-   * @param position The position where the item should be dropped.
-   * @return Whether the item was dropped successfully.
+   * @param position the position where the item should be dropped
+   * @return an {@code Optional} containing the dropped item entity if the drop was successful, or
+   *     an empty {@code Optional} otherwise
    */
-  public boolean drop(final Point position) {
+  public Optional<Entity> drop(final Point position) {
     Tile tile = Game.tileAt(position).orElse(null);
     if (tile instanceof FloorTile) {
-      Game.add(WorldItemBuilder.buildWorldItem(this, position));
-      return true;
+      Entity item = (WorldItemBuilder.buildWorldItem(this, position));
+      Game.add(item);
+      return Optional.of(item);
     }
-    return false;
+    return Optional.empty();
   }
 
   /**

--- a/dungeon/src/contrib/item/concreteItem/ItemFairy.java
+++ b/dungeon/src/contrib/item/concreteItem/ItemFairy.java
@@ -14,6 +14,7 @@ import core.utils.TriConsumer;
 import core.utils.components.draw.animation.Animation;
 import core.utils.components.path.IPath;
 import core.utils.components.path.SimpleIPath;
+import java.util.Optional;
 
 /**
  * A fairy pickup that restores health on collision.
@@ -47,7 +48,7 @@ public class ItemFairy extends Item {
   }
 
   @Override
-  public boolean drop(final Point position) {
+  public Optional<Entity> drop(final Point position) {
     Tile tile = Game.tileAt(position).orElse(null);
     if (tile instanceof FloorTile) {
       TriConsumer<Entity, Entity, Direction> onCollide =
@@ -67,8 +68,8 @@ public class ItemFairy extends Item {
       Entity pickUpItem = WorldItemBuilder.buildWorldItem(this, position);
       pickUpItem.add(new CollideComponent(onCollide, CollideComponent.DEFAULT_COLLIDER));
       Game.add(pickUpItem);
-      return true;
+      return Optional.of(pickUpItem);
     }
-    return false;
+    return Optional.empty();
   }
 }

--- a/dungeon/src/contrib/item/concreteItem/ItemHeart.java
+++ b/dungeon/src/contrib/item/concreteItem/ItemHeart.java
@@ -14,6 +14,7 @@ import core.utils.TriConsumer;
 import core.utils.components.draw.animation.Animation;
 import core.utils.components.path.IPath;
 import core.utils.components.path.SimpleIPath;
+import java.util.Optional;
 
 /**
  * A heart pickup that restores health on collision.
@@ -51,7 +52,7 @@ public class ItemHeart extends Item {
   }
 
   @Override
-  public boolean drop(final Point position) {
+  public Optional<Entity> drop(final Point position) {
     Tile tile = Game.tileAt(position).orElse(null);
     if (tile instanceof FloorTile) {
       TriConsumer<Entity, Entity, Direction> onCollide =
@@ -70,8 +71,8 @@ public class ItemHeart extends Item {
       Entity pickUpItem = WorldItemBuilder.buildWorldItem(this, position);
       pickUpItem.add(new CollideComponent(onCollide, CollideComponent.DEFAULT_COLLIDER));
       Game.add(pickUpItem);
-      return true;
+      return Optional.of(pickUpItem);
     }
-    return false;
+    return Optional.empty();
   }
 }

--- a/dungeon/src/contrib/item/concreteItem/ItemWoodenArrow.java
+++ b/dungeon/src/contrib/item/concreteItem/ItemWoodenArrow.java
@@ -36,6 +36,16 @@ public class ItemWoodenArrow extends Item {
         MAX_ARROW_STACK_SIZE);
   }
 
+  /**
+   * Create a {@link Item} that looks like an arrow and can be collected to be used as ammunition
+   * for the bow item.
+   *
+   * <p>The stack size will be set to one.
+   */
+  public ItemWoodenArrow() {
+    this(1);
+  }
+
   @Override
   public void use(final Entity user) {
     user.fetch(PositionComponent.class)

--- a/dungeon/src/contrib/item/concreteItem/ItemWoodenBow.java
+++ b/dungeon/src/contrib/item/concreteItem/ItemWoodenBow.java
@@ -14,6 +14,7 @@ import core.utils.Point;
 import core.utils.components.draw.animation.Animation;
 import core.utils.components.path.IPath;
 import core.utils.components.path.SimpleIPath;
+import java.util.Optional;
 
 /**
  * This item is a bow. It can be used to shoot arrows, if any are stored in the inventory.
@@ -49,7 +50,7 @@ public class ItemWoodenBow extends Item {
   }
 
   @Override
-  public boolean drop(final Point position) {
+  public Optional<Entity> drop(final Point position) {
     Game.hero()
         .flatMap(hero -> hero.fetch(SkillComponent.class))
         .ifPresent(sc -> sc.removeSkill(BowSkill.class));
@@ -58,10 +59,11 @@ public class ItemWoodenBow extends Item {
         .filter(FloorTile.class::isInstance)
         .map(
             tile -> {
-              Game.add(WorldItemBuilder.buildWorldItem(this, position));
-              return true;
+              Entity bow = WorldItemBuilder.buildWorldItem(this, position);
+              Game.add(bow);
+              return Optional.of(bow);
             })
-        .orElse(false);
+        .orElse(Optional.empty());
   }
 
   @Override

--- a/dungeon/src/contrib/utils/components/skill/Skill.java
+++ b/dungeon/src/contrib/utils/components/skill/Skill.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -20,6 +21,9 @@ import java.util.stream.Collectors;
  * <p>This class also provides a static {@link #NONE} instance that represents a no-op skill.
  */
 public abstract class Skill {
+
+  /** Random Instance to use for skills. */
+  public static final Random RANDOM = new Random();
 
   /** Logger for skill-related events. */
   protected static final Logger LOGGER = Logger.getLogger(Skill.class.getSimpleName());

--- a/dungeon/src/contrib/utils/components/skill/projectileSkill/ProjectileSkill.java
+++ b/dungeon/src/contrib/utils/components/skill/projectileSkill/ProjectileSkill.java
@@ -157,7 +157,8 @@ public abstract class ProjectileSkill extends Skill {
    * Defines what happens when the projectile hits a wall.
    *
    * @param caster The entity that cast the projectile.
-   * @return A consumer handling wall collisions.
+   * @return A consumer handling wall collisions. The Entity for the Consumer will be the projectile
+   *     entity.
    */
   protected Consumer<Entity> onWallHit(Entity caster) {
     return REMOVE_CONSUMER;


### PR DESCRIPTION
Pfeile können jetzt in der Wand stecken bleiben und wieder aufgesammelt werden.
Technisch wird ein Arrow bei der `onWallhit` gespawnt.
Das ganze ist Chancenbasiert (default 10%)

Dafür musste ich `Item#drop` nicht mehr ein boolean sondern ein `Optional<Entity>` returnen lassen. 

Mit #2397 passt dann auch optisch die Rotation


Wer testen will: Im `runDemoRoom` hat man direkt nen Hero mit Bogen (reminder mit . und , wechselt man zwischen den skills)