### PR TITLE
Dungeon: Add ShowImage module

### DIFF
--- a/dungeon/src/contrib/components/ShowImageComponent.java
+++ b/dungeon/src/contrib/components/ShowImageComponent.java
@@ -5,31 +5,173 @@ import core.Component;
 import core.Entity;
 import java.util.function.BiConsumer;
 
+/** Component that marks an entity as one that can show an image in fullscreen when triggered. */
 public class ShowImageComponent implements Component {
 
-  public String imagePath;
-  public ShowImageText textConfig;
-  public boolean isUIOpen = false;
-  public BiConsumer<Entity, Entity> onOpenAction;
-  public BiConsumer<Entity, Entity> onCloseAction;
-  public Entity overlay;
+  private String imagePath;
+  private ShowImageText textConfig;
+  private boolean isUIOpen = false;
+  private BiConsumer<Entity, Entity> onOpenAction;
+  private BiConsumer<Entity, Entity> onCloseAction;
+  private Entity overlay;
 
   /** Defines the maximum size the image should occupy on the screen, in its biggest axis. */
-  public float maxSize = 0.85f;
+  private float maxSize = 0.85f;
 
+  /**
+   * Creates a ShowImageComponent with the specified image path.
+   *
+   * @param imagePath the path of the image to be shown
+   */
   public ShowImageComponent(String imagePath) {
     this.imagePath = imagePath;
   }
 
+  /**
+   * Executes the onOpenAction if it is set.
+   *
+   * @param entity the entity that triggered the action
+   * @param overlay the overlay entity displaying the image
+   */
   public void onOpen(Entity entity, Entity overlay) {
     if (onOpenAction != null) {
       onOpenAction.accept(entity, overlay);
     }
   }
 
+  /**
+   * Executes the onCloseAction if it is set.
+   *
+   * @param entity the entity that triggered the action
+   * @param overlay the overlay entity displaying the image
+   */
   public void onClose(Entity entity, Entity overlay) {
     if (onCloseAction != null) {
       onCloseAction.accept(entity, overlay);
     }
+  }
+
+  /**
+   * Gets the path of the image to be shown.
+   *
+   * @return the path of the image
+   */
+  public String imagePath() {
+    return imagePath;
+  }
+
+  /**
+   * Sets the path of the image to be shown.
+   *
+   * @param imagePath the path of the image
+   * @return this component for chaining
+   */
+  public ShowImageComponent imagePath(String imagePath) {
+    this.imagePath = imagePath;
+    return this;
+  }
+
+  /**
+   * Gets the text config for the image.
+   *
+   * @return the text config
+   */
+  public ShowImageText textConfig() {
+    return textConfig;
+  }
+
+  /**
+   * Sets the text config for the image.
+   *
+   * @param textConfig the text config
+   * @return this component for chaining
+   */
+  public ShowImageComponent textConfig(ShowImageText textConfig) {
+    this.textConfig = textConfig;
+    return this;
+  }
+
+  /**
+   * Get whether the UI is currently open.
+   *
+   * @return true if the UI is open, false otherwise
+   */
+  public boolean isUIOpen() {
+    return isUIOpen;
+  }
+
+  /**
+   * Sets whether the UI is currently open.
+   *
+   * @param isUIOpen true if the UI is open, false otherwise
+   * @return this component for chaining
+   */
+  public ShowImageComponent isUIOpen(boolean isUIOpen) {
+    this.isUIOpen = isUIOpen;
+    return this;
+  }
+
+  /**
+   * Sets the action to be performed when the image is opened.
+   *
+   * @param onOpenAction the action to be performed
+   * @return this component for chaining
+   */
+  public ShowImageComponent onOpenAction(BiConsumer<Entity, Entity> onOpenAction) {
+    this.onOpenAction = onOpenAction;
+    return this;
+  }
+
+  /**
+   * Sets the action to be performed when the image is closed.
+   *
+   * @param onCloseAction the action to be performed
+   * @return this component for chaining
+   */
+  public ShowImageComponent onCloseAction(BiConsumer<Entity, Entity> onCloseAction) {
+    this.onCloseAction = onCloseAction;
+    return this;
+  }
+
+  /**
+   * Gets the overlay entity used to display the image.
+   *
+   * @return the overlay entity
+   */
+  public Entity overlay() {
+    return overlay;
+  }
+
+  /**
+   * Sets the overlay entity used to display the image.
+   *
+   * @param overlay the overlay entity
+   * @return this component for chaining
+   */
+  public ShowImageComponent overlay(Entity overlay) {
+    this.overlay = overlay;
+    return this;
+  }
+
+  /**
+   * Gets the factor that defines how much of the screen the image should take up in its biggest
+   * axis.
+   *
+   * @return the max size factor
+   */
+  public float maxSize() {
+    return maxSize;
+  }
+
+  /**
+   * Sets the factor that defines how much of the screen the image should take up in its biggest
+   * axis.
+   *
+   * @param maxSize the max size factor (can be above 1)
+   * @return this component for chaining
+   */
+  public ShowImageComponent maxSize(float maxSize) {
+    this.maxSize = maxSize;
+    return this;
   }
 }

