### PR TITLE
Blockly: apply magic offset to InevitableFireballSkill

### DIFF
--- a/blockly/src/coderunner/BlocklyCommands.java
+++ b/blockly/src/coderunner/BlocklyCommands.java
@@ -42,7 +42,7 @@ public class BlocklyCommands {
    *
    * <p>Move the position slightly further into the tile to avoid rounding errors at edge positions
    */
-  private static final Vector2 MAGIC_OFFSET = Vector2.of(0.3, 0.3);
+  public static final Vector2 MAGIC_OFFSET = Vector2.of(0.3, 0.3);
 
   /**
    * If this is et to true, the Guard-Monster will not shoot on the hero.


### PR DESCRIPTION
Analog zu #2467 wende ich hier den Offset jetzt auch auf den Check zwischen Held und Monster an.
Dadurch wird der Held nurnoch von unseren Guard Monstern (den Onehit Feuerball Monstern) angegriffen, wenn er auch wirklich auf dem entsprechenden Tile steht. 

Dafür bau ich mir im Check eine Dummy-Entität, versetzte sie um den Magic Offset, prüfe ob das Monster die Dummy-Entität sieht und ab dann läuft es wie gewohnt weiter. 