### PR TITLE
Blockly: Use ids instead of the times method for `for-loops`

### DIFF
--- a/blockly/frontend/src/generators/java/loops.ts
+++ b/blockly/frontend/src/generators/java/loops.ts
@@ -1,16 +1,18 @@
 import * as Blockly from "blockly";
-import { Order } from "../java.ts";
+import {Order} from "../java.ts";
 
 export function repeat(block: Blockly.Block, generator: Blockly.Generator) {
   const times = generator.valueToCode(block, "TIMES", Order.NONE);
+  // total amount of loops in whole workspace
 
   const repeat_body = generator.prefixLines(
     generator.blockToCode(block.getInputTargetBlock("DO")) as string,
     generator.INDENT
   );
 
-  const code = "hero.times("+ times +",() ->{"+ repeat_body + "});"
-  return code;
+  // create a variable name that is unique to this block (java var can only contain letters, _)
+  const repeat_var = block.id.replace(/[^a-zA-Z_]/g, '');
+  return "for(int " + repeat_var + " = 0; " + repeat_var + " < " + times + "; " + repeat_var + "++) {\n" + repeat_body + "\n}";
 }
 
 export function while_loop(block: Blockly.Block, generator: Blockly.Generator) {

--- a/blockly/src/coderunner/BlocklyCommands.java
+++ b/blockly/src/coderunner/BlocklyCommands.java
@@ -593,14 +593,4 @@ public class BlocklyCommands {
   public static void rest() {
     Server.waitDelta();
   }
-
-  /**
-   * Executes a given function a specified number of times.
-   *
-   * @param counter the number of times to execute the function; must be non-negative
-   * @param function the function to be executed repeatedly
-   */
-  public static void times(int counter, IVoidFunction function) {
-    IntStream.range(0, counter).forEach(value -> function.execute());
-  }
 }


### PR DESCRIPTION
Statt die `hero.times` Methode verwende ich jetzt eine `for-i` Schleife. Als Counter Variable verwende ich die Block-ID die einzigartig sein sollte. Das erlaubt jetzt das man auch Variablen in Schleifen verändern kann.