### PR TITLE
Blockly: add statemachine to boss; do not center on tile

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -175,6 +175,7 @@ public class Client {
     Game.add(new EventScheduler());
     Game.add(new FogSystem());
     Game.add(new PressurePlateSystem());
+    if (DEBUG_MODE) Game.add(new DebugDrawSystem());
     Game.add(
         new System() {
           @Override

--- a/blockly/src/entities/monster/BlocklyMonster.java
+++ b/blockly/src/entities/monster/BlocklyMonster.java
@@ -10,6 +10,12 @@ import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.components.VelocityComponent;
 import core.utils.Point;
+import core.utils.components.draw.animation.Animation;
+import core.utils.components.draw.state.DirectionalState;
+import core.utils.components.draw.state.State;
+import core.utils.components.draw.state.StateMachine;
+import java.util.Arrays;
+import java.util.Map;
 import java.util.function.Supplier;
 
 /**
@@ -129,11 +135,21 @@ public enum BlocklyMonster {
     public Entity build(Point spawnPos) {
       Entity monster = name().isEmpty() ? new Entity() : new Entity(name());
 
-      monster.add(new DrawComponent(texture()));
-
+      // hotfix for https://github.com/Dungeon-CampusMinden/Dungeon/issues/2413
+      // the boss uses hero textures so we can copy the hero statemachine
+      if (name().equals("Blockly Black Knight")) {
+        Map<String, Animation> animationMap = Animation.loadAnimationSpritesheet(texture());
+        State stIdle = new DirectionalState("idle", animationMap);
+        State stMove = new DirectionalState("move", animationMap, "run");
+        StateMachine sm = new StateMachine(Arrays.asList(stIdle, stMove));
+        sm.addTransition(stIdle, "move", stMove);
+        sm.addTransition(stMove, "move", stMove);
+        sm.addTransition(stMove, "idle", stIdle);
+        DrawComponent dc = new DrawComponent(sm);
+        monster.add(dc);
+      } else monster.add(new DrawComponent(texture()));
       PositionComponent pc = new PositionComponent(spawnPos, viewDirection());
       monster.add(pc);
-
       AIComponent aic = new AIComponent(fightAISupplier().get(), entity -> {}, entity -> true);
       monster.add(aic);
       if (aic.fightBehavior() instanceof StraightRangeAI straightRangeAI) {

--- a/blockly/src/entities/monster/BlocklyMonster.java
+++ b/blockly/src/entities/monster/BlocklyMonster.java
@@ -1,5 +1,6 @@
 package entities.monster;
 
+import coderunner.BlocklyCommands;
 import components.TintDirectionComponent;
 import contrib.components.*;
 import contrib.entities.*;
@@ -168,7 +169,7 @@ public enum BlocklyMonster {
       if (addToGame) {
         Game.add(monster);
       }
-
+      BlocklyCommands.turnEntity(monster, viewDirection());
       return monster;
     }
   }

--- a/dungeon/src/contrib/entities/MonsterBuilder.java
+++ b/dungeon/src/contrib/entities/MonsterBuilder.java
@@ -624,7 +624,7 @@ public class MonsterBuilder<T extends MonsterBuilder<T>> {
    * @return constructed Entity
    */
   public Entity build(Coordinate spawnPoint) {
-    return build(spawnPoint.toCenteredPoint());
+    return build(spawnPoint.toPoint());
   }
 
   /**
@@ -634,7 +634,7 @@ public class MonsterBuilder<T extends MonsterBuilder<T>> {
    * @return constructed Entity
    */
   public Entity build(Tile spawnTile) {
-    return build(spawnTile.coordinate().toCenteredPoint());
+    return build(spawnTile.coordinate());
   }
 
   private HealthComponent buildHealthComponent() {


### PR DESCRIPTION
fixes #2450 

außerdem entferne ich das `toCenterPoint` im MonsterBuilder; Das ist durch #2444 hinfällig und ein merge Artefakt. 
außerdem drehe ich im BlocklyMosterBuilder die Entitäten nochmal explizit über die BlocklyCommands, damit auch Visuell die Blickrichtung geändert wird. 