### PR TITLE
Dungeon: add Move-Colidebox

### DIFF
--- a/dungeon/src/contrib/systems/DebugDrawSystem.java
+++ b/dungeon/src/contrib/systems/DebugDrawSystem.java
@@ -7,6 +7,7 @@ import core.Entity;
 import core.System;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
+import core.components.VelocityComponent;
 import core.systems.CameraSystem;
 import core.utils.Point;
 import core.utils.Vector2;
@@ -73,6 +74,7 @@ public class DebugDrawSystem extends System {
 
     if (entity.isPresent(DrawComponent.class)) drawTextureSize(entity, pc);
     if (entity.isPresent(CollideComponent.class)) drawColideHitbox(entity, pc);
+    if (entity.isPresent(VelocityComponent.class)) drawMoveHitbox(entity, pc);
   }
 
   /**
@@ -127,6 +129,34 @@ public class DebugDrawSystem extends System {
     SHAPE_RENDERER.begin(ShapeRenderer.ShapeType.Line);
     SHAPE_RENDERER.setColor(Color.GREEN);
     SHAPE_RENDERER.rect(x, y, width, height);
+    SHAPE_RENDERER.end();
+  }
+
+  /**
+   * Draws a white rectangle representing the entity's movement hitbox.
+   *
+   * <p>This is useful for debugging collision and movement boundaries.
+   *
+   * @param entity The entity whose movement hitbox should be drawn. Must have a {@link
+   *     VelocityComponent}.
+   * @param pc The {@link PositionComponent} of the entity, used as the reference point for the
+   *     hitbox.
+   */
+  private void drawMoveHitbox(Entity entity, PositionComponent pc) {
+    VelocityComponent vc =
+        entity
+            .fetch(VelocityComponent.class)
+            .orElseThrow(() -> MissingComponentException.build(entity, VelocityComponent.class));
+
+    // Compute bottom-left corner of the hitbox
+    Point bottomLeft = pc.position().translate(vc.moveboxOffset());
+    Vector2 size = vc.moveboxSize();
+    float width = size.x();
+    float height = size.y();
+
+    SHAPE_RENDERER.begin(ShapeRenderer.ShapeType.Line);
+    SHAPE_RENDERER.setColor(Color.WHITE);
+    SHAPE_RENDERER.rect(bottomLeft.x(), bottomLeft.y(), width, height);
     SHAPE_RENDERER.end();
   }
 }

--- a/dungeon/src/contrib/systems/FallingSystem.java
+++ b/dungeon/src/contrib/systems/FallingSystem.java
@@ -55,27 +55,18 @@ public class FallingSystem extends System {
             .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
     Point pos = pc.position();
 
-    // Entities mit FlyComponent fallen nicht
     if (entity.isPresent(FlyComponent.class)) return false;
-
-    // Holt die VelocityComponent (für MoveBox)
     VelocityComponent vc =
         entity
             .fetch(VelocityComponent.class)
             .orElseThrow(() -> MissingComponentException.build(entity, VelocityComponent.class));
-
     Vector2 offset = vc.moveboxOffset();
     Vector2 size = vc.moveboxSize();
-
-    // Mittelpunkt der MoveBox
     Point center = pos.translate(offset).translate(size.scale(0.5f));
-
-    // Prüfe, ob der Centerpunkt auf einem offenen PitTile liegt
     Tile tile = Game.tileAt(center).orElse(null);
     if (tile instanceof PitTile pitTile) {
       return pitTile.isOpen();
     }
-
     return false;
   }
 

