### PR TITLE
Dungeon: remove centering in MonsterBuilder

### DIFF
--- a/dungeon/src/contrib/entities/MonsterBuilder.java
+++ b/dungeon/src/contrib/entities/MonsterBuilder.java
@@ -624,7 +624,7 @@ public class MonsterBuilder<T extends MonsterBuilder<T>> {
    * @return constructed Entity
    */
   public Entity build(Coordinate spawnPoint) {
-    return build(spawnPoint.toCenteredPoint());
+    return build(spawnPoint.toPoint());
   }
 
   /**
@@ -634,7 +634,7 @@ public class MonsterBuilder<T extends MonsterBuilder<T>> {
    * @return constructed Entity
    */
   public Entity build(Tile spawnTile) {
-    return build(spawnTile.coordinate().toCenteredPoint());
+    return build(spawnTile.coordinate());
   }
 
   private HealthComponent buildHealthComponent() {


### PR DESCRIPTION
Durch #2444 ist das toCenterPoint nicht mehr nötig bzw. erfüllt nicht mehr den gewollten zweck. 
Entitäten stehen jetzt visuell im Center, wenn sie auf der Ecke der Coordinate sitzen