### PR TITLE
Dungeon: add delta for float check in VelocitySystem

### DIFF
--- a/dungeon/src/core/systems/VelocitySystem.java
+++ b/dungeon/src/core/systems/VelocitySystem.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
  */
 public final class VelocitySystem extends System {
 
-  private static final double EPSILON = 1e-6;
+  private static final double EPSILON_ANIMATION = 0.2;
 
   private static final Logger LOGGER = Logger.getLogger(VelocitySystem.class.getName());
 
@@ -88,7 +88,7 @@ public final class VelocitySystem extends System {
     float x = vsd.vc.currentVelocity().x();
     float y = vsd.vc.currentVelocity().y();
 
-    if (Math.abs(x) > EPSILON || Math.abs(y) > EPSILON) {
+    if (Math.abs(x) > EPSILON_ANIMATION || Math.abs(y) > EPSILON_ANIMATION) {
       Direction newDirection = Direction.NONE;
       // Use the velocity axis with the greatest magnitude for animation direction
       if (Math.abs(x) >= Math.abs(y)) {

--- a/dungeon/src/core/systems/VelocitySystem.java
+++ b/dungeon/src/core/systems/VelocitySystem.java
@@ -28,6 +28,8 @@ import java.util.logging.Logger;
  */
 public final class VelocitySystem extends System {
 
+  private static final double EPSILON = 1e-6;
+
   private static final Logger LOGGER = Logger.getLogger(VelocitySystem.class.getName());
 
   // Default time (frames) an animation should be enqueued for
@@ -86,10 +88,8 @@ public final class VelocitySystem extends System {
     float x = vsd.vc.currentVelocity().x();
     float y = vsd.vc.currentVelocity().y();
 
-    // Entity is moving
-    if (x != 0 || y != 0) {
+    if (Math.abs(x) > EPSILON || Math.abs(y) > EPSILON) {
       Direction newDirection = Direction.NONE;
-
       // Use the velocity axis with the greatest magnitude for animation direction
       if (Math.abs(x) >= Math.abs(y)) {
         if (x > 0) {


### PR DESCRIPTION
Im VelocitySystem wurde ein float ohne delta verglichen.
Das sorgte dafür, dass auch beim Idlen das Move-Signal gesendet wurde

https://github.com/user-attachments/assets/646d76cb-f9a9-4fb4-97af-d08f5311671c


https://github.com/user-attachments/assets/8c994aa6-b3a8-4d0b-b615-c836ea921d94

