### PR TITLE
Dungeon: remove Leveloffset

### DIFF
--- a/advancedDungeon/src/aiAdvanced/starter/ComparePathfindingStarter.java
+++ b/advancedDungeon/src/aiAdvanced/starter/ComparePathfindingStarter.java
@@ -91,9 +91,9 @@ public class ComparePathfindingStarter {
     Tile[][] layout = Game.currentLevel().orElse(null).layout();
     int levelHeight = layout.length;
 
-    Point topTile = layout[0][0].coordinate().translate(Vector2.of(0, 2)).toCenteredPoint();
+    Point topTile = layout[0][0].coordinate().translate(Vector2.of(0, 2)).toPoint();
     Point bottomTile =
-        layout[levelHeight - 1][0].coordinate().translate(Vector2.of(0, 2)).toCenteredPoint();
+        layout[levelHeight - 1][0].coordinate().translate(Vector2.of(0, 2)).toPoint();
 
     // Zoom out until the whole level is visible
     int currentTries = 0;
@@ -131,7 +131,7 @@ public class ComparePathfindingStarter {
             Game.currentLevel().map(ILevel::customPoints).orElse(Collections.emptyList())));
 
     // Position the runners
-    Debugger.TELEPORT(orgStart.toCenteredPoint());
+    Debugger.TELEPORT(orgStart.toPoint());
 
     RUNNERS[1] = createRunnerMob();
     PositionComponent pc =
@@ -139,7 +139,7 @@ public class ComparePathfindingStarter {
             .fetch(PositionComponent.class)
             .orElseThrow(
                 () -> MissingComponentException.build(RUNNERS[1], PositionComponent.class));
-    pc.position(newStart.toCenteredPoint());
+    pc.position(newStart.toPoint());
 
     setupPathFindingSystem(rows);
   }

