### PR TITLE
Dungeon: Fix death animation not working

### DIFF
--- a/dungeon/assets/character/knight/knight.json
+++ b/dungeon/assets/character/knight/knight.json
@@ -8,10 +8,10 @@
       "rows": 1,
       "columns": 5
     },
-    "framesPerSprite": 10,
+    "framesPerSprite": 15,
     "scaleX": 1,
     "scaleY": 0,
-    "isLooping": true,
+    "isLooping": false,
     "centered": false
   },
   "die_left": {
@@ -23,10 +23,10 @@
       "rows": 1,
       "columns": 4
     },
-    "framesPerSprite": 10,
+    "framesPerSprite": 15,
     "scaleX": 1,
     "scaleY": 0,
-    "isLooping": true,
+    "isLooping": false,
     "centered": false
   },
   "die_right": {
@@ -38,10 +38,10 @@
       "rows": 1,
       "columns": 4
     },
-    "framesPerSprite": 10,
+    "framesPerSprite": 15,
     "scaleX": 1,
     "scaleY": 0,
-    "isLooping": true,
+    "isLooping": false,
     "centered": false
   },
   "die_up": {
@@ -53,10 +53,10 @@
       "rows": 1,
       "columns": 5
     },
-    "framesPerSprite": 10,
+    "framesPerSprite": 15,
     "scaleX": 1,
     "scaleY": 0,
-    "isLooping": true,
+    "isLooping": false,
     "centered": false
   },
   "fight_down": {

--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -142,7 +142,7 @@ public final class HeroFactory {
     State stMove = new DirectionalState("move", animationMap, "run");
 
     State stDead;
-    if(animationMap.containsKey("die_down")){
+    if (animationMap.containsKey("die_down")) {
       stDead = new DirectionalState("dead", animationMap, "die");
     } else if (animationMap.containsKey("die")) {
       stDead = new State("dead", animationMap.get("die"));

--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -141,15 +141,21 @@ public final class HeroFactory {
     State stIdle = new DirectionalState("idle", animationMap);
     State stMove = new DirectionalState("move", animationMap, "run");
 
-    // TODO FIX BUG
-    // HOTFIX FOR: https://github.com/Dungeon-CampusMinden/Dungeon/issues/2402
-    // State stDead = new State("dead", animationMap.get("idle_down"));
-    StateMachine sm = new StateMachine(Arrays.asList(stIdle, stMove)); // , stDead));
+    State stDead;
+    if(animationMap.containsKey("die_down")){
+      stDead = new DirectionalState("dead", animationMap, "die");
+    } else if (animationMap.containsKey("die")) {
+      stDead = new State("dead", animationMap.get("die"));
+    } else {
+      stDead = new State("dead", animationMap.get("idle_down"));
+    }
+
+    StateMachine sm = new StateMachine(Arrays.asList(stIdle, stMove, stDead));
     sm.addTransition(stIdle, "move", stMove);
     sm.addTransition(stMove, "move", stMove);
     sm.addTransition(stMove, "idle", stIdle);
-    // sm.addTransition(stIdle, "died", stDead);
-    // sm.addTransition(stMove, "died", stDead);
+    sm.addTransition(stIdle, "die", stDead);
+    sm.addTransition(stMove, "die", stDead);
     DrawComponent dc = new DrawComponent(sm);
     dc.depth(DepthLayer.Player.depth());
     hero.add(dc);


### PR DESCRIPTION
Fix für https://github.com/Dungeon-CampusMinden/Dungeon/issues/2402

Problem war: Falsches Signal in der Transition und der Knight hatte die death Animation nicht als `looping` gesetzt.