--- a/dungeon/src/contrib/systems/FallingSystem.java
+++ b/dungeon/src/contrib/systems/FallingSystem.java
@@ -40,7 +40,7 @@ public class FallingSystem extends System {
 
   /** Constructs a new FallingSystem. */
   public FallingSystem() {
-    super(PositionComponent.class, HealthComponent.class);
+    super(PositionComponent.class, HealthComponent.class, VelocityComponent.class);
   }
 
   @Override

--- a/dungeon/src/contrib/systems/FallingSystem.java
+++ b/dungeon/src/contrib/systems/FallingSystem.java
@@ -11,10 +11,12 @@ import core.Game;
 import core.System;
 import core.components.PlayerComponent;
 import core.components.PositionComponent;
+import core.components.VelocityComponent;
 import core.level.Tile;
 import core.level.elements.tile.PitTile;
 import core.level.utils.LevelElement;
 import core.utils.Point;
+import core.utils.Vector2;
 import core.utils.components.MissingComponentException;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -47,17 +49,33 @@ public class FallingSystem extends System {
   }
 
   private boolean filterFalling(Entity entity) {
-    Point entityPosition =
+    PositionComponent pc =
         entity
             .fetch(PositionComponent.class)
-            .map(PositionComponent::position)
             .orElseThrow(() -> MissingComponentException.build(entity, PositionComponent.class));
-    if (entity.isPresent(FlyComponent.class)) return false;
-    Tile currentTile = Game.tileAt(entityPosition).orElse(null);
+    Point pos = pc.position();
 
-    if (currentTile instanceof PitTile pitTile) {
+    // Entities mit FlyComponent fallen nicht
+    if (entity.isPresent(FlyComponent.class)) return false;
+
+    // Holt die VelocityComponent (für MoveBox)
+    VelocityComponent vc =
+        entity
+            .fetch(VelocityComponent.class)
+            .orElseThrow(() -> MissingComponentException.build(entity, VelocityComponent.class));
+
+    Vector2 offset = vc.moveboxOffset();
+    Vector2 size = vc.moveboxSize();
+
+    // Mittelpunkt der MoveBox
+    Point center = pos.translate(offset).translate(size.scale(0.5f));
+
+    // Prüfe, ob der Centerpunkt auf einem offenen PitTile liegt
+    Tile tile = Game.tileAt(center).orElse(null);
+    if (tile instanceof PitTile pitTile) {
       return pitTile.isOpen();
     }
+
     return false;
   }
 

--- a/dungeon/src/core/components/VelocityComponent.java
+++ b/dungeon/src/core/components/VelocityComponent.java
@@ -53,6 +53,24 @@ import java.util.stream.Stream;
  * }</pre>
  */
 public final class VelocityComponent implements Component {
+
+  /**
+   * The default offset of the hit box.
+   *
+   * <p>This hitbox is used for level collision checks.
+   */
+  public static final Vector2 MOVEBOX_DEFAULT_OFFSET = Vector2.of(0.25f, 0.25f);
+
+  /**
+   * The default size of the hit box.
+   *
+   * <p>This hitbox is used for level collision checks.
+   */
+  public static final Vector2 MOVEBOX_DEFAULT_SIZE = Vector2.of(0.5f, 0.5f);
+
+  private Vector2 moveboxOffset;
+  private Vector2 moveboxSize;
+
   /** The default mass of an entity, on no other is configurated. */
   public static final float DEFAULT_MASS = 1;
 
@@ -83,6 +101,8 @@ public final class VelocityComponent implements Component {
     this.onWallHit = onWallHit;
     this.canEnterOpenPits = canEnterOpenPits;
     this.maxSpeed = maxSpeed;
+    moveboxOffset = MOVEBOX_DEFAULT_OFFSET;
+    moveboxSize = MOVEBOX_DEFAULT_SIZE;
   }
 
   /**
@@ -270,5 +290,49 @@ public final class VelocityComponent implements Component {
    */
   public void maxSpeed(float maxSpeed) {
     this.maxSpeed = maxSpeed;
+  }
+
+  /**
+   * Sets the offset of the collision box relative to the entity's position.
+   *
+   * <p>This hitbox is used for level collision checks.
+   *
+   * @param offset the new offset of the collision box
+   */
+  public void moveboxOffset(Vector2 offset) {
+    moveboxOffset = offset;
+  }
+
+  /**
+   * Sets the size of the collision box for the entity.
+   *
+   * <p>This hitbox is used for level collision checks.
+   *
+   * @param size the new size of the collision box
+   */
+  public void moveboxSize(Vector2 size) {
+    moveboxSize = size;
+  }
+
+  /**
+   * Returns the current size of the collision box.
+   *
+   * <p>This hitbox is used for level collision checks.
+   *
+   * @return the size of the collision box
+   */
+  public Vector2 moveboxSize() {
+    return moveboxSize;
+  }
+
+  /**
+   * Returns the current offset of the collision box relative to the entity's position.
+   *
+   * <p>This hitbox is used for level collision checks.
+   *
+   * @return the offset of the collision box
+   */
+  public Vector2 moveboxOffset() {
+    return moveboxOffset;
   }
 }

--- a/dungeon/src/core/systems/MoveSystem.java
+++ b/dungeon/src/core/systems/MoveSystem.java
@@ -79,11 +79,11 @@ public class MoveSystem extends System {
           Vector2 offset = data.vc.moveboxOffset();
           Vector2 size = data.vc.moveboxSize();
           return List.of(
-              new Point(pos.x() + offset.x(), pos.y() + offset.y()), // top-left
-              new Point(pos.x() + offset.x() + size.x(), pos.y() + offset.y()), // top-right
-              new Point(pos.x() + offset.x(), pos.y() + offset.y() + size.y()), // bottom-left
+              new Point(pos.x() + offset.x(), pos.y() + offset.y()), // bottom-left
+              new Point(pos.x() + offset.x() + size.x(), pos.y() + offset.y()), // top-left
+              new Point(pos.x() + offset.x(), pos.y() + offset.y() + size.y()), // top-left
               new Point(
-                  pos.x() + offset.x() + size.x(), pos.y() + offset.y() + size.y()) // bottom-right
+                  pos.x() + offset.x() + size.x(), pos.y() + offset.y() + size.y()) // top-right
               );
         };
 