--- a/dungeon/src/contrib/components/ShowImageComponent.java
+++ b/dungeon/src/contrib/components/ShowImageComponent.java
@@ -1,6 +1,7 @@
 package contrib.components;
 
 import contrib.utils.components.showImage.ShowImageText;
+import contrib.utils.components.showImage.TransitionSpeed;
 import core.Component;
 import core.Entity;
 import java.util.function.BiConsumer;
@@ -11,6 +12,7 @@ public class ShowImageComponent implements Component {
   private String imagePath;
   private ShowImageText textConfig;
   private boolean isUIOpen = false;
+  private TransitionSpeed transitionSpeed = TransitionSpeed.MEDIUM;
   private BiConsumer<Entity, Entity> onOpenAction;
   private BiConsumer<Entity, Entity> onCloseAction;
   private Entity overlay;
@@ -172,6 +174,26 @@ public class ShowImageComponent implements Component {
    */
   public ShowImageComponent maxSize(float maxSize) {
     this.maxSize = maxSize;
+    return this;
+  }
+
+  /**
+   * Gets the speed of the transition animation when showing the image.
+   *
+   * @return the transition speed
+   */
+  public TransitionSpeed transitionSpeed() {
+    return transitionSpeed;
+  }
+
+  /**
+   * Sets the speed of the transition animation when showing the image.
+   *
+   * @param transitionSpeed the transition speed
+   * @return this component for chaining
+   */
+  public ShowImageComponent transitionSpeed(TransitionSpeed transitionSpeed) {
+    this.transitionSpeed = transitionSpeed;
     return this;
   }
 }

--- a/dungeon/src/contrib/components/ShowImageComponent.java
+++ b/dungeon/src/contrib/components/ShowImageComponent.java
@@ -1,0 +1,35 @@
+package contrib.components;
+
+import contrib.utils.components.showImage.ShowImageText;
+import core.Component;
+import core.Entity;
+import java.util.function.BiConsumer;
+
+public class ShowImageComponent implements Component {
+
+  public String imagePath;
+  public ShowImageText textConfig;
+  public boolean isUIOpen = false;
+  public BiConsumer<Entity, Entity> onOpenAction;
+  public BiConsumer<Entity, Entity> onCloseAction;
+  public Entity overlay;
+
+  /** Defines the maximum size the image should occupy on the screen, in its biggest axis. */
+  public float maxSize = 0.85f;
+
+  public ShowImageComponent(String imagePath) {
+    this.imagePath = imagePath;
+  }
+
+  public void onOpen(Entity entity, Entity overlay) {
+    if (onOpenAction != null) {
+      onOpenAction.accept(entity, overlay);
+    }
+  }
+
+  public void onClose(Entity entity, Entity overlay) {
+    if (onCloseAction != null) {
+      onCloseAction.accept(entity, overlay);
+    }
+  }
+}

--- a/dungeon/src/contrib/entities/ShowImageFactory.java
+++ b/dungeon/src/contrib/entities/ShowImageFactory.java
@@ -1,0 +1,77 @@
+package contrib.entities;
+
+import contrib.components.InteractionComponent;
+import contrib.components.ShowImageComponent;
+import contrib.utils.components.showImage.ShowImageText;
+import core.Entity;
+import core.components.DrawComponent;
+import core.components.PositionComponent;
+import core.utils.Point;
+import core.utils.Vector2;
+import core.utils.components.path.SimpleIPath;
+import java.util.function.BiConsumer;
+
+public class ShowImageFactory {
+
+  private static final float INTERACTION_RADIUS = 1.5f;
+  private static final float X_OFFSET = 0.5f;
+  private static final float Y_OFFSET = 0.25f;
+
+  /**
+   * Creates a keypad at the designated position.
+   *
+   * @param pos The position where the lever will be created.
+   * @return The created keypad entity.
+   */
+  public static Entity createShowImage(
+      Point pos,
+      String spriteImage,
+      String imagePath,
+      BiConsumer<Entity, Entity> onClose,
+      float maxSize,
+      float radius,
+      ShowImageText text) {
+    Entity entity = new Entity("show-image");
+    entity.add(new PositionComponent(pos.translate(Vector2.of(X_OFFSET, Y_OFFSET))));
+
+    DrawComponent dc = new DrawComponent(new SimpleIPath(spriteImage));
+    entity.add(dc);
+
+    ShowImageComponent sic = new ShowImageComponent(imagePath);
+    sic.onCloseAction = onClose;
+    sic.maxSize = maxSize;
+    sic.textConfig = text;
+    entity.add(sic);
+
+    entity.add(new InteractionComponent(radius, true, (e, who) -> sic.isUIOpen = true));
+    return entity;
+  }
+
+  public static Entity createShowImage(
+      Point pos,
+      String spriteImage,
+      String imagePath,
+      BiConsumer<Entity, Entity> onClose,
+      float maxSize,
+      float radius) {
+    return createShowImage(pos, spriteImage, imagePath, onClose, maxSize, radius, null);
+  }
+
+  public static Entity createShowImage(
+      Point pos,
+      String spriteImage,
+      String imagePath,
+      BiConsumer<Entity, Entity> onClose,
+      float maxSize) {
+    return createShowImage(pos, spriteImage, imagePath, onClose, maxSize, INTERACTION_RADIUS, null);
+  }
+
+  public static Entity createShowImage(
+      Point pos, String spriteImage, String imagePath, float maxSize) {
+    return createShowImage(pos, spriteImage, imagePath, null, maxSize, INTERACTION_RADIUS, null);
+  }
+
+  public static Entity createShowImage(Point pos, String spriteImage, String imagePath) {
+    return createShowImage(pos, spriteImage, imagePath, null, 0.85f, INTERACTION_RADIUS, null);
+  }
+}

--- a/dungeon/src/contrib/entities/ShowImageFactory.java
+++ b/dungeon/src/contrib/entities/ShowImageFactory.java
@@ -11,6 +11,7 @@ import core.utils.Vector2;
 import core.utils.components.path.SimpleIPath;
 import java.util.function.BiConsumer;
 
+/** Factory class for creating ShowImage entities. */
 public class ShowImageFactory {
 
   private static final float INTERACTION_RADIUS = 1.5f;
@@ -18,10 +19,17 @@ public class ShowImageFactory {
   private static final float Y_OFFSET = 0.25f;
 
   /**
-   * Creates a keypad at the designated position.
+   * Creates an entity that will show the specified image when interacted with, at the designated
+   * position.
    *
-   * @param pos The position where the lever will be created.
-   * @return The created keypad entity.
+   * @param pos the position of the entity
+   * @param spriteImage the path to the sprite image representing the entity
+   * @param imagePath the path of the image to be shown
+   * @param onClose action to be performed when the image is closed
+   * @param maxSize the maximum size the image should occupy on the screen, in its biggest axis
+   * @param radius the interaction radius of the entity
+   * @param text optional text configuration for displaying text alongside the image
+   * @return the entity
    */
   public static Entity createShowImage(
       Point pos,
@@ -38,39 +46,24 @@ public class ShowImageFactory {
     entity.add(dc);
 
     ShowImageComponent sic = new ShowImageComponent(imagePath);
-    sic.onCloseAction = onClose;
-    sic.maxSize = maxSize;
-    sic.textConfig = text;
+    sic.onCloseAction(onClose);
+    sic.maxSize(maxSize);
+    sic.textConfig(text);
     entity.add(sic);
 
-    entity.add(new InteractionComponent(radius, true, (e, who) -> sic.isUIOpen = true));
+    entity.add(new InteractionComponent(radius, true, (e, who) -> sic.isUIOpen(true)));
     return entity;
   }
 
-  public static Entity createShowImage(
-      Point pos,
-      String spriteImage,
-      String imagePath,
-      BiConsumer<Entity, Entity> onClose,
-      float maxSize,
-      float radius) {
-    return createShowImage(pos, spriteImage, imagePath, onClose, maxSize, radius, null);
-  }
-
-  public static Entity createShowImage(
-      Point pos,
-      String spriteImage,
-      String imagePath,
-      BiConsumer<Entity, Entity> onClose,
-      float maxSize) {
-    return createShowImage(pos, spriteImage, imagePath, onClose, maxSize, INTERACTION_RADIUS, null);
-  }
-
-  public static Entity createShowImage(
-      Point pos, String spriteImage, String imagePath, float maxSize) {
-    return createShowImage(pos, spriteImage, imagePath, null, maxSize, INTERACTION_RADIUS, null);
-  }
-
+  /**
+   * Creates an entity that will show the specified image when interacted with, at the designated
+   * position.
+   *
+   * @param pos the position of the entity
+   * @param spriteImage the path to the sprite image representing the entity
+   * @param imagePath the path of the image to be shown
+   * @return the entity
+   */
   public static Entity createShowImage(Point pos, String spriteImage, String imagePath) {
     return createShowImage(pos, spriteImage, imagePath, null, 0.85f, INTERACTION_RADIUS, null);
   }

--- a/dungeon/src/contrib/hud/DialogUtils.java
+++ b/dungeon/src/contrib/hud/DialogUtils.java
@@ -1,7 +1,11 @@
 package contrib.hud;
 
+import contrib.components.ShowImageComponent;
+import contrib.components.UIComponent;
 import contrib.hud.dialogs.OkDialog;
+import contrib.utils.components.showImage.ShowImageUI;
 import core.Entity;
+import core.Game;
 import core.utils.IVoidFunction;
 import java.util.Iterator;
 import java.util.function.Function;
@@ -91,5 +95,18 @@ public class DialogUtils {
                         }
                       });
                 }));
