### PR TITLE
Blockly: center hero on the correct tile for fireball

### DIFF
--- a/blockly/src/entities/monster/InevitableFireballSkill.java
+++ b/blockly/src/entities/monster/InevitableFireballSkill.java
@@ -1,6 +1,7 @@
 package entities.monster;
 
 import client.Client;
+import coderunner.BlocklyCommands;
 import contrib.utils.components.skill.projectileSkill.FireballSkill;
 import core.Entity;
 import core.Game;
@@ -43,14 +44,16 @@ public class InevitableFireballSkill extends FireballSkill {
     Game.hero()
         .flatMap(hero -> hero.fetch(VelocityComponent.class))
         .ifPresent(
-            velocityComponent -> {
-              velocityComponent.maxSpeed(0);
-            });
+            velocityComponent -> velocityComponent.maxSpeed(0));
     // Centers the hero on the tile, so the Blockly step looks completed, and the hero doesn't
     // freeze on the corner of the red zone
-    Game.hero()
-        .flatMap(hero -> hero.fetch(PositionComponent.class))
-        .ifPresent(pc -> pc.position(pc.position().toCoordinate().toPoint()));
+      Game.hero()
+              .flatMap(hero -> hero.fetch(PositionComponent.class))
+              .ifPresent(
+                      pc -> {
+                          pc.position(pc.position().translate(BlocklyCommands.MAGIC_OFFSET));
+                          pc.toTileCorner();
+                      });
   }
 
   protected void additionalEffectAfterDamage(
@@ -60,8 +63,6 @@ public class InevitableFireballSkill extends FireballSkill {
     target
         .fetch(VelocityComponent.class)
         .ifPresent(
-            velocityComponent -> {
-              velocityComponent.maxSpeed(Client.MOVEMENT_FORCE.x());
-            });
+            velocityComponent -> velocityComponent.maxSpeed(Client.MOVEMENT_FORCE.x()));
   }
 }

--- a/blockly/src/entities/monster/InevitableFireballSkill.java
+++ b/blockly/src/entities/monster/InevitableFireballSkill.java
@@ -43,17 +43,16 @@ public class InevitableFireballSkill extends FireballSkill {
     // Set the velocity to zero to freeze the entity (hero only)
     Game.hero()
         .flatMap(hero -> hero.fetch(VelocityComponent.class))
-        .ifPresent(
-            velocityComponent -> velocityComponent.maxSpeed(0));
+        .ifPresent(velocityComponent -> velocityComponent.maxSpeed(0));
     // Centers the hero on the tile, so the Blockly step looks completed, and the hero doesn't
     // freeze on the corner of the red zone
-      Game.hero()
-              .flatMap(hero -> hero.fetch(PositionComponent.class))
-              .ifPresent(
-                      pc -> {
-                          pc.position(pc.position().translate(BlocklyCommands.MAGIC_OFFSET));
-                          pc.toTileCorner();
-                      });
+    Game.hero()
+        .flatMap(hero -> hero.fetch(PositionComponent.class))
+        .ifPresent(
+            pc -> {
+              pc.position(pc.position().translate(BlocklyCommands.MAGIC_OFFSET));
+              pc.toTileCorner();
+            });
   }
 
   protected void additionalEffectAfterDamage(
@@ -62,7 +61,6 @@ public class InevitableFireballSkill extends FireballSkill {
     if (!target.isPresent(PlayerComponent.class)) return;
     target
         .fetch(VelocityComponent.class)
-        .ifPresent(
-            velocityComponent -> velocityComponent.maxSpeed(Client.MOVEMENT_FORCE.x()));
+        .ifPresent(velocityComponent -> velocityComponent.maxSpeed(Client.MOVEMENT_FORCE.x()));
   }
 }


### PR DESCRIPTION
fixes #2484

Selber spaß wie immer: Durch Float Rundungen stimmt die `tileAt` bestimmung nicht immer

Lösung: Apply MagicOffset