### PR TITLE
Blockly: use `EventSchedular` for Hero Fireball

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import level.produs.*;
 import server.Server;
+import systems.ScheduleShootFireballSystem;
 import systems.TintTilesSystem;
 
 /**
@@ -109,12 +110,9 @@ public class Client {
           DungeonLoader.addLevel(Tuple.of("level020", Level020.class));
           DungeonLoader.addLevel(Tuple.of("level021", Level021.class));
           DungeonLoader.addLevel(Tuple.of("level022", Level022.class));
-
-          createSystems();
-
           HeroFactory.heroDeath(entity -> restart());
-
           createHero();
+          createSystems();
           Crafting.loadRecipes();
 
           startServer();
@@ -176,6 +174,8 @@ public class Client {
     Game.add(new EventScheduler());
     Game.add(new FogSystem());
     Game.add(new PressurePlateSystem());
+    Game.add(new ScheduleShootFireballSystem());
+
     Game.add(
         new System() {
           @Override

--- a/blockly/src/systems/ScheduleShootFireballSystem.java
+++ b/blockly/src/systems/ScheduleShootFireballSystem.java
@@ -1,0 +1,73 @@
+package systems;
+
+import components.AmmunitionComponent;
+import contrib.components.CollideComponent;
+import contrib.utils.EntityUtils;
+import contrib.utils.components.skill.projectileSkill.FireballSkill;
+import core.Entity;
+import core.Game;
+import core.System;
+import core.utils.MissingHeroException;
+import core.utils.components.MissingComponentException;
+import server.Server;
+
+/**
+ * System that allows the hero in Blockly to shoot a fireball.
+ *
+ * <p>Since Blockly code is executed in a separate thread, the libGDX context does not exist in that
+ * thread, and no textures can be loaded there.
+ *
+ * <p>This system makes it possible to schedule the shooting of a fireball, which will then be
+ * executed inside the ECS thread. This ensures that the textures for the fireball can be loaded.
+ *
+ * <p>Only one shot can be scheduled at a time. Make sure to call {@link server.Server#waitDelta()}
+ * accordingly.
+ */
+public class ScheduleShootFireballSystem extends System {
+
+  private static final float FIREBALL_RANGE = Integer.MAX_VALUE;
+  private static final float FIREBALL_SPEED = 15f;
+  private static final int FIREBALL_DMG = 1;
+  private final FireballSkill fireballSkill =
+      new FireballSkill(
+          () -> {
+            Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
+            return hero.fetch(CollideComponent.class)
+                .map(cc -> cc.center(hero))
+                .map(p -> p.translate(EntityUtils.getViewDirection(hero)))
+                .orElseThrow(() -> MissingComponentException.build(hero, CollideComponent.class));
+          },
+          1,
+          FIREBALL_SPEED,
+          FIREBALL_RANGE,
+          FIREBALL_DMG);
+  private boolean shoot = false;
+
+  @Override
+  public void execute() {
+    if (shoot) {
+      Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
+      hero.fetch(AmmunitionComponent.class)
+          .filter(AmmunitionComponent::checkAmmunition)
+          .ifPresent(ac -> aimAndShoot(ac, hero));
+      shoot = false;
+    }
+  }
+
+  /** Schedule to shoot a fireball. */
+  public void scheduleShoot() {
+    shoot = true;
+  }
+
+  /**
+   * Shoots a fireball in direction the hero is facing.
+   *
+   * @param ac AmmunitionComponent of the hero, ammunition amount will be reduced by 1
+   * @param hero Entity to be used as hero for positioning
+   */
+  private void aimAndShoot(AmmunitionComponent ac, Entity hero) {
+    fireballSkill.execute(hero);
+    ac.spendAmmo();
+    Server.waitDelta();
+  }
+}


### PR DESCRIPTION
In Blockly konnte der Held keinen Feuerball schießen, weil die Textur aufgrund des fehlenden libGDX Kontext im Blockly-Thread nicht geladen werden konnte.

DIeser PR nutz den EventSchedular, um das schießen des Feuerballs in den ECS-Thread zu bewegen