+  }
+
+  /**
+   * Displays an image in a popup.
+   *
+   * @param imagePath The path to the image to display.
+   * @see ShowImageUI
+   */
+  public static void showImagePopUp(String imagePath) {
+    Entity e = new Entity();
+    ShowImageComponent sic = new ShowImageComponent(imagePath);
+    e.add(new UIComponent(new ShowImageUI(sic), true, true));
+    Game.add(e);
   }
 }

--- a/dungeon/src/contrib/hud/DialogUtils.java
+++ b/dungeon/src/contrib/hud/DialogUtils.java
@@ -4,6 +4,7 @@ import contrib.components.ShowImageComponent;
 import contrib.components.UIComponent;
 import contrib.hud.dialogs.OkDialog;
 import contrib.utils.components.showImage.ShowImageUI;
+import contrib.utils.components.showImage.TransitionSpeed;
 import core.Entity;
 import core.Game;
 import core.utils.IVoidFunction;
@@ -101,12 +102,24 @@ public class DialogUtils {
    * Displays an image in a popup.
    *
    * @param imagePath The path to the image to display.
+   * @param speed The speed of the transition.
+   * @see ShowImageUI
+   */
+  public static void showImagePopUp(String imagePath, TransitionSpeed speed) {
+    Entity e = new Entity();
+    ShowImageComponent sic = new ShowImageComponent(imagePath);
+    sic.transitionSpeed(speed);
+    e.add(new UIComponent(new ShowImageUI(sic), true, true));
+    Game.add(e);
+  }
+
+  /**
+   * Displays an image in a popup.
+   *
+   * @param imagePath The path to the image to display.
    * @see ShowImageUI
    */
   public static void showImagePopUp(String imagePath) {
-    Entity e = new Entity();
-    ShowImageComponent sic = new ShowImageComponent(imagePath);
-    e.add(new UIComponent(new ShowImageUI(sic), true, true));
-    Game.add(e);
+    showImagePopUp(imagePath, TransitionSpeed.MEDIUM);
   }
 }