--- a/advancedDungeon/src/produsAdvanced/level/AdvancedBerryLevel.java
+++ b/advancedDungeon/src/produsAdvanced/level/AdvancedBerryLevel.java
@@ -147,8 +147,7 @@ public class AdvancedBerryLevel extends AdvancedLevel {
   private void spawnBerry(boolean isToxic) {
     Entity berry =
         WorldItemBuilder.buildWorldItem(
-            new Berry(isToxic),
-            Game.randomTile(LevelElement.FLOOR).get().coordinate().toCenteredPoint());
+            new Berry(isToxic), Game.randomTile(LevelElement.FLOOR).get().coordinate().toPoint());
     berry.name(Berry.NAME);
     HealthComponent health =
         new HealthComponent(
@@ -180,7 +179,7 @@ public class AdvancedBerryLevel extends AdvancedLevel {
   /** Creates a chest at the second custom point. */
   private void createChest() {
     try {
-      chest = EntityFactory.newChest(Set.of(), customPoints().get(1).toCenteredPoint());
+      chest = EntityFactory.newChest(Set.of(), customPoints().get(1).toPoint());
     } catch (IOException e) {
       throw new RuntimeException("Failed to create chest", e);
     }
@@ -190,7 +189,7 @@ public class AdvancedBerryLevel extends AdvancedLevel {
   /** Creates an NPC that gives the player a berry-fetching quest. */
   private void createNPC() {
     Entity npc = new Entity("NPC");
-    npc.add(new PositionComponent(customPoints().get(0).toCenteredPoint()));
+    npc.add(new PositionComponent(customPoints().get(0).toPoint()));
 
     npc.add(new DrawComponent(new SimpleIPath(NPC_TEXTURE_PATH)));
     npc.add(new CollideComponent());

--- a/advancedDungeon/src/produsAdvanced/level/AdvancedControlLevel3.java
+++ b/advancedDungeon/src/produsAdvanced/level/AdvancedControlLevel3.java
@@ -75,9 +75,9 @@ public class AdvancedControlLevel3 extends AdvancedLevel {
 
     exit = (ExitTile) Game.endTile().orElseThrow();
     exit.close();
-    Entity lever1 = LeverFactory.createLever(customPoints().get(0).toCenteredPoint());
-    Entity lever2 = LeverFactory.createLever(customPoints().get(1).toCenteredPoint());
-    Entity lever3 = LeverFactory.createLever(customPoints().get(2).toCenteredPoint());
+    Entity lever1 = LeverFactory.createLever(customPoints().get(0).toPoint());
+    Entity lever2 = LeverFactory.createLever(customPoints().get(1).toPoint());
+    Entity lever3 = LeverFactory.createLever(customPoints().get(2).toPoint());
     l1 = lever1.fetch(LeverComponent.class).get();
     l2 = lever2.fetch(LeverComponent.class).get();
     l3 = lever3.fetch(LeverComponent.class).get();
@@ -99,7 +99,7 @@ public class AdvancedControlLevel3 extends AdvancedLevel {
             coordinate -> {
               try {
                 Entity m = EntityFactory.randomMonster();
-                m.fetch(PositionComponent.class).get().position(coordinate.toCenteredPoint());
+                m.fetch(PositionComponent.class).get().position(coordinate.toPoint());
                 Game.add(m);
 
               } catch (IOException e) {

--- a/advancedDungeon/src/produsAdvanced/level/AdvancedControlLevel4.java
+++ b/advancedDungeon/src/produsAdvanced/level/AdvancedControlLevel4.java
@@ -63,7 +63,7 @@ public class AdvancedControlLevel4 extends AdvancedLevel {
     customPoints()
         .forEach(
             coordinate -> {
-              Entity lever = LeverFactory.createLever(coordinate.toCenteredPoint());
+              Entity lever = LeverFactory.createLever(coordinate.toPoint());
               leverComponentSet.add(lever.fetch(LeverComponent.class).get());
               Game.add(lever);
             });

--- a/advancedDungeon/src/produsAdvanced/level/AdvancedSortLevel.java
+++ b/advancedDungeon/src/produsAdvanced/level/AdvancedSortLevel.java
@@ -147,7 +147,7 @@ public class AdvancedSortLevel extends AdvancedLevel {
         };
 
     Entity lever =
-        LeverFactory.createLever(new Point(customPoints().get(0).toCenteredPoint()), leverAction);
+        LeverFactory.createLever(new Point(customPoints().get(0).toPoint()), leverAction);
     customPoints().remove(0);
 
     customPoints()
@@ -159,7 +159,7 @@ public class AdvancedSortLevel extends AdvancedLevel {
               } catch (IOException e) {
                 throw new RuntimeException(e);
               }
-              mob.fetch(PositionComponent.class).get().position(coordinate.toCenteredPoint());
+              mob.fetch(PositionComponent.class).get().position(coordinate.toPoint());
               mob.remove(AIComponent.class);
               mobs.add(new Monster(mob));
               mob.fetch(HealthComponent.class).orElseThrow().maximalHealthpoints(10);

--- a/advancedDungeon/src/produsAdvanced/level/ArrayCreateLevel.java
+++ b/advancedDungeon/src/produsAdvanced/level/ArrayCreateLevel.java
@@ -236,7 +236,7 @@ public class ArrayCreateLevel extends AdvancedLevel {
           default -> throw new IllegalArgumentException("Unbekannter Monster-Typ: " + monsterType);
         };
 
-    monster.fetch(PositionComponent.class).ifPresent(pc -> pc.position(pos.toCenteredPoint()));
+    monster.fetch(PositionComponent.class).ifPresent(pc -> pc.position(pos.toPoint()));
 
     Game.add(monster);
   }

--- a/advancedDungeon/src/produsAdvanced/level/ArrayRemoveLevel.java
+++ b/advancedDungeon/src/produsAdvanced/level/ArrayRemoveLevel.java
@@ -234,7 +234,7 @@ public class ArrayRemoveLevel extends AdvancedLevel {
           default -> throw new IllegalArgumentException("Unbekannter Monster-Typ: " + monsterType);
         };
 
-    monster.fetch(PositionComponent.class).ifPresent(pc -> pc.position(pos.toCenteredPoint()));
+    monster.fetch(PositionComponent.class).ifPresent(pc -> pc.position(pos.toPoint()));
 
     Game.add(monster);
   }

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -229,14 +229,12 @@ public class Client {
    * be placed before the level is fully loaded.
    */
   public static void restart() {
-
     // if not the main thread, schedule restart
     if (!Thread.currentThread().getName().equals("main")) {
       scheduleRestart = true;
       Server.waitDelta(); // wait for the next tick to execute the restart
       return;
     }
-
     Game.removeAllEntities();
     Game.system(PositionSystem.class, System::stop);
     createHero();

--- a/blockly/src/coderunner/BlocklyCommands.java
+++ b/blockly/src/coderunner/BlocklyCommands.java
@@ -431,7 +431,7 @@ public class BlocklyCommands {
 
     double[] distances =
         entityComponents.stream()
-            .mapToDouble(e -> e.pc.position().distance(e.targetPosition.toPoint()))
+            .mapToDouble(e -> e.pc.position().distance(e.targetPosition.toCenteredPoint()))
             .toArray();
     double[] lastDistances = new double[entities.length];
 
@@ -444,7 +444,7 @@ public class BlocklyCommands {
         comp.vc.applyForce(MOVEMENT_FORCE_ID, direction.scale((Client.MOVEMENT_FORCE.x())));
 
         lastDistances[i] = distances[i];
-        distances[i] = comp.pc.position().distance(comp.targetPosition.toPoint());
+        distances[i] = comp.pc.position().distance(comp.targetPosition.toCenteredPoint());
 
         if (comp.vc().maxSpeed() > 0
             && Game.existInLevel(entities[i])

--- a/blockly/src/coderunner/BlocklyCommands.java
+++ b/blockly/src/coderunner/BlocklyCommands.java
@@ -418,8 +418,11 @@ public class BlocklyCommands {
           entity
               .fetch(VelocityComponent.class)
               .orElseThrow(() -> MissingComponentException.build(entity, VelocityComponent.class));
+      // Magic Translate for https://github.com/Dungeon-CampusMinden/Dungeon/issues/2448
+      // Move the position slightly further into the tile to avoid rounding errors at edge positions
 
-      Tile targetTile = Game.tileAt(pc.position(), direction).orElse(null);
+      Tile targetTile =
+          Game.tileAt(pc.position().translate(Vector2.of(0.1, 0.1)), direction).orElse(null);
       if (targetTile == null
           || (!targetTile.isAccessible() && !(targetTile instanceof PitTile))
           || Game.entityAtTile(targetTile).anyMatch(e -> e.isPresent(BlockComponent.class))) {

--- a/blockly/src/coderunner/BlocklyCommands.java
+++ b/blockly/src/coderunner/BlocklyCommands.java
@@ -431,7 +431,7 @@ public class BlocklyCommands {
 
     double[] distances =
         entityComponents.stream()
-            .mapToDouble(e -> e.pc.position().distance(e.targetPosition.toCenteredPoint()))
+            .mapToDouble(e -> e.pc.position().distance(e.targetPosition.toPoint()))
             .toArray();
     double[] lastDistances = new double[entities.length];
 
@@ -444,7 +444,7 @@ public class BlocklyCommands {
         comp.vc.applyForce(MOVEMENT_FORCE_ID, direction.scale((Client.MOVEMENT_FORCE.x())));
 
         lastDistances[i] = distances[i];
-        distances[i] = comp.pc.position().distance(comp.targetPosition.toCenteredPoint());
+        distances[i] = comp.pc.position().distance(comp.targetPosition.toPoint());
 
         if (comp.vc().maxSpeed() > 0
             && Game.existInLevel(entities[i])

--- a/blockly/src/entities/HeroTankControlledFactory.java
+++ b/blockly/src/entities/HeroTankControlledFactory.java
@@ -3,6 +3,7 @@ package entities;
 import client.Client;
 import coderunner.BlocklyCommands;
 import contrib.entities.EntityFactory;
+import contrib.entities.HeroFactory;
 import core.Entity;
 import core.components.InputComponent;
 import core.components.PositionComponent;
@@ -27,6 +28,15 @@ public class HeroTankControlledFactory {
    * @throws IOException if there is an error creating the hero
    */
   public static Entity newTankControlledHero() throws IOException {
+    // TODO: Hotfix for multithreading issues during level reset on hero death.
+    // The server executes the next block immediately after the hero dies.
+    // Calling Client.restart() twice ensures the level is fully reset and avoids race conditions.
+    HeroFactory.heroDeath(
+        entity -> {
+          Client.restart();
+          Client.restart();
+        });
+
     Entity hero = EntityFactory.newHero();
     InputComponent ic = hero.fetch(InputComponent.class).orElse(new InputComponent());
 
@@ -49,6 +59,7 @@ public class HeroTankControlledFactory {
         KeyboardConfig.MOVEMENT_RIGHT.value(),
         (entity) -> BlocklyCommands.rotate(Direction.RIGHT),
         false);
+
     return hero;
   }
 

--- a/blockly/src/entities/MiscFactory.java
+++ b/blockly/src/entities/MiscFactory.java
@@ -36,7 +36,7 @@ public class MiscFactory {
   public static Entity stone(Point position) {
     Entity stone = new Entity("stone");
     stone.add(new PushableComponent());
-    stone.add(new PositionComponent(position.toCenteredPoint()));
+    stone.add(new PositionComponent(position));
     stone.add(new BlockComponent());
     stone.add(new VelocityComponent(Client.MOVEMENT_FORCE.x()));
     stone.add(new CollideComponent());
@@ -53,7 +53,7 @@ public class MiscFactory {
    * @return lever entity
    */
   public static Entity blocklyLever(final Point position) {
-    Entity lever = LeverFactory.createLever(position.toCenteredPoint());
+    Entity lever = LeverFactory.createLever(position);
     lever.add(new BlockComponent());
     return lever;
   }
@@ -65,7 +65,7 @@ public class MiscFactory {
    * @return lever entity
    */
   public static Entity blocklyTorch(final Point position) {
-    Entity torch = LeverFactory.createTorch(position.toCenteredPoint());
+    Entity torch = LeverFactory.createTorch(position);
     torch.add(new BlockComponent());
     return torch;
   }
@@ -84,7 +84,7 @@ public class MiscFactory {
    */
   public static Entity bookPickup(Point position, String title, String pickupText) {
     Entity pickup = new Entity("Book Pickup");
-    pickup.add(new PositionComponent(position.toCenteredPoint()));
+    pickup.add(new PositionComponent(position));
     pickup.add(new DrawComponent(new Animation(PICKUP_BOCK_PATH)));
     pickup.add(
         new InteractionComponent(
@@ -108,7 +108,7 @@ public class MiscFactory {
    */
   public static Entity breadcrumb(Point position) {
     Entity breadcrumb = new Entity("breadcrumb");
-    breadcrumb.add(new PositionComponent(position.toCenteredPoint()));
+    breadcrumb.add(new PositionComponent(position));
     breadcrumb.add(new DrawComponent(new Animation(BREADCRUMB_PATH)));
     breadcrumb.add(new BlocklyItemComponent());
     breadcrumb.add(new BreadcrumbComponent());
@@ -133,7 +133,7 @@ public class MiscFactory {
    */
   public static Entity clover(Point position) {
     Entity breadcrumb = new Entity("clover");
-    breadcrumb.add(new PositionComponent(position.toCenteredPoint()));
+    breadcrumb.add(new PositionComponent(position));
     breadcrumb.add(new DrawComponent(new Animation(CLOVER_PATH)));
     breadcrumb.add(new BlocklyItemComponent());
     breadcrumb.add(new CloverComponent());
@@ -158,7 +158,7 @@ public class MiscFactory {
    */
   public static Entity fireballScroll(Point position) {
     Entity fireballScroll = new Entity("fireballScroll");
-    fireballScroll.add(new PositionComponent(position.toCenteredPoint()));
+    fireballScroll.add(new PositionComponent(position));
     fireballScroll.add(new DrawComponent(new Animation(SCROLL_PATH)));
     fireballScroll.add(new BlocklyItemComponent());
     fireballScroll.add(

--- a/blockly/src/entities/monster/InevitableFireballSkill.java
+++ b/blockly/src/entities/monster/InevitableFireballSkill.java
@@ -26,7 +26,6 @@ public class InevitableFireballSkill extends FireballSkill {
           Game.hero()
               .flatMap(hero -> hero.fetch(PositionComponent.class))
               .map(PositionComponent::position)
-              .map(Point::toCenteredPoint)
               // offset for error with fireball path calculation (#2230)
               .map(point -> point.translate(Vector2.of(0.5f, 0.5f)))
               .orElse(null);
@@ -51,7 +50,7 @@ public class InevitableFireballSkill extends FireballSkill {
     // freeze on the corner of the red zone
     Game.hero()
         .flatMap(hero -> hero.fetch(PositionComponent.class))
-        .ifPresent(PositionComponent::centerPositionOnTile);
+        .ifPresent(pc -> pc.position(pc.position().toCoordinate().toPoint()));
   }
 
   protected void additionalEffectAfterDamage(

--- a/blockly/src/level/LevelManagementUtils.java
+++ b/blockly/src/level/LevelManagementUtils.java
@@ -59,7 +59,7 @@ public class LevelManagementUtils {
     PositionComponent pc =
         hero.fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(hero, PositionComponent.class));
-    pc.position(pc.position().toCenteredPoint());
+    pc.position(pc.position());
   }
 
   /**

--- a/blockly/src/level/LevelManagementUtils.java
+++ b/blockly/src/level/LevelManagementUtils.java
@@ -59,7 +59,7 @@ public class LevelManagementUtils {
     PositionComponent pc =
         hero.fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(hero, PositionComponent.class));
-    pc.position(pc.position().toCoordinate().toPoint());
+    pc.toTileCorner();
   }
 
   /**

--- a/blockly/src/level/LevelManagementUtils.java
+++ b/blockly/src/level/LevelManagementUtils.java
@@ -59,7 +59,7 @@ public class LevelManagementUtils {
     PositionComponent pc =
         hero.fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(hero, PositionComponent.class));
-    pc.position(pc.position());
+    pc.position(pc.position().toCoordinate().toPoint());
   }
 
   /**

--- a/blockly/src/level/produs/Level002.java
+++ b/blockly/src/level/produs/Level002.java
@@ -63,7 +63,7 @@ public class Level002 extends BlocklyLevel {
     guardBuilder.range(3);
     guardBuilder.viewDirection(Direction.LEFT);
     guardBuilder.addToGame();
-    guardBuilder.spawnPoint(customPoints().get(0).toCenteredPoint());
+    guardBuilder.spawnPoint(customPoints().get(0).toPoint());
     guardBuilder.build();
     customPoints().remove(0);
 
@@ -72,7 +72,7 @@ public class Level002 extends BlocklyLevel {
     customPoints()
         .forEach(
             coordinate -> {
-              hedgehogBuilder.spawnPoint(coordinate.toCenteredPoint());
+              hedgehogBuilder.spawnPoint(coordinate.toPoint());
               hedgehogBuilder.addToGame();
               hedgehogBuilder.build();
             });

--- a/blockly/src/level/produs/Level003.java
+++ b/blockly/src/level/produs/Level003.java
@@ -63,8 +63,8 @@ public class Level003 extends BlocklyLevel {
     LevelManagementUtils.zoomDefault();
     Coordinate stone1C = customPoints().get(0);
     Coordinate stone2C = customPoints().get(1);
-    Game.add(MiscFactory.stone(stone1C.toCenteredPoint()));
-    Game.add(MiscFactory.stone(stone2C.toCenteredPoint()));
+    Game.add(MiscFactory.stone(stone1C.toPoint()));
+    Game.add(MiscFactory.stone(stone2C.toPoint()));
 
     Game.tileAt(new Coordinate(0, 5))
         .filter(DoorTile.class::isInstance)

--- a/blockly/src/level/produs/Level004.java
+++ b/blockly/src/level/produs/Level004.java
@@ -75,15 +75,15 @@ public class Level004 extends BlocklyLevel {
     door2 = (DoorTile) Game.tileAt(new Coordinate(16, 3)).orElse(null);
     door1.close();
     door2.close();
-    Entity s1 = LeverFactory.createLever(customPoints().get(0).toCenteredPoint());
-    Entity s2 = LeverFactory.pressurePlate(customPoints().get(1).toCenteredPoint());
+    Entity s1 = LeverFactory.createLever(customPoints().get(0).toPoint());
+    Entity s2 = LeverFactory.pressurePlate(customPoints().get(1).toPoint());
     switch1 =
         s1.fetch(LeverComponent.class)
             .orElseThrow(() -> MissingComponentException.build(s1, LeverComponent.class));
     switch2 =
         s2.fetch(LeverComponent.class)
             .orElseThrow(() -> MissingComponentException.build(s2, LeverComponent.class));
-    Game.add(MiscFactory.stone(customPoints().get(2).toCenteredPoint()));
+    Game.add(MiscFactory.stone(customPoints().get(2).toPoint()));
     Game.add(s1);
     Game.add(s2);
   }

--- a/blockly/src/level/produs/Level005.java
+++ b/blockly/src/level/produs/Level005.java
@@ -72,26 +72,26 @@ public class Level005 extends BlocklyLevel {
     Coordinate m3C = customPoints().get(3);
     Coordinate m4C = customPoints().get(4);
 
-    Game.add(MiscFactory.stone(stone1C.toCenteredPoint()));
-    Game.add(MiscFactory.stone(stone2C.toCenteredPoint()));
+    Game.add(MiscFactory.stone(stone1C.toPoint()));
+    Game.add(MiscFactory.stone(stone2C.toPoint()));
 
     BlocklyMonster.BlocklyMonsterBuilder guardBuilder = BlocklyMonster.GUARD.builder();
     guardBuilder.addToGame();
     guardBuilder.range(6);
     guardBuilder.viewDirection(Direction.LEFT);
-    guardBuilder.spawnPoint(m1C.toCenteredPoint());
+    guardBuilder.spawnPoint(m1C.toPoint());
     guardBuilder.build();
     guardBuilder.range(5);
     guardBuilder.viewDirection(Direction.RIGHT);
-    guardBuilder.spawnPoint(m2C.toCenteredPoint());
+    guardBuilder.spawnPoint(m2C.toPoint());
     guardBuilder.build();
     guardBuilder.range(5);
     guardBuilder.viewDirection(Direction.UP);
-    guardBuilder.spawnPoint(m3C.toCenteredPoint());
+    guardBuilder.spawnPoint(m3C.toPoint());
     guardBuilder.build();
     guardBuilder.range(5);
     guardBuilder.viewDirection(Direction.UP);
-    guardBuilder.spawnPoint(m4C.toCenteredPoint());
+    guardBuilder.spawnPoint(m4C.toPoint());
     guardBuilder.build();
   }
 

--- a/blockly/src/level/produs/Level006.java
+++ b/blockly/src/level/produs/Level006.java
@@ -71,10 +71,10 @@ public class Level006 extends BlocklyLevel {
     Coordinate stone2C = customPoints().get(1);
     Coordinate switch1C = customPoints().get(2);
     Coordinate switch2C = customPoints().get(3);
-    Entity s1 = LeverFactory.pressurePlate(switch1C.toCenteredPoint());
-    Entity s2 = LeverFactory.pressurePlate(switch2C.toCenteredPoint());
-    Game.add(MiscFactory.stone(stone1C.toCenteredPoint()));
-    Game.add(MiscFactory.stone(stone2C.toCenteredPoint()));
+    Entity s1 = LeverFactory.pressurePlate(switch1C.toPoint());
+    Entity s2 = LeverFactory.pressurePlate(switch2C.toPoint());
+    Game.add(MiscFactory.stone(stone1C.toPoint()));
+    Game.add(MiscFactory.stone(stone2C.toPoint()));
 
     Game.add(s1);
     Game.add(s2);

--- a/blockly/src/level/produs/Level007.java
+++ b/blockly/src/level/produs/Level007.java
@@ -69,10 +69,10 @@ public class Level007 extends BlocklyLevel {
     LevelManagementUtils.heroViewDirection(Direction.LEFT);
     LevelManagementUtils.centerHero();
     LevelManagementUtils.zoomDefault();
-    Entity s1 = LeverFactory.createLever(customPoints().get(0).toCenteredPoint());
-    Entity s2 = LeverFactory.createLever(customPoints().get(1).toCenteredPoint());
-    Entity s3 = LeverFactory.createLever(customPoints().get(2).toCenteredPoint());
-    Entity s4 = LeverFactory.createLever(customPoints().get(3).toCenteredPoint());
+    Entity s1 = LeverFactory.createLever(customPoints().get(0).toPoint());
+    Entity s2 = LeverFactory.createLever(customPoints().get(1).toPoint());
+    Entity s3 = LeverFactory.createLever(customPoints().get(2).toPoint());
+    Entity s4 = LeverFactory.createLever(customPoints().get(3).toPoint());
     switch1 =
         s1.fetch(LeverComponent.class)
             .orElseThrow(() -> MissingComponentException.build(s1, LeverComponent.class));

--- a/blockly/src/level/produs/Level008.java
+++ b/blockly/src/level/produs/Level008.java
@@ -66,18 +66,18 @@ public class Level008 extends BlocklyLevel {
     guardBuilder.addToGame();
     guardBuilder.range(5);
     guardBuilder.viewDirection(Direction.UP);
-    guardBuilder.spawnPoint(customPoints().get(7).toCenteredPoint());
+    guardBuilder.spawnPoint(customPoints().get(7).toPoint());
     guardBuilder.build();
     guardBuilder.range(5);
     guardBuilder.viewDirection(Direction.LEFT);
-    guardBuilder.spawnPoint(customPoints().get(8).toCenteredPoint());
+    guardBuilder.spawnPoint(customPoints().get(8).toPoint());
     guardBuilder.build();
 
-    Entity s1 = LeverFactory.pressurePlate(customPoints().get(2).toCenteredPoint());
-    Entity s2 = LeverFactory.createLever(customPoints().get(3).toCenteredPoint());
-    Entity s3 = LeverFactory.createLever(customPoints().get(4).toCenteredPoint());
-    Entity s4 = LeverFactory.createLever(customPoints().get(5).toCenteredPoint());
-    Entity s5 = LeverFactory.createLever(customPoints().get(6).toCenteredPoint());
+    Entity s1 = LeverFactory.pressurePlate(customPoints().get(2).toPoint());
+    Entity s2 = LeverFactory.createLever(customPoints().get(3).toPoint());
+    Entity s3 = LeverFactory.createLever(customPoints().get(4).toPoint());
+    Entity s4 = LeverFactory.createLever(customPoints().get(5).toPoint());
+    Entity s5 = LeverFactory.createLever(customPoints().get(6).toPoint());
     switch1 =
         s1.fetch(LeverComponent.class)
             .orElseThrow(() -> MissingComponentException.build(s1, LeverComponent.class));
@@ -111,8 +111,8 @@ public class Level008 extends BlocklyLevel {
     door5 = (DoorTile) Game.tileAt(new Coordinate(8, 5)).orElse(null);
     door5.close();
 
-    Game.add(MiscFactory.stone(customPoints().get(0).toCenteredPoint()));
-    Game.add(MiscFactory.stone(customPoints().get(1).toCenteredPoint()));
+    Game.add(MiscFactory.stone(customPoints().get(0).toPoint()));
+    Game.add(MiscFactory.stone(customPoints().get(1).toPoint()));
   }
 
   @Override

--- a/blockly/src/level/produs/Level009.java
+++ b/blockly/src/level/produs/Level009.java
@@ -57,17 +57,17 @@ public class Level009 extends BlocklyLevel {
           "Kapitel 1: Ausbruch");
       showText = false;
     }
-    Game.add(MiscFactory.fireballScroll(customPoints().get(0).toCenteredPoint()));
-    Game.add(MiscFactory.fireballScroll(customPoints().get(1).toCenteredPoint()));
+    Game.add(MiscFactory.fireballScroll(customPoints().get(0).toPoint()));
+    Game.add(MiscFactory.fireballScroll(customPoints().get(1).toPoint()));
 
     BlocklyMonster.BlocklyMonsterBuilder hedgehogBuilder = BlocklyMonster.HEDGEHOG.builder();
     hedgehogBuilder.range(0);
     hedgehogBuilder.addToGame();
-    hedgehogBuilder.spawnPoint(customPoints().get(2).toCenteredPoint());
+    hedgehogBuilder.spawnPoint(customPoints().get(2).toPoint());
     hedgehogBuilder.build();
-    hedgehogBuilder.spawnPoint(customPoints().get(3).toCenteredPoint());
+    hedgehogBuilder.spawnPoint(customPoints().get(3).toPoint());
     hedgehogBuilder.build();
-    hedgehogBuilder.spawnPoint(customPoints().get(4).toCenteredPoint());
+    hedgehogBuilder.spawnPoint(customPoints().get(4).toPoint());
     hedgehogBuilder.build();
   }
 

--- a/blockly/src/level/produs/Level010.java
+++ b/blockly/src/level/produs/Level010.java
@@ -50,26 +50,26 @@ public class Level010 extends BlocklyLevel {
     LevelManagementUtils.fog(false);
     LevelManagementUtils.cameraFocusOn(new Coordinate(8, 6));
     LevelManagementUtils.heroViewDirection(Direction.RIGHT);
-    Game.add(MiscFactory.fireballScroll(customPoints().get(0).toCenteredPoint()));
-    Game.add(MiscFactory.fireballScroll(customPoints().get(1).toCenteredPoint()));
-    Game.add(MiscFactory.fireballScroll(customPoints().get(2).toCenteredPoint()));
-    Game.add(MiscFactory.fireballScroll(customPoints().get(3).toCenteredPoint()));
-    Game.add(MiscFactory.fireballScroll(customPoints().get(4).toCenteredPoint()));
+    Game.add(MiscFactory.fireballScroll(customPoints().get(0).toPoint()));
+    Game.add(MiscFactory.fireballScroll(customPoints().get(1).toPoint()));
+    Game.add(MiscFactory.fireballScroll(customPoints().get(2).toPoint()));
+    Game.add(MiscFactory.fireballScroll(customPoints().get(3).toPoint()));
+    Game.add(MiscFactory.fireballScroll(customPoints().get(4).toPoint()));
 
     BlocklyMonster.BlocklyMonsterBuilder guardBuilder = BlocklyMonster.GUARD.builder();
     guardBuilder.addToGame();
     guardBuilder.range(5);
     guardBuilder.viewDirection(Direction.DOWN);
-    guardBuilder.spawnPoint(customPoints().get(5).toCenteredPoint());
+    guardBuilder.spawnPoint(customPoints().get(5).toPoint());
     guardBuilder.build();
-    guardBuilder.spawnPoint(customPoints().get(8).toCenteredPoint());
+    guardBuilder.spawnPoint(customPoints().get(8).toPoint());
     guardBuilder.build();
-    guardBuilder.spawnPoint(customPoints().get(9).toCenteredPoint());
+    guardBuilder.spawnPoint(customPoints().get(9).toPoint());
     guardBuilder.build();
     guardBuilder.viewDirection(Direction.RIGHT);
-    guardBuilder.spawnPoint(customPoints().get(6).toCenteredPoint());
+    guardBuilder.spawnPoint(customPoints().get(6).toPoint());
     guardBuilder.build();
-    guardBuilder.spawnPoint(customPoints().get(7).toCenteredPoint());
+    guardBuilder.spawnPoint(customPoints().get(7).toPoint());
     guardBuilder.build();
   }
 

--- a/blockly/src/level/produs/Level011.java
+++ b/blockly/src/level/produs/Level011.java
@@ -68,46 +68,46 @@ public class Level011 extends BlocklyLevel {
       showText = false;
     }
 
-    Game.add(MiscFactory.stone(customPoints().get(1).toCenteredPoint()));
+    Game.add(MiscFactory.stone(customPoints().get(1).toPoint()));
 
-    Entity s1 = LeverFactory.pressurePlate(customPoints().get(2).toCenteredPoint());
+    Entity s1 = LeverFactory.pressurePlate(customPoints().get(2).toPoint());
     switch1 =
         s1.fetch(LeverComponent.class)
             .orElseThrow(() -> MissingComponentException.build(s1, LeverComponent.class));
     Game.add(s1);
 
-    Game.add(MiscFactory.fireballScroll(customPoints().get(3).toCenteredPoint()));
-    Entity s2 = LeverFactory.pressurePlate(customPoints().get(4).toCenteredPoint());
+    Game.add(MiscFactory.fireballScroll(customPoints().get(3).toPoint()));
+    Entity s2 = LeverFactory.pressurePlate(customPoints().get(4).toPoint());
     switch2 =
         s2.fetch(LeverComponent.class)
             .orElseThrow(() -> MissingComponentException.build(s1, LeverComponent.class));
     Game.add(s2);
-    Entity s3 = LeverFactory.createLever(customPoints().get(5).toCenteredPoint());
+    Entity s3 = LeverFactory.createLever(customPoints().get(5).toPoint());
     switch3 =
         s3.fetch(LeverComponent.class)
             .orElseThrow(() -> MissingComponentException.build(s1, LeverComponent.class));
     Game.add(s3);
-    Entity s4 = LeverFactory.createLever(customPoints().get(6).toCenteredPoint());
+    Entity s4 = LeverFactory.createLever(customPoints().get(6).toPoint());
     switch4 =
         s4.fetch(LeverComponent.class)
             .orElseThrow(() -> MissingComponentException.build(s1, LeverComponent.class));
     Game.add(s4);
 
-    Game.add(MiscFactory.fireballScroll(customPoints().get(8).toCenteredPoint()));
-    Game.add(MiscFactory.fireballScroll(customPoints().get(9).toCenteredPoint()));
+    Game.add(MiscFactory.fireballScroll(customPoints().get(8).toPoint()));
+    Game.add(MiscFactory.fireballScroll(customPoints().get(9).toPoint()));
 
     BlocklyMonster.BlocklyMonsterBuilder guardBuilder = BlocklyMonster.GUARD.builder();
     guardBuilder.addToGame();
     guardBuilder.range(5);
     guardBuilder.viewDirection(Direction.LEFT);
-    guardBuilder.spawnPoint(customPoints().get(10).toCenteredPoint());
+    guardBuilder.spawnPoint(customPoints().get(10).toPoint());
     guardBuilder.build();
 
     BlocklyMonster.BlocklyMonsterBuilder bossBuilder = BlocklyMonster.BLACK_KNIGHT.builder();
     bossBuilder.range(0);
     bossBuilder.addToGame();
     bossBuilder.viewDirection(Direction.UP);
-    bossBuilder.spawnPoint(customPoints().get(11).toCenteredPoint());
+    bossBuilder.spawnPoint(customPoints().get(11).toPoint());
     Entity boss = bossBuilder.build();
     boss.fetch(HealthComponent.class)
         .orElseThrow()

--- a/blockly/src/level/produs/Level012.java
+++ b/blockly/src/level/produs/Level012.java
@@ -84,7 +84,7 @@ public class Level012 extends BlocklyLevel {
     customPoints()
         .forEach(
             coordinate -> {
-              Entity torch = LeverFactory.createTorch(coordinate.toCenteredPoint());
+              Entity torch = LeverFactory.createTorch(coordinate.toPoint());
               torch.add(new BlockComponent());
               Game.add(torch);
               LeverComponent lc =

--- a/blockly/src/level/produs/Level015.java
+++ b/blockly/src/level/produs/Level015.java
@@ -81,7 +81,7 @@ public class Level015 extends BlocklyLevel {
         .forEach(
             coordinate -> {
               if (counter[0] == 0 || random.nextBoolean()) {
-                hedgehogBuilder.spawnPoint(coordinate.toCenteredPoint());
+                hedgehogBuilder.spawnPoint(coordinate.toPoint());
                 hedgehogBuilder.build();
                 counter[0]++;
               }

--- a/blockly/src/level/produs/Level018.java
+++ b/blockly/src/level/produs/Level018.java
@@ -66,7 +66,7 @@ public class Level018 extends BlocklyLevel {
     customPoints()
         .forEach(
             coordinate -> {
-              hedgehogBuilder.spawnPoint(coordinate.toCenteredPoint());
+              hedgehogBuilder.spawnPoint(coordinate.toPoint());
               hedgehogBuilder.build();
             });
   }

--- a/blockly/src/level/produs/Level020.java
+++ b/blockly/src/level/produs/Level020.java
@@ -115,7 +115,7 @@ public class Level020 extends BlocklyLevel {
     bossBuilder.range(0);
     bossBuilder.addToGame();
     bossBuilder.viewDirection(Direction.RIGHT);
-    bossBuilder.spawnPoint(c.toCenteredPoint());
+    bossBuilder.spawnPoint(c.toPoint());
     boss = bossBuilder.build();
     bosspc =
         boss.fetch(PositionComponent.class)

--- a/blockly/src/level/produs/Level021.java
+++ b/blockly/src/level/produs/Level021.java
@@ -79,12 +79,12 @@ public class Level021 extends BlocklyLevel {
                 pt.close();
               }
             });
-    Game.add(MiscFactory.breadcrumb(new Coordinate(25, 14).toCenteredPoint()));
-    Game.add(MiscFactory.breadcrumb(new Coordinate(12, 4).toCenteredPoint()));
-    Game.add(MiscFactory.breadcrumb(new Coordinate(11, 11).toCenteredPoint()));
-    Game.add(MiscFactory.breadcrumb(new Coordinate(11, 16).toCenteredPoint()));
-    Game.add(MiscFactory.breadcrumb(new Coordinate(9, 17).toCenteredPoint()));
-    Game.add(MiscFactory.breadcrumb(new Coordinate(20, 12).toCenteredPoint()));
+    Game.add(MiscFactory.breadcrumb(new Coordinate(25, 14).toPoint()));
+    Game.add(MiscFactory.breadcrumb(new Coordinate(12, 4).toPoint()));
+    Game.add(MiscFactory.breadcrumb(new Coordinate(11, 11).toPoint()));
+    Game.add(MiscFactory.breadcrumb(new Coordinate(11, 16).toPoint()));
+    Game.add(MiscFactory.breadcrumb(new Coordinate(9, 17).toPoint()));
+    Game.add(MiscFactory.breadcrumb(new Coordinate(20, 12).toPoint()));
 
     // BOSS
     Coordinate c =
@@ -94,7 +94,7 @@ public class Level021 extends BlocklyLevel {
     bossBuilder.range(0);
     bossBuilder.addToGame();
     bossBuilder.viewDirection(Direction.LEFT);
-    bossBuilder.spawnPoint(c.toCenteredPoint());
+    bossBuilder.spawnPoint(c.toPoint());
     boss = bossBuilder.build();
     bossPC =
         boss.fetch(PositionComponent.class)

--- a/blockly/src/level/produs/Level022.java
+++ b/blockly/src/level/produs/Level022.java
@@ -60,7 +60,7 @@ public class Level022 extends BlocklyLevel {
     bossBuilder.speed(Client.MOVEMENT_FORCE.x());
     bossBuilder.addToGame();
     bossBuilder.viewDirection(Direction.LEFT);
-    bossBuilder.spawnPoint(customPoints().get(0).toCenteredPoint());
+    bossBuilder.spawnPoint(customPoints().get(0).toPoint());
 
     Entity boss = bossBuilder.build();
     boss.fetch(HealthComponent.class)

--- a/devDungeon/src/entities/MobSpawnerFactory.java
+++ b/devDungeon/src/entities/MobSpawnerFactory.java
@@ -44,7 +44,7 @@ public class MobSpawnerFactory {
       Coordinate pos, MonsterType[] monsterTypes, int maxMobCount) {
     Entity mobSpawner = new Entity("mobSpawner");
 
-    mobSpawner.add(new PositionComponent(pos.toCenteredPoint()));
+    mobSpawner.add(new PositionComponent(pos.toPoint()));
     mobSpawner.add(new DrawComponent(new Animation(SPAWNER_TEXTURE)));
     mobSpawner.add(
         new MobSpawnerComponent(

--- a/devDungeon/src/level/devlevel/BossLevel.java
+++ b/devDungeon/src/level/devlevel/BossLevel.java
@@ -108,7 +108,7 @@ public class BossLevel extends DevDungeonLevel implements IHealthObserver {
         chest
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(chest, PositionComponent.class));
-    pc.position(chestSpawn.toCenteredPoint());
+    pc.position(chestSpawn.toPoint());
     InventoryComponent ic =
         chest
             .fetch(InventoryComponent.class)
@@ -129,7 +129,7 @@ public class BossLevel extends DevDungeonLevel implements IHealthObserver {
         cauldon
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(cauldon, PositionComponent.class));
-    pc.position(cauldronSpawn.toCenteredPoint());
+    pc.position(cauldronSpawn.toPoint());
     Game.add(cauldon);
   }
 

--- a/devDungeon/src/level/devlevel/DamagedBridgeRiddleLevel.java
+++ b/devDungeon/src/level/devlevel/DamagedBridgeRiddleLevel.java
@@ -114,7 +114,7 @@ public class DamagedBridgeRiddleLevel extends DevDungeonLevel {
         chest
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(chest, PositionComponent.class));
-    pc.position(secretWay[secretWay.length - 1].coordinate().toCenteredPoint());
+    pc.position(secretWay[secretWay.length - 1].coordinate().toPoint());
     InventoryComponent ic =
         chest
             .fetch(InventoryComponent.class)

--- a/devDungeon/src/level/devlevel/DevDungeonRoom.java
+++ b/devDungeon/src/level/devlevel/DevDungeonRoom.java
@@ -94,8 +94,7 @@ public class DevDungeonRoom {
     Entity[] torches = new Entity[torchSpawns.length];
     for (int i = 0; i < torchSpawns.length; i++) {
       torches[i] =
-          EntityUtils.spawnAntiLightTorch(
-              torchSpawns[i].toCenteredPoint(), true, true, (x, y) -> {});
+          EntityUtils.spawnAntiLightTorch(torchSpawns[i].toPoint(), true, true, (x, y) -> {});
     }
     return torches;
   }

--- a/devDungeon/src/level/devlevel/IllusionRiddleLevel.java
+++ b/devDungeon/src/level/devlevel/IllusionRiddleLevel.java
@@ -237,13 +237,13 @@ public class IllusionRiddleLevel extends DevDungeonLevel {
 
     // Secret Passages
     EntityUtils.spawnLever(
-        leverSpawns[0].toCenteredPoint(),
+        leverSpawns[0].toPoint(),
         new OpenPassageCommand(secretPassages[0][0], secretPassages[0][1]));
     EntityUtils.spawnLever(
-        leverSpawns[1].toCenteredPoint(),
+        leverSpawns[1].toPoint(),
         new OpenPassageCommand(secretPassages[1][0], secretPassages[1][1]));
     EntityUtils.spawnLever(
-        leverSpawns[2].toCenteredPoint(),
+        leverSpawns[2].toPoint(),
         new OpenPassageCommand(secretPassages[2][0], secretPassages[2][1]));
     spawnChestsAndCauldrons();
     riddleHandler.onFirstTick();
@@ -346,7 +346,7 @@ public class IllusionRiddleLevel extends DevDungeonLevel {
                   () ->
                       MissingComponentException.build(
                           newIllusionRiddleLevelChestEntity, PositionComponent.class));
-      pc.position(chestSpawnTileCoordinate.toCenteredPoint());
+      pc.position(chestSpawnTileCoordinate.toPoint());
       InventoryComponent ic =
           newIllusionRiddleLevelChestEntity
               .fetch(InventoryComponent.class)

--- a/devDungeon/src/level/devlevel/TorchRiddleLevel.java
+++ b/devDungeon/src/level/devlevel/TorchRiddleLevel.java
@@ -115,7 +115,7 @@ public class TorchRiddleLevel extends DevDungeonLevel {
     Coordinate[] positions = torchPositions;
     for (int i = 0; i < positions.length; i++) {
       Coordinate torchPosition = positions[i];
-      Point torchPos = torchPosition.toCenteredPoint();
+      Point torchPos = torchPosition.toPoint();
       Entity torch =
           utils.EntityUtils.spawnTorch(
               torchPos,
@@ -155,7 +155,7 @@ public class TorchRiddleLevel extends DevDungeonLevel {
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(chest, PositionComponent.class));
 
-    pc.position(riddleRoomContent[0].toCenteredPoint());
+    pc.position(riddleRoomContent[0].toPoint());
 
     InventoryComponent ic =
         chest
@@ -177,7 +177,7 @@ public class TorchRiddleLevel extends DevDungeonLevel {
         cauldron
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(cauldron, PositionComponent.class));
-    pc.position(riddleRoomContent[1].toCenteredPoint());
+    pc.position(riddleRoomContent[1].toPoint());
     Game.add(cauldron);
   }
 }

--- a/devDungeon/src/level/devlevel/TutorialLevel.java
+++ b/devDungeon/src/level/devlevel/TutorialLevel.java
@@ -55,8 +55,8 @@ public class TutorialLevel extends DevDungeonLevel {
         "Willkommen im Tutorial! Hier lernst Du die Grundlagen des Spiels kennen.");
     this.mobSpawn = customPoints.get(0);
 
-    this.chestSpawn = customPoints.get(1).toCenteredPoint();
-    this.cauldronSpawn = customPoints.get(2).toCenteredPoint();
+    this.chestSpawn = customPoints.get(1).toPoint();
+    this.cauldronSpawn = customPoints.get(2).toPoint();
   }
 
   @Override
@@ -220,7 +220,7 @@ public class TutorialLevel extends DevDungeonLevel {
     ic =
         b.fetch(InventoryComponent.class)
             .orElseThrow(() -> MissingComponentException.build(b, InventoryComponent.class));
-    pc.position(customPoints().get(3).toCenteredPoint());
+    pc.position(customPoints().get(3).toPoint());
     ic.add(new ItemPotionHealth(HealthPotionType.NORMAL));
     Game.add(b);
   }

--- a/devDungeon/src/level/devlevel/riddleHandler/BridgeGuardRiddleHandler.java
+++ b/devDungeon/src/level/devlevel/riddleHandler/BridgeGuardRiddleHandler.java
@@ -117,7 +117,7 @@ public class BridgeGuardRiddleHandler implements IHealthObserver {
         .peek(wallTile -> level.changeTileElementType(wallTile, LevelElement.FLOOR))
         .forEach(
             tile -> {
-              utils.EntityUtils.spawnTorch(tile.coordinate().toCenteredPoint(), true, false, 0);
+              utils.EntityUtils.spawnTorch(tile.coordinate().toPoint(), true, false, 0);
             });
 
     LevelUtils.tilesInArea(bridgeBounds[0], bridgeBounds[1]).stream()
@@ -133,13 +133,13 @@ public class BridgeGuardRiddleHandler implements IHealthObserver {
 
   private void prepareBridgeEntities() {
     EntityUtils.spawnLever(
-        bridgeLever.toCenteredPoint(), new BridgeControlCommand(bridgeBounds[0], bridgeBounds[1]));
+        bridgeLever.toPoint(), new BridgeControlCommand(bridgeBounds[0], bridgeBounds[1]));
     EntityUtils.spawnSign(
         "Pull the lever to raise and lower the bridge",
         "Bridge Control",
-        bridgeLeverSign.toCenteredPoint());
+        bridgeLeverSign.toPoint());
     this.bridgeGuard =
-        utils.EntityUtils.spawnBridgeGuard(bridgeGuardSpawn.toCenteredPoint(), riddles, lastTask());
+        utils.EntityUtils.spawnBridgeGuard(bridgeGuardSpawn.toPoint(), riddles, lastTask());
     bridgeGuard
         .fetch(HealthComponent.class)
         .ifPresent(
@@ -251,7 +251,7 @@ public class BridgeGuardRiddleHandler implements IHealthObserver {
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(chest, PositionComponent.class));
 
-    pc.position(riddleRoomChest.toCenteredPoint());
+    pc.position(riddleRoomChest.toPoint());
 
     InventoryComponent ic =
         chest
@@ -271,7 +271,7 @@ public class BridgeGuardRiddleHandler implements IHealthObserver {
         cauldron
             .fetch(PositionComponent.class)
             .orElseThrow(() -> MissingComponentException.build(cauldron, PositionComponent.class));
-    pc.position(new Coordinate(riddleRoomChest.x() + 1, riddleRoomChest.y()).toCenteredPoint());
+    pc.position(new Coordinate(riddleRoomChest.x() + 1, riddleRoomChest.y()).toPoint());
     Game.add(cauldron);
   }
 }

--- a/devDungeon/src/level/devlevel/riddleHandler/DamagedBridgeRiddleHandler.java
+++ b/devDungeon/src/level/devlevel/riddleHandler/DamagedBridgeRiddleHandler.java
@@ -188,13 +188,13 @@ public class DamagedBridgeRiddleHandler {
                     If you were faster, you could cross it.
                     Maybe theres a Speed Potion somewhere nearby?""",
         "Riddle: The damaged Bridge",
-        riddleEntranceSign.toCenteredPoint());
+        riddleEntranceSign.toPoint());
     EntityUtils.spawnSign(
         """
                     This looks interesting. Maybe there is
                     something hidden behind those sculptures?""",
         "Riddle: The damaged Bridge",
-        speedPotionChestHint.toCenteredPoint());
+        speedPotionChestHint.toPoint());
   }
 
   private void spawnChest() {
@@ -210,7 +210,7 @@ public class DamagedBridgeRiddleHandler {
             .orElseThrow(
                 () -> MissingComponentException.build(speedPotionChest, PositionComponent.class));
 
-    pc.position(this.speedPotionChest.toCenteredPoint());
+    pc.position(this.speedPotionChest.toPoint());
 
     InventoryComponent ic =
         speedPotionChest
@@ -232,7 +232,7 @@ public class DamagedBridgeRiddleHandler {
             .orElseThrow(
                 () -> MissingComponentException.build(riddleChest, PositionComponent.class));
 
-    pc.position(riddleChestSpawn.toCenteredPoint());
+    pc.position(riddleChestSpawn.toPoint());
 
     ic =
         riddleChest

--- a/devDungeon/src/level/utils/LevelUtils.java
+++ b/devDungeon/src/level/utils/LevelUtils.java
@@ -27,8 +27,6 @@ public class LevelUtils {
     } catch (ClassCastException e) {
       return null;
     }
-    return Optional.ofNullable(level.randomTPTarget())
-        .map(Coordinate::toCenteredPoint)
-        .orElse(null);
+    return Optional.ofNullable(level.randomTPTarget()).map(Coordinate::toPoint).orElse(null);
   }
 }

--- a/devDungeon/src/systems/MobSpawnerSystem.java
+++ b/devDungeon/src/systems/MobSpawnerSystem.java
@@ -103,7 +103,7 @@ public class MobSpawnerSystem extends System {
     }
 
     Tile spawnTile = possibleSpawns.get(ILevel.RANDOM.nextInt(possibleSpawns.size()));
-    mobSpawner.spawnRandomMonster(spawnTile.coordinate().toCenteredPoint());
+    mobSpawner.spawnRandomMonster(spawnTile.coordinate().toPoint());
     lastSpawnTimes.put(mobSpawner, java.lang.System.currentTimeMillis());
   }
 

--- a/devDungeon/src/utils/EntityUtils.java
+++ b/devDungeon/src/utils/EntityUtils.java
@@ -84,7 +84,7 @@ public class EntityUtils {
           newMob
               .fetch(PositionComponent.class)
               .orElseThrow(() -> MissingComponentException.build(newMob, PositionComponent.class));
-      positionComponent.position(tile.coordinate().toCenteredPoint());
+      positionComponent.position(tile.coordinate().toPoint());
       Game.add(newMob);
       return newMob;
     } catch (IOException e) {

--- a/dungeon/src/contrib/entities/LeverFactory.java
+++ b/dungeon/src/contrib/entities/LeverFactory.java
@@ -179,7 +179,7 @@ public class LeverFactory {
    */
   public static Entity pressurePlate(Point position, float massTrigger) {
     Entity pressurePlate = new Entity("pressureplate");
-    pressurePlate.add(new PositionComponent(position.toCenteredPoint()));
+    pressurePlate.add(new PositionComponent(position));
 
     Map<String, Animation> map =
         Animation.loadAnimationSpritesheet(new SimpleIPath("objects/pressureplate"));

--- a/dungeon/src/contrib/entities/MiscFactory.java
+++ b/dungeon/src/contrib/entities/MiscFactory.java
@@ -547,8 +547,8 @@ public final class MiscFactory {
     String reqKeyName =
         requiredKeyType.equals(ItemKey.class) ? "silbernen Schlüssel" : "großen goldenen Schlüssel";
     Entity doorBlocker = new Entity("doorBlocker");
-    float x = door.position().toCenteredPoint().x();
-    float y = door.position().toCenteredPoint().y();
+    float x = door.position().x();
+    float y = door.position().y();
     Point blockerPosition = new Point(x, (y - 0.4f));
     doorBlocker.add(new PositionComponent(blockerPosition));
 

--- a/dungeon/src/contrib/utils/components/Debugger.java
+++ b/dungeon/src/contrib/utils/components/Debugger.java
@@ -104,7 +104,7 @@ public class Debugger {
    * @param targetLocation the tile to teleport to
    */
   public static void TELEPORT(Tile targetLocation) {
-    TELEPORT(targetLocation.coordinate().toCenteredPoint());
+    TELEPORT(targetLocation.coordinate().toPoint());
   }
 
   /**

--- a/dungeon/src/contrib/utils/components/skill/selfSkill/FireShockWaveSkill.java
+++ b/dungeon/src/contrib/utils/components/skill/selfSkill/FireShockWaveSkill.java
@@ -76,7 +76,7 @@ public class FireShockWaveSkill extends Skill {
           placedPositions.add(tile.coordinate());
 
           Entity entity = new Entity(SKILL_NAME + "_entity");
-          PositionComponent posComp = new PositionComponent(tile.coordinate().toCenteredPoint());
+          PositionComponent posComp = new PositionComponent(tile.coordinate().toPoint());
           posComp.rotation(-90f); // Look like sitting on the ground
           entity.add(posComp);
           entity.add(new CollideComponent());

--- a/dungeon/src/core/components/PositionComponent.java
+++ b/dungeon/src/core/components/PositionComponent.java
@@ -141,6 +141,15 @@ public final class PositionComponent implements Component {
   }
 
   /**
+   * Set the position to the corner of the current tile.
+   *
+   * <p>This basically rounds down the x and y coordinates.
+   */
+  public void toTileCorner() {
+    position = position.toCoordinate().toPoint();
+  }
+
+  /**
    * Get the position as coordinate.
    *
    * @return The position as coordinate.

--- a/dungeon/src/core/components/PositionComponent.java
+++ b/dungeon/src/core/components/PositionComponent.java
@@ -137,7 +137,7 @@ public final class PositionComponent implements Component {
    * @see Tile
    */
   public void position(final Tile tile) {
-    position(tile.position().toCenteredPoint());
+    position(tile.position());
   }
 
   /**
@@ -147,15 +147,6 @@ public final class PositionComponent implements Component {
    */
   public Coordinate coordinate() {
     return position.toCoordinate();
-  }
-
-  /**
-   * Set the position.
-   *
-   * <p>Will center the entity on the tile it is currently on.
-   */
-  public void centerPositionOnTile() {
-    position(position.toCenteredPoint());
   }
 
   /**

--- a/dungeon/src/core/level/utils/Coordinate.java
+++ b/dungeon/src/core/level/utils/Coordinate.java
@@ -65,15 +65,6 @@ public record Coordinate(int x, int y) {
     return Math.abs(x - other.x) + Math.abs(y - other.y);
   }
 
-  /**
-   * Convert Coordinate to Point centered in the tile.
-   *
-   * @return Coordinate converted to a point;
-   */
-  public Point toCenteredPoint() {
-    return new Point(x + 0.5f, y + 0.5f);
-  }
-
   @Override
   public String toString() {
     return x + "," + y;

--- a/dungeon/src/core/level/utils/Coordinate.java
+++ b/dungeon/src/core/level/utils/Coordinate.java
@@ -36,15 +36,6 @@ public record Coordinate(int x, int y) {
   }
 
   /**
-   * Convert Coordinate to Point centered in the tile.
-   *
-   * @return Coordinate converted to a point;
-   */
-  public Point toCenteredPoint() {
-    return new Point(x + 0.5f, y + 0.5f);
-  }
-
-  /**
    * Moves this coordinate by a vector.
    *
    * @param vector The vector to move the coordinate by.

--- a/dungeon/src/core/level/utils/Coordinate.java
+++ b/dungeon/src/core/level/utils/Coordinate.java
@@ -65,6 +65,15 @@ public record Coordinate(int x, int y) {
     return Math.abs(x - other.x) + Math.abs(y - other.y);
   }
 
+  /**
+   * Convert Coordinate to Point centered in the tile.
+   *
+   * @return Coordinate converted to a point;
+   */
+  public Point toCenteredPoint() {
+    return new Point(x + 0.5f, y + 0.5f);
+  }
+
   @Override
   public String toString() {
     return x + "," + y;

--- a/dungeon/src/core/level/utils/Coordinate.java
+++ b/dungeon/src/core/level/utils/Coordinate.java
@@ -36,6 +36,15 @@ public record Coordinate(int x, int y) {
   }
 
   /**
+   * Create new Point centered in the tile.
+   *
+   * @return centered Point
+   */
+  public Point toCenteredPoint() {
+    return new Point(x() + 0.5f, y() + 0.5f);
+  }
+
+  /**
    * Moves this coordinate by a vector.
    *
    * @param vector The vector to move the coordinate by.

--- a/dungeon/src/core/systems/DrawSystem.java
+++ b/dungeon/src/core/systems/DrawSystem.java
@@ -51,15 +51,6 @@ public final class DrawSystem extends System {
   /** Draws objects. */
   private static final Painter PAINTER = new Painter(BATCH);
 
-  /** offset the coordinate by half a tile, it makes every Entity not walk on the sidewalls. */
-  private static final float X_OFFSET = 0.5f;
-
-  /**
-   * offset the coordinate by a quarter tile,it looks a bit more like every Entity is not walking
-   * over walls.
-   */
-  private static final float Y_OFFSET = 0.25f;
-
   private final TreeMap<Integer, List<DSData>> sortedEntities = new TreeMap<>();
   private final Map<IPath, PainterConfig> configs;
 
@@ -238,8 +229,7 @@ public final class DrawSystem extends System {
           IPath texturePath = t.texturePath();
           if (!mapping.containsKey(texturePath)
               || (mapping.get(texturePath).tintColor() != t.tintColor())) {
-            mapping.put(
-                texturePath, new PainterConfig(texturePath, X_OFFSET, Y_OFFSET, t.tintColor()));
+            mapping.put(texturePath, new PainterConfig(texturePath, 0, 0, t.tintColor()));
           }
           PAINTER.draw(t.position(), texturePath, mapping.get(texturePath));
         }

--- a/dungeon/src/core/utils/Point.java
+++ b/dungeon/src/core/utils/Point.java
@@ -88,15 +88,6 @@ public record Point(float x, float y) {
   }
 
   /**
-   * Create new Point centered in the tile.
-   *
-   * @return centered Point
-   */
-  public Point toCenteredPoint() {
-    return new Point((int) x() + 0.5f, (int) y() + 0.5f);
-  }
-
-  /**
    * Create new Point flooring the values.
    *
    * @return floored Point

--- a/dungeon/src/core/utils/Point.java
+++ b/dungeon/src/core/utils/Point.java
@@ -88,6 +88,15 @@ public record Point(float x, float y) {
   }
 
   /**
+   * Create new Point centered in the tile.
+   *
+   * @return centered Point
+   */
+  public Point toCenteredPoint() {
+    return new Point((int) x() + 0.5f, (int) y() + 0.5f);
+  }
+
+  /**
    * Create new Point flooring the values.
    *
    * @return floored Point

--- a/dungeon/src/core/utils/Point.java
+++ b/dungeon/src/core/utils/Point.java
@@ -96,6 +96,15 @@ public record Point(float x, float y) {
     return new Point((int) x(), (int) y());
   }
 
+  /**
+   * Create new Point centered in the tile.
+   *
+   * @return centered Point
+   */
+  public Point toCenteredPoint() {
+    return new Point((int) x() + 0.5f, (int) y() + 0.5f);
+  }
+
   @Override
   public String toString() {
     return x + "," + y;

--- a/dungeon/src/core/utils/Point.java
+++ b/dungeon/src/core/utils/Point.java
@@ -49,15 +49,6 @@ public record Point(float x, float y) {
   }
 
   /**
-   * Create new Point centered in the tile.
-   *
-   * @return centered Point
-   */
-  public Point toCenteredPoint() {
-    return new Point((int) x() + 0.5f, (int) y() + 0.5f);
-  }
-
-  /**
    * Convert Point to Coordinate by parsing float to int.
    *
    * @return the converted point

--- a/escapeRoom/src/coopDungeon/level/Level01.java
+++ b/escapeRoom/src/coopDungeon/level/Level01.java
@@ -51,18 +51,18 @@ public class Level01 extends DungeonLevel {
   }
 
   private void setupLever() {
-    Entity l = LeverFactory.pressurePlate(customPoints.get(0).toCenteredPoint());
+    Entity l = LeverFactory.pressurePlate(customPoints.get(0).toPoint());
     Game.add(l);
     l1 = l.fetch(LeverComponent.class).get();
 
-    l = LeverFactory.pressurePlate(customPoints.get(1).toCenteredPoint());
+    l = LeverFactory.pressurePlate(customPoints.get(1).toPoint());
     Game.add(l);
     l2 = l.fetch(LeverComponent.class).get();
 
-    l = LeverFactory.createTimedLever(customPoints.get(2).toCenteredPoint(), DELAY_MILLIS);
+    l = LeverFactory.createTimedLever(customPoints.get(2).toPoint(), DELAY_MILLIS);
     l3 = l.fetch(LeverComponent.class).get();
     Game.add(l);
-    l = LeverFactory.createTimedLever(customPoints.get(3).toCenteredPoint(), DELAY_MILLIS);
+    l = LeverFactory.createTimedLever(customPoints.get(3).toPoint(), DELAY_MILLIS);
     Game.add(l);
     l4 = l.fetch(LeverComponent.class).get();
   }

--- a/escapeRoom/src/coopDungeon/level/Level02.java
+++ b/escapeRoom/src/coopDungeon/level/Level02.java
@@ -56,41 +56,39 @@ public class Level02 extends DungeonLevel {
   private void spawnCatapults() {
     Game.add(
         MiscFactory.catapult(
-            customPoints().get(0).toCenteredPoint(), customPoints().get(1).toCenteredPoint(), 10f));
-    Game.add(MiscFactory.marker(customPoints.get(1).toCenteredPoint()));
+            customPoints().get(0).toPoint(), customPoints().get(1).toPoint(), 10f));
+    Game.add(MiscFactory.marker(customPoints.get(1).toPoint()));
     Game.add(
         MiscFactory.catapult(
-            customPoints().get(4).toCenteredPoint(), customPoints().get(5).toCenteredPoint(), 10f));
-    Game.add(MiscFactory.marker(customPoints.get(5).toCenteredPoint()));
+            customPoints().get(4).toPoint(), customPoints().get(5).toPoint(), 10f));
+    Game.add(MiscFactory.marker(customPoints.get(5).toPoint()));
 
     Game.add(
         MiscFactory.catapult(
-            customPoints().get(2).toCenteredPoint(), customPoints().get(3).toCenteredPoint(), 10f));
-    Game.add(MiscFactory.marker(customPoints.get(3).toCenteredPoint()));
+            customPoints().get(2).toPoint(), customPoints().get(3).toPoint(), 10f));
+    Game.add(MiscFactory.marker(customPoints.get(3).toPoint()));
 
     Game.add(
         MiscFactory.catapult(
-            customPoints().get(8).toCenteredPoint(), customPoints().get(9).toCenteredPoint(), 10f));
-    Game.add(MiscFactory.marker(customPoints.get(9).toCenteredPoint()));
+            customPoints().get(8).toPoint(), customPoints().get(9).toPoint(), 10f));
+    Game.add(MiscFactory.marker(customPoints.get(9).toPoint()));
   }
 
   private void setupCrateRiddle() {
-    Entity plate = LeverFactory.pressurePlate(customPoints.get(7).toCenteredPoint(), CRATE_MASS);
+    Entity plate = LeverFactory.pressurePlate(customPoints.get(7).toPoint(), CRATE_MASS);
     p = plate.fetch(LeverComponent.class).get();
     Game.add(plate);
-    Entity plate2 = LeverFactory.pressurePlate(customPoints.get(14).toCenteredPoint());
+    Entity plate2 = LeverFactory.pressurePlate(customPoints.get(14).toPoint());
     p2 = plate2.fetch(LeverComponent.class).get();
     Game.add(plate2);
-    Entity crate = MiscFactory.crate(customPoints.get(6).toCenteredPoint(), CRATE_MASS);
+    Entity crate = MiscFactory.crate(customPoints.get(6).toPoint(), CRATE_MASS);
     crate.add(new CatapultableComponent(entity -> {}, entity -> {}));
     Game.add(crate);
   }
 
   private void setupExitLevers() {
-    Entity lever1 =
-        LeverFactory.createTimedLever(customPoints.get(10).toCenteredPoint(), DELAY_MILLIS);
-    Entity lever2 =
-        LeverFactory.createTimedLever(customPoints.get(11).toCenteredPoint(), DELAY_MILLIS);
+    Entity lever1 = LeverFactory.createTimedLever(customPoints.get(10).toPoint(), DELAY_MILLIS);
+    Entity lever2 = LeverFactory.createTimedLever(customPoints.get(11).toPoint(), DELAY_MILLIS);
     Game.add(lever1);
     Game.add(lever2);
     l1 = lever1.fetch(LeverComponent.class).get();

--- a/escapeRoom/src/demoDungeon/level/Level01.java
+++ b/escapeRoom/src/demoDungeon/level/Level01.java
@@ -101,7 +101,7 @@ public class Level01 extends DungeonLevel {
   private void setupHints() {
     HintSystem hintSystem = new HintSystem();
     Game.add(hintSystem);
-    Game.add(HintGiverFactory.mailbox(new Point(1, 5).toCenteredPoint()));
+    Game.add(HintGiverFactory.mailbox(new Point(1, 5)));
     PetriNetSystem petriNetSystem = new PetriNetSystem();
     Game.add(petriNetSystem);
     // register hint log
@@ -151,13 +151,13 @@ public class Level01 extends DungeonLevel {
   }
 
   private void npc() {
-    Entity plate = LeverFactory.pressurePlate(customPoints.get(6).toCenteredPoint());
+    Entity plate = LeverFactory.pressurePlate(customPoints.get(6).toPoint());
     preasurePlate = plate.fetch(LeverComponent.class).get();
     Game.add(plate);
     Entity npc = new Entity();
     npc.add(new VelocityComponent(5));
     npc.add(new CollideComponent());
-    npc.add(new PositionComponent(customPoints.get(0).toCenteredPoint()));
+    npc.add(new PositionComponent(customPoints.get(0).toPoint()));
     npc.add(new DrawComponent(new SimpleIPath("character/monster/chort")));
     npc.add(
         new InteractionComponent(
@@ -222,7 +222,7 @@ public class Level01 extends DungeonLevel {
   }
 
   private void moveNpc(Entity npc) {
-    Point goal = customPoints.get(6).toCenteredPoint();
+    Point goal = customPoints.get(6).toPoint();
     npc.add(
         new AIComponent(
             entity -> {},
@@ -243,12 +243,11 @@ public class Level01 extends DungeonLevel {
   }
 
   private void crafting() {
-    Game.add(MiscFactory.newCraftingCauldron(customPoints.get(1).toCenteredPoint()));
+    Game.add(MiscFactory.newCraftingCauldron(customPoints.get(1).toPoint()));
   }
 
   private void books() {
-    List<Tile> points =
-        LevelUtils.accessibleTilesInRange(customPoints.get(2).toCenteredPoint(), 5f);
+    List<Tile> points = LevelUtils.accessibleTilesInRange(customPoints.get(2).toPoint(), 5f);
     Point p1 = points.get(RANDOM.nextInt(points.size())).position();
     Point p2 = points.get(RANDOM.nextInt(points.size())).position();
     while (p1.equals(p2)) p2 = points.get(RANDOM.nextInt(points.size())).position();
@@ -267,8 +266,7 @@ public class Level01 extends DungeonLevel {
 
   private void monster() {
     monster = new HashSet<>();
-    List<Tile> points =
-        LevelUtils.accessibleTilesInRange(customPoints.get(7).toCenteredPoint(), 5f);
+    List<Tile> points = LevelUtils.accessibleTilesInRange(customPoints.get(7).toPoint(), 5f);
     for (int i = 0; i < 5; i++) {
       try {
         Entity m = MonsterFactory.randomMonster();
@@ -292,19 +290,15 @@ public class Level01 extends DungeonLevel {
 
   private void chest() {
     Game.add(
-        MiscFactory.catapult(
-            customPoints.get(9).toCenteredPoint(), customPoints.get(10).toCenteredPoint(), 10f));
+        MiscFactory.catapult(customPoints.get(9).toPoint(), customPoints.get(10).toPoint(), 10f));
     Game.add(
-        MiscFactory.catapult(
-            customPoints.get(11).toCenteredPoint(), customPoints.get(12).toCenteredPoint(), 10f));
+        MiscFactory.catapult(customPoints.get(11).toPoint(), customPoints.get(12).toPoint(), 10f));
     Game.add(
-        MiscFactory.catapult(
-            customPoints.get(13).toCenteredPoint(), customPoints.get(14).toCenteredPoint(), 10f));
-    Game.add(MiscFactory.marker(customPoints.get(10).toCenteredPoint()));
-    Game.add(MiscFactory.marker(customPoints.get(12).toCenteredPoint()));
-    Game.add(MiscFactory.marker(customPoints.get(14).toCenteredPoint()));
-    Game.add(
-        MiscFactory.newChest(Set.of(new ItemPotionWater()), customPoints.get(8).toCenteredPoint()));
+        MiscFactory.catapult(customPoints.get(13).toPoint(), customPoints.get(14).toPoint(), 10f));
+    Game.add(MiscFactory.marker(customPoints.get(10).toPoint()));
+    Game.add(MiscFactory.marker(customPoints.get(12).toPoint()));
+    Game.add(MiscFactory.marker(customPoints.get(14).toPoint()));
+    Game.add(MiscFactory.newChest(Set.of(new ItemPotionWater()), customPoints.get(8).toPoint()));
   }
 
   @Override
@@ -313,7 +307,7 @@ public class Level01 extends DungeonLevel {
     if (spawnMushroom && monster.isEmpty()) {
       spawnMushroom = false;
       ItemResourceMushroomRed mushroom = new ItemResourceMushroomRed();
-      mushroom.drop(customPoints.get(7).toCenteredPoint());
+      mushroom.drop(customPoints.get(7).toPoint());
     }
   }
 }


### PR DESCRIPTION
Dieser PR entfernt dieses bescheuerte Level-Offset beim zeichnen des Levels.
In einem Zug entferne ich die `toCenterPoint` Methode, die war unser Pflaster für diese Wunde.


Das optische "in Wände reinrennen" hab ich hier noch nicht gefixt. Das wird ein sep. PR.


@Flamtky @viddie bitte zur Kenntnis nehmen.
@b-franklin guckst du mal aktiv in Blockly rein? Ich hab drüber gegukct und funktional schien alles zu sein. 


Ich rechne mit kleineren Bugs die noch auftreten. Aber dieser Tumor muss raus