### PR TITLE
All: Fix Starter and add gradle target to javadoc

### DIFF
--- a/advancedDungeon/src/aiAdvanced/starter/ComparePathfindingStarter.java
+++ b/advancedDungeon/src/aiAdvanced/starter/ComparePathfindingStarter.java
@@ -38,7 +38,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 
-/** This class starts a comparator for the pathfinding algorithms. */
+/**
+ * This class starts a comparator for the pathfinding algorithms.
+ *
+ * <p>Usage: run with the Gradle task {@code runPathFindingComparison}.
+ */
 public class ComparePathfindingStarter {
   private static final Entity[] RUNNERS = new Entity[2];
 

--- a/advancedDungeon/src/aiAdvanced/starter/PathfinderStarter.java
+++ b/advancedDungeon/src/aiAdvanced/starter/PathfinderStarter.java
@@ -23,7 +23,11 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/** This class starts the dungeon Ai level to visualize the DFS and BFS. */
+/**
+ * This class starts the dungeon Ai level to visualize the DFS and BFS.
+ *
+ * <p>Usage: run with the Gradle task {@code runPathfinder}.
+ */
 public class PathfinderStarter {
   private static final Logger LOGGER = Logger.getLogger(PathfinderStarter.class.getName());
   private static final boolean DRAW_CHECKER_PATTERN = true;

--- a/advancedDungeon/src/produsAdvanced/AdvancedDungeon.java
+++ b/advancedDungeon/src/produsAdvanced/AdvancedDungeon.java
@@ -33,6 +33,8 @@ import produsAdvanced.level.*;
  * <p>This class is responsible for initializing and launching the game. It configures the game
  * environment, sets up levels, adds systems, creates the player hero, and integrates dynamic
  * recompilation of user control code for live testing of custom hero controllers.
+ *
+ * <p>Usage: run with the Gradle task {@code runAdvancedDungeon}.
  */
 public class AdvancedDungeon {
   /**
@@ -185,6 +187,10 @@ public class AdvancedDungeon {
     Game.add(new FallingSystem());
     Game.add(new PitSystem());
     Game.add(new EventScheduler());
+    Game.add(new ManaRestoreSystem());
+    Game.add(new StaminaRestoreSystem());
+    Game.add(new ManaBarSystem());
+    Game.add(new StaminaBarSystem());
     if (DEBUG_MODE) Game.add(new LevelEditorSystem());
   }
 

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -31,6 +31,10 @@ import systems.TintTilesSystem;
 /**
  * This Class must be run to start the dungeon application. Otherwise, the blockly frontend won't
  * have any effect
+ *
+ * <p>Usage: run with the Gradle task {@code runBlockly}.
+ *
+ * <p>For the Web-Ui you have to start the frontend yourself.
  */
 public class Client {
 

--- a/devDungeon/src/starter/DevDungeon.java
+++ b/devDungeon/src/starter/DevDungeon.java
@@ -33,7 +33,11 @@ import java.util.logging.Level;
 import level.devlevel.*;
 import systems.*;
 
-/** Starter class for the DevDungeon game. */
+/**
+ * Starter class for the DevDungeon game.
+ *
+ * <p>Usage: run with the Gradle task {@code runDevDungeon}.
+ */
 public class DevDungeon {
   private static final String BACKGROUND_MUSIC = "sounds/background.wav";
   private static final boolean ENABLE_CHEATS = false;

--- a/dungeon/src/starter/BasicStarter.java
+++ b/dungeon/src/starter/BasicStarter.java
@@ -1,7 +1,6 @@
 package starter;
 
 import contrib.entities.HeroFactory;
-import contrib.systems.ProjectileSystem;
 import core.Game;
 import core.configuration.KeyboardConfig;
 import core.level.DungeonLevel;
@@ -12,23 +11,38 @@ import java.io.IOException;
 import java.util.logging.Level;
 
 /**
- * @return WTF? .
+ * Entry point for running a minimal dungeon game instance.
+ *
+ * <p>This starter initializes the game framework, loads the dungeon configuration, spawns a basic
+ * hero, and starts the game loop. It is mainly used to verify that the engine runs correctly with a
+ * simple setup.
+ *
+ * <p>Usage: run with the Gradle task {@code runBasicStarter}.
  */
 public class BasicStarter {
 
   /**
-   * WTF? .
+   * Main entry point to launch the basic dungeon game.
    *
-   * @param args foo
-   * @throws IOException foo
+   * @param args command-line arguments (not used in this starter)
    */
-  public static void main(String[] args) throws IOException {
+  public static void main(String[] args) {
     Game.initBaseLogger(Level.WARNING);
     DungeonLoader.addLevel(Tuple.of("maze", DungeonLevel.class));
-    Game.loadConfig(new SimpleIPath("dungeon_config.json"), KeyboardConfig.class);
+    try {
+      Game.loadConfig(new SimpleIPath("dungeon_config.json"), KeyboardConfig.class);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
     Game.disableAudio(true);
-    Game.add(HeroFactory.newHero());
-    Game.add(new ProjectileSystem());
+    Game.userOnSetup(
+        () -> {
+          try {
+            Game.add(HeroFactory.newHero());
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        });
     Game.frameRate(30);
     Game.windowTitle("Basic Dungeon");
     Game.run();

--- a/escapeRoom/src/starter/CoopDungeon.java
+++ b/escapeRoom/src/starter/CoopDungeon.java
@@ -22,6 +22,8 @@ import java.util.logging.Level;
  *
  * <p>The players have to work together to solve small parkour-style riddles, such as jumping over
  * pits or using levers to open gates to reach the end.
+ *
+ * <p>Usage: run with the Gradle task {@code runCoopDungeon}.
  */
 public class CoopDungeon {
   private static final boolean DEBUG_MODE = false;
@@ -96,6 +98,10 @@ public class CoopDungeon {
     Game.add(new LeverSystem());
     Game.add(new PressurePlateSystem());
     Game.add(new IdleSoundSystem());
+    Game.add(new ManaRestoreSystem());
+    Game.add(new StaminaRestoreSystem());
+    Game.add(new ManaBarSystem());
+    Game.add(new StaminaBarSystem());
   }
 
   private static void setupMusic() {

--- a/escapeRoom/src/starter/DemoRoom.java
+++ b/escapeRoom/src/starter/DemoRoom.java
@@ -17,12 +17,15 @@ import hint.HintLogComponent;
 import java.io.IOException;
 import java.util.logging.Level;
 
-/** Starter for the Demo Escaperoom Dungeon. */
+/**
+ * Starter for the Demo Escaperoom Dungeon.
+ *
+ * <p>Usage: run with the Gradle task {@code runDemoRoom}.
+ */
 public class DemoRoom {
   private static final boolean DEBUG_MODE = false;
   private static final String BACKGROUND_MUSIC = "sounds/background.wav";
   private static final int START_LEVEL = 0;
-  private static final CharacterClass CHARACTER_CLASS = CharacterClass.HUNTER;
 
   /**
    * Main method to start the game.
@@ -60,7 +63,7 @@ public class DemoRoom {
   }
 
   private static void createHero() throws IOException {
-    Entity hero = HeroFactory.newHero(CHARACTER_CLASS);
+    Entity hero = HeroFactory.newHero(CharacterClass.HUNTER);
     hero.add(new HintLogComponent());
     Game.add(hero);
   }


### PR DESCRIPTION
Fixt den `BasicStarter` und `DemoRoom` (siehe #2401)
Ergänzt im AdvancedDungeon und den EscapeRooms die neuen Resourcen Systeme aus #2368 

Fügt jedem Starter in der Javadoc einen Hinweis auf das gradle target hinzu