--- a/dungeon/src/contrib/systems/ShowImageSystem.java
+++ b/dungeon/src/contrib/systems/ShowImageSystem.java
@@ -1,0 +1,58 @@
+package contrib.systems;
+
+import contrib.components.ShowImageComponent;
+import contrib.components.UIComponent;
+import contrib.utils.components.showImage.ShowImageUI;
+import core.Entity;
+import core.Game;
+import core.System;
+import core.components.DrawComponent;
+import core.components.PositionComponent;
+
+public class ShowImageSystem extends System {
+
+  public ShowImageSystem() {
+    super(ShowImageComponent.class, DrawComponent.class, PositionComponent.class);
+  }
+
+  @Override
+  public void execute() {
+    filteredEntityStream(ShowImageComponent.class, DrawComponent.class, PositionComponent.class)
+        .map(this::buildDataObject)
+        .forEach(this::execute);
+  }
+
+  public void execute(Data d) {
+    Entity overlay = d.sic.overlay;
+
+    if (overlay == null && d.sic.isUIOpen) {
+      // Dialog is closed but should be open
+      Entity newOverlay = new Entity("show-image-overlay");
+      UIComponent uic = new UIComponent(new ShowImageUI(d.e), true, true);
+      uic.onClose(
+          () -> {
+            d.sic.isUIOpen = false;
+            d.sic.onClose(d.e, newOverlay);
+          });
+      newOverlay.add(uic);
+      d.sic.overlay = newOverlay;
+      Game.add(newOverlay);
+      d.sic.onOpen(d.e, newOverlay);
+
+    } else if (overlay != null && !d.sic.isUIOpen) {
+      // Dialog is open but should be closed
+      Game.remove(overlay);
+      d.sic.overlay = null;
+    }
+  }
+
+  private Data buildDataObject(Entity e) {
+    return new Data(
+        e,
+        e.fetch(ShowImageComponent.class).orElseThrow(),
+        e.fetch(DrawComponent.class).orElseThrow(),
+        e.fetch(PositionComponent.class).orElseThrow());
+  }
+
+  private record Data(Entity e, ShowImageComponent sic, DrawComponent dc, PositionComponent pc) {}
+}