--- a/dungeon/src/core/systems/MoveSystem.java
+++ b/dungeon/src/core/systems/MoveSystem.java
@@ -50,7 +50,7 @@ public class MoveSystem extends System {
    * Updates the position of a single entity based on its velocity and collision rules.
    *
    * <p>The velocity is capped at the entity's maxSpeed to prevent moving too fast diagonally. The
-   * method checks the accessibility of all corners of the entity's move collision box and handles
+   * method checks the accessibility of all corners of the entity's collision box and handles
    * sliding along walls by checking individual axis movement.
    *
    * <p>If the tile is blocked, the entity's {@code onWallHit} callback is invoked.

--- a/dungeon/src/core/systems/MoveSystem.java
+++ b/dungeon/src/core/systems/MoveSystem.java
@@ -50,7 +50,7 @@ public class MoveSystem extends System {
    * Updates the position of a single entity based on its velocity and collision rules.
    *
    * <p>The velocity is capped at the entity's maxSpeed to prevent moving too fast diagonally. The
-   * method checks the accessibility of all corners of the entity's collision box and handles
+   * method checks the accessibility of all corners of the entity's move collision box and handles
    * sliding along walls by checking individual axis movement.
    *
    * <p>If the tile is blocked, the entity's {@code onWallHit} callback is invoked.


### PR DESCRIPTION
Baut auf #2444 auf.

Ich hab @viddie Idee aus seiner MA geklaut/übernommen.

Im VelocityComponent gibt es jetzt eine Move Hitbox (analog zur Hitbox im CollisionComponent).
Im ´MoveSystem` überprüft das System jetzt, ob alle 4-Punkte der Move Hitbox auf einem gültigen Tile stehen.



https://github.com/user-attachments/assets/93cc76cc-6bd5-4767-b121-4366d4bd1664

https://github.com/user-attachments/assets/69e62878-f29c-41ce-9293-e4597611c33d


Es funktioniert, aber die letzen 5% sind manchmal etwas ruckelig. (later?)

Pits und Falling wird mit dem Center der Move-Hitbox getriggered.



@Flamtky und ich haben eben kurz gesprochen und sind über eine Menge Sachen gestoßen, die mal entschieden werden müssten. Daher geht dieser PR den KISS weg. 
Für die Discussion mach ich was auf

Edit: https://github.com/Dungeon-CampusMinden/Dungeon/discussions/2449