--- a/dungeon/src/contrib/systems/ShowImageSystem.java
+++ b/dungeon/src/contrib/systems/ShowImageSystem.java
@@ -41,7 +41,7 @@ public class ShowImageSystem extends System {
     if (overlay == null && d.sic.isUIOpen()) {
       // Dialog is closed but should be open
       Entity newOverlay = new Entity("show-image-overlay");
-      UIComponent uic = new UIComponent(new ShowImageUI(d.e), true, true);
+      UIComponent uic = new UIComponent(new ShowImageUI(d.sic), true, true);
       uic.onClose(
           () -> {
             d.sic.isUIOpen(false);

--- a/dungeon/src/contrib/systems/ShowImageSystem.java
+++ b/dungeon/src/contrib/systems/ShowImageSystem.java
@@ -9,8 +9,16 @@ import core.System;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
 
+/**
+ * System that handles showing images in fullscreen when an entity with a ShowImageComponent is
+ * interacted with.
+ */
 public class ShowImageSystem extends System {
 
+  /**
+   * Creates a new ShowImageSystem that processes entities with ShowImageComponent, DrawComponent,
+   * and PositionComponent.
+   */
   public ShowImageSystem() {
     super(ShowImageComponent.class, DrawComponent.class, PositionComponent.class);
   }
@@ -22,37 +30,42 @@ public class ShowImageSystem extends System {
         .forEach(this::execute);
   }
 
-  public void execute(Data d) {
-    Entity overlay = d.sic.overlay;
+  /**
+   * Executes the system logic.
+   *
+   * @param d the data object containing the entity and its components
+   */
+  public void execute(SIData d) {
+    Entity overlay = d.sic.overlay();
 
-    if (overlay == null && d.sic.isUIOpen) {
+    if (overlay == null && d.sic.isUIOpen()) {
       // Dialog is closed but should be open
       Entity newOverlay = new Entity("show-image-overlay");
       UIComponent uic = new UIComponent(new ShowImageUI(d.e), true, true);
       uic.onClose(
           () -> {
-            d.sic.isUIOpen = false;
+            d.sic.isUIOpen(false);
             d.sic.onClose(d.e, newOverlay);
           });
       newOverlay.add(uic);
-      d.sic.overlay = newOverlay;
+      d.sic.overlay(newOverlay);
       Game.add(newOverlay);
       d.sic.onOpen(d.e, newOverlay);
 
-    } else if (overlay != null && !d.sic.isUIOpen) {
+    } else if (overlay != null && !d.sic.isUIOpen()) {
       // Dialog is open but should be closed
       Game.remove(overlay);
-      d.sic.overlay = null;
+      d.sic.overlay(null);
     }
   }
 
-  private Data buildDataObject(Entity e) {
-    return new Data(
+  private SIData buildDataObject(Entity e) {
+    return new SIData(
         e,
         e.fetch(ShowImageComponent.class).orElseThrow(),
         e.fetch(DrawComponent.class).orElseThrow(),
         e.fetch(PositionComponent.class).orElseThrow());
   }
 
-  private record Data(Entity e, ShowImageComponent sic, DrawComponent dc, PositionComponent pc) {}
+  private record SIData(Entity e, ShowImageComponent sic, DrawComponent dc, PositionComponent pc) {}
 }

--- a/dungeon/src/contrib/utils/components/showImage/ShowImageText.java
+++ b/dungeon/src/contrib/utils/components/showImage/ShowImageText.java
@@ -2,23 +2,31 @@ package contrib.utils.components.showImage;
 
 import com.badlogic.gdx.graphics.Color;
 
-public class ShowImageText {
+/**
+ * A record that holds configuration for displaying text on an image.
+ *
+ * @param text the text to display
+ * @param scale the scale of the text
+ * @param color the color of the text
+ */
+public record ShowImageText(String text, float scale, Color color) {
 
-  public String text;
-  public float scale;
-  public Color color;
-
-  public ShowImageText(String text, float scale, Color color) {
-    this.text = text;
-    this.scale = scale;
-    this.color = color;
-  }
-
+  /**
+   * Creates a text config with the specified text and scale, in black.
+   *
+   * @param text the text to display
+   * @param scale the scale of the text
+   */
   public ShowImageText(String text, float scale) {
     this(text, scale, Color.BLACK);
   }
 
+  /**
+   * Creates a text config with the specified text, in black and with a scale of 1.
+   *
+   * @param text the text to display
+   */
   public ShowImageText(String text) {
-    this(text, 1);
+    this(text, 1f, Color.BLACK);
   }
 }

--- a/dungeon/src/contrib/utils/components/showImage/ShowImageText.java
+++ b/dungeon/src/contrib/utils/components/showImage/ShowImageText.java
@@ -1,0 +1,24 @@
+package contrib.utils.components.showImage;
+
+import com.badlogic.gdx.graphics.Color;
+
+public class ShowImageText {
+
+  public String text;
+  public float scale;
+  public Color color;
+
+  public ShowImageText(String text, float scale, Color color) {
+    this.text = text;
+    this.scale = scale;
+    this.color = color;
+  }
+
+  public ShowImageText(String text, float scale) {
+    this(text, scale, Color.BLACK);
+  }
+
+  public ShowImageText(String text) {
+    this(text, 1);
+  }
+}

--- a/dungeon/src/contrib/utils/components/showImage/ShowImageUI.java
+++ b/dungeon/src/contrib/utils/components/showImage/ShowImageUI.java
@@ -15,6 +15,7 @@ import contrib.hud.UIUtils;
 import core.Entity;
 import core.Game;
 
+/** UI element that displays an image with optional text, used through the ShowImageSystem. */
 public class ShowImageUI extends Group {
 
   private static final float SCALE = 1f;
@@ -28,6 +29,11 @@ public class ShowImageUI extends Group {
   private String currentImagePath = null;
   private float animation;
 
+  /**
+   * Creates a new ShowImageUI for the given entity.
+   *
+   * @param keypad the entity containing the ShowImageComponent
+   */
   public ShowImageUI(Entity keypad) {
     this.sprite = keypad;
     createActors();
@@ -41,17 +47,17 @@ public class ShowImageUI extends Group {
 
     ShowImageComponent sic = sprite.fetch(ShowImageComponent.class).orElseThrow();
 
-    currentImagePath = sic.imagePath;
+    currentImagePath = sic.imagePath();
     background = new Image(new Texture(Gdx.files.internal(currentImagePath)));
     background.setOrigin(Align.center);
     this.addActor(background);
 
-    if (sic.textConfig != null) {
+    if (sic.textConfig() != null) {
       Table table = new Table();
       table.setFillParent(true);
-      Label label = new Label(sic.textConfig.text, UIUtils.defaultSkin());
-      label.setFontScale(sic.textConfig.scale);
-      label.setColor(sic.textConfig.color);
+      Label label = new Label(sic.textConfig().text(), UIUtils.defaultSkin());
+      label.setFontScale(sic.textConfig().scale());
+      label.setColor(sic.textConfig().color());
       table.add(label);
       this.addActor(table);
     }
@@ -64,15 +70,15 @@ public class ShowImageUI extends Group {
     this.setBounds(0, 0, Game.windowWidth(), Game.windowHeight());
 
     ShowImageComponent sic = sprite.fetch(ShowImageComponent.class).orElseThrow();
-    if (!currentImagePath.equals(sic.imagePath)) {
-      currentImagePath = sic.imagePath;
+    if (!currentImagePath.equals(sic.imagePath())) {
+      currentImagePath = sic.imagePath();
       background.setDrawable(
           new TextureRegionDrawable(new Texture(Gdx.files.internal(currentImagePath))));
     }
     float imageWidth = background.getImageWidth();
     float imageHeight = background.getImageHeight();
-    float maxWidth = Game.windowWidth() * sic.maxSize;
-    float maxHeight = Game.windowHeight() * sic.maxSize;
+    float maxWidth = Game.windowWidth() * sic.maxSize();
+    float maxHeight = Game.windowHeight() * sic.maxSize();
 
     float scaleX = maxWidth / imageWidth;
     float scaleY = maxHeight / imageHeight;

--- a/dungeon/src/contrib/utils/components/showImage/ShowImageUI.java
+++ b/dungeon/src/contrib/utils/components/showImage/ShowImageUI.java
@@ -37,6 +37,7 @@ public class ShowImageUI extends Group {
     this.component = sic;
     createActors();
     animation = 0;
+    if (sic.transitionSpeed() == TransitionSpeed.DISABLED) animation = 1;
   }
 
   private void createActors() {
@@ -85,7 +86,9 @@ public class ShowImageUI extends Group {
 
     this.setPosition(animationOffsetX(), animationOffsetY());
     this.setColor(1, 1, 1, animation);
-    animation = Math.min(1, animation + SHOW_TRANSITION_PROGRESS);
+    if (animation < 1) {
+      animation = Math.min(1, animation + (1f / component.transitionSpeed().framesToComplete));
+    }
 
     super.draw(batch, parentAlpha);
   }

--- a/dungeon/src/contrib/utils/components/showImage/ShowImageUI.java
+++ b/dungeon/src/contrib/utils/components/showImage/ShowImageUI.java
@@ -12,7 +12,6 @@ import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.badlogic.gdx.utils.Align;
 import contrib.components.ShowImageComponent;
 import contrib.hud.UIUtils;
-import core.Entity;
 import core.Game;
 
 /** UI element that displays an image with optional text, used through the ShowImageSystem. */
@@ -23,7 +22,7 @@ public class ShowImageUI extends Group {
   private static final int ANIMATION_OFFSET_Y = -50;
   private static final float SHOW_TRANSITION_PROGRESS = 1 / 30f;
 
-  private final Entity sprite;
+  private final ShowImageComponent component;
 
   private Image background;
   private String currentImagePath = null;
@@ -32,10 +31,10 @@ public class ShowImageUI extends Group {
   /**
    * Creates a new ShowImageUI for the given entity.
    *
-   * @param keypad the entity containing the ShowImageComponent
+   * @param sic the ShowImageComponent containing the image and text configuration
    */
-  public ShowImageUI(Entity keypad) {
-    this.sprite = keypad;
+  public ShowImageUI(ShowImageComponent sic) {
+    this.component = sic;
     createActors();
     animation = 0;
   }
@@ -45,19 +44,17 @@ public class ShowImageUI extends Group {
     this.setOrigin(Align.center);
     this.setBounds(0, 0, Game.windowWidth(), Game.windowHeight());
 
-    ShowImageComponent sic = sprite.fetch(ShowImageComponent.class).orElseThrow();
-
-    currentImagePath = sic.imagePath();
+    currentImagePath = component.imagePath();
     background = new Image(new Texture(Gdx.files.internal(currentImagePath)));
     background.setOrigin(Align.center);
     this.addActor(background);
 
-    if (sic.textConfig() != null) {
+    if (component.textConfig() != null) {
       Table table = new Table();
       table.setFillParent(true);
-      Label label = new Label(sic.textConfig().text(), UIUtils.defaultSkin());
-      label.setFontScale(sic.textConfig().scale());
-      label.setColor(sic.textConfig().color());
+      Label label = new Label(component.textConfig().text(), UIUtils.defaultSkin());
+      label.setFontScale(component.textConfig().scale());
+      label.setColor(component.textConfig().color());
       table.add(label);
       this.addActor(table);
     }
@@ -69,16 +66,15 @@ public class ShowImageUI extends Group {
     this.setOrigin(Align.center);
     this.setBounds(0, 0, Game.windowWidth(), Game.windowHeight());
 
-    ShowImageComponent sic = sprite.fetch(ShowImageComponent.class).orElseThrow();
-    if (!currentImagePath.equals(sic.imagePath())) {
-      currentImagePath = sic.imagePath();
+    if (!currentImagePath.equals(component.imagePath())) {
+      currentImagePath = component.imagePath();
       background.setDrawable(
           new TextureRegionDrawable(new Texture(Gdx.files.internal(currentImagePath))));
     }
     float imageWidth = background.getImageWidth();
     float imageHeight = background.getImageHeight();
-    float maxWidth = Game.windowWidth() * sic.maxSize();
-    float maxHeight = Game.windowHeight() * sic.maxSize();
+    float maxWidth = Game.windowWidth() * component.maxSize();
+    float maxHeight = Game.windowHeight() * component.maxSize();
 
     float scaleX = maxWidth / imageWidth;
     float scaleY = maxHeight / imageHeight;

--- a/dungeon/src/contrib/utils/components/showImage/ShowImageUI.java
+++ b/dungeon/src/contrib/utils/components/showImage/ShowImageUI.java
@@ -1,0 +1,98 @@
+package contrib.utils.components.showImage;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.math.Interpolation;
+import com.badlogic.gdx.scenes.scene2d.Group;
+import com.badlogic.gdx.scenes.scene2d.ui.Image;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
+import com.badlogic.gdx.utils.Align;
+import contrib.components.ShowImageComponent;
+import contrib.hud.UIUtils;
+import core.Entity;
+import core.Game;
+
+public class ShowImageUI extends Group {
+
+  private static final float SCALE = 1f;
+  private static final int ANIMATION_OFFSET_X = -5;
+  private static final int ANIMATION_OFFSET_Y = -50;
+  private static final float SHOW_TRANSITION_PROGRESS = 1 / 30f;
+
+  private final Entity sprite;
+
+  private Image background;
+  private String currentImagePath = null;
+  private float animation;
+
+  public ShowImageUI(Entity keypad) {
+    this.sprite = keypad;
+    createActors();
+    animation = 0;
+  }
+
+  private void createActors() {
+    this.setScale(SCALE);
+    this.setOrigin(Align.center);
+    this.setBounds(0, 0, Game.windowWidth(), Game.windowHeight());
+
+    ShowImageComponent sic = sprite.fetch(ShowImageComponent.class).orElseThrow();
+
+    currentImagePath = sic.imagePath;
+    background = new Image(new Texture(Gdx.files.internal(currentImagePath)));
+    background.setOrigin(Align.center);
+    this.addActor(background);
+
+    if (sic.textConfig != null) {
+      Table table = new Table();
+      table.setFillParent(true);
+      Label label = new Label(sic.textConfig.text, UIUtils.defaultSkin());
+      label.setFontScale(sic.textConfig.scale);
+      label.setColor(sic.textConfig.color);
+      table.add(label);
+      this.addActor(table);
+    }
+  }
+
+  @Override
+  public void draw(Batch batch, float parentAlpha) {
+    this.setScale(SCALE);
+    this.setOrigin(Align.center);
+    this.setBounds(0, 0, Game.windowWidth(), Game.windowHeight());
+
+    ShowImageComponent sic = sprite.fetch(ShowImageComponent.class).orElseThrow();
+    if (!currentImagePath.equals(sic.imagePath)) {
+      currentImagePath = sic.imagePath;
+      background.setDrawable(
+          new TextureRegionDrawable(new Texture(Gdx.files.internal(currentImagePath))));
+    }
+    float imageWidth = background.getImageWidth();
+    float imageHeight = background.getImageHeight();
+    float maxWidth = Game.windowWidth() * sic.maxSize;
+    float maxHeight = Game.windowHeight() * sic.maxSize;
+
+    float scaleX = maxWidth / imageWidth;
+    float scaleY = maxHeight / imageHeight;
+
+    float minScale = Math.min(scaleX, scaleY);
+    background.setScale(minScale);
+    background.setPosition(getX(Align.center), getY(Align.center), Align.center);
+
+    this.setPosition(animationOffsetX(), animationOffsetY());
+    this.setColor(1, 1, 1, animation);
+    animation = Math.min(1, animation + SHOW_TRANSITION_PROGRESS);
+
+    super.draw(batch, parentAlpha);
+  }
+
+  private float animationOffsetX() {
+    return Interpolation.smooth.apply(ANIMATION_OFFSET_X, 0, animation);
+  }
+
+  private float animationOffsetY() {
+    return Interpolation.smooth.apply(ANIMATION_OFFSET_Y, 0, animation);
+  }
+}

--- a/dungeon/src/contrib/utils/components/showImage/TransitionSpeed.java
+++ b/dungeon/src/contrib/utils/components/showImage/TransitionSpeed.java
@@ -1,0 +1,24 @@
+package contrib.utils.components.showImage;
+
+/** Enum representing the speed of the transition animation. */
+public enum TransitionSpeed {
+
+  /** Fast transition speed (10 frames to complete). */
+  FAST(10),
+
+  /** Medium transition speed (30 frames to complete). */
+  MEDIUM(30),
+
+  /** Slow transition speed (60 frames to complete). */
+  SLOW(60),
+
+  /** Disabled transition (no animation). */
+  DISABLED(0);
+
+  /** Number of frames the transition takes to complete. */
+  public final float framesToComplete;
+
+  TransitionSpeed(final float framesToComplete) {
+    this.framesToComplete = framesToComplete;
+  }
+}


### PR DESCRIPTION
Platziert ein Entity in der Welt, das bei Interaktion ein Bild (mit optionalem zentrierten Text) in Fullscreen auf dem Bildschirm anzeigen lässt. Beinhaltet System, Component und Factory-Methoden.

~~Hilft bei #2419, aber ändert nichts an der Dialog API.~~

Fügt `DialogUtils.showImagePopUp` hinzu, um Bilder als eigener Dialog auch ohne in-world entity anzeigen zu können. Immer noch nicht alle Funktionen, die in #2419 gefordert werden.

@AMatutat @Flamtky thoughts?