### PR TITLE
Dungeon: Update Debugger

### DIFF
--- a/advancedDungeon/src/produsAdvanced/AdvancedDungeon.java
+++ b/advancedDungeon/src/produsAdvanced/AdvancedDungeon.java
@@ -13,7 +13,6 @@ import core.Game;
 import core.components.PlayerComponent;
 import core.game.WindowEventManager;
 import core.level.loader.DungeonLoader;
-import core.utils.IVoidFunction;
 import core.utils.JsonHandler;
 import core.utils.Tuple;
 import core.utils.components.path.SimpleIPath;
@@ -52,8 +51,6 @@ public class AdvancedDungeon {
 
   private static final String SAVE_FILE = "currentAdvancedLevel.json";
 
-  private static final Debugger DEBUGGER = new Debugger();
-
   /** Global reference to the {@link Hero} instance used in the game. */
   public static Hero hero;
 
@@ -74,16 +71,6 @@ public class AdvancedDungeon {
   private static final String CONTROLLER_CLASSNAME = "produsAdvanced.riddles.MyPlayerController";
 
   private static final String FIREBALL_CLASSNAME = "produsAdvanced.riddles.MyFireballSkill";
-
-  /**
-   * Function called every frame to check for manual recompilation trigger.
-   *
-   * <p>Pressing the 'M' key triggers recompilation of the user-defined player controller class.
-   */
-  private static final IVoidFunction onFrame =
-      () -> {
-        if (DEBUG_MODE) DEBUGGER.execute();
-      };
 
   /**
    * Attempts to dynamically recompile and load the custom player controller class.
@@ -117,7 +104,6 @@ public class AdvancedDungeon {
     Game.initBaseLogger(Level.WARNING);
     configGame();
     onSetup();
-    Game.userOnFrame(onFrame);
     Game.run();
   }
 
@@ -191,6 +177,7 @@ public class AdvancedDungeon {
     Game.add(new StaminaRestoreSystem());
     Game.add(new ManaBarSystem());
     Game.add(new StaminaBarSystem());
+    if (DEBUG_MODE) Game.add(new Debugger());
     if (DEBUG_MODE) Game.add(new LevelEditorSystem());
   }
 

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -61,8 +61,6 @@ public class Client {
     // Set up components and level
     onSetup();
 
-    if (DEBUG_MODE) onFrame(debugger);
-
     onLevelLoad();
 
     // build and start game
@@ -74,10 +72,6 @@ public class Client {
         httpServer.stop(0);
       }
     }
-  }
-
-  private static void onFrame(Debugger debugger) {
-    Game.userOnFrame(debugger::execute);
   }
 
   private static void onSetup() {
@@ -175,6 +169,7 @@ public class Client {
     Game.add(new FogSystem());
     Game.add(new PressurePlateSystem());
     Game.add(new ScheduleShootFireballSystem());
+    if (DEBUG_MODE) Game.add(new Debugger());
 
     Game.add(
         new System() {

--- a/devDungeon/src/starter/DevDungeon.java
+++ b/devDungeon/src/starter/DevDungeon.java
@@ -158,6 +158,7 @@ public class DevDungeon {
 
     /* Cheats */
     if (ENABLE_CHEATS) {
+      Game.add(new Debugger());
       enableCheats();
     }
   }

--- a/dungeon/src/contrib/components/HealthComponent.java
+++ b/dungeon/src/contrib/components/HealthComponent.java
@@ -233,4 +233,13 @@ public final class HealthComponent implements Component {
   public void godMode(boolean status) {
     this.godMode = status;
   }
+
+  /**
+   * Check if god mode is activated.
+   *
+   * @return true if god mode is activated, false otherwise.
+   */
+  public boolean godMode() {
+    return this.godMode;
+  }
 }

--- a/dungeon/src/contrib/configuration/KeyboardConfig.java
+++ b/dungeon/src/contrib/configuration/KeyboardConfig.java
@@ -148,4 +148,11 @@ public class KeyboardConfig {
   /** Keybinding to open all doors, if the {@link contrib.utils.components.Debugger} is active. */
   public static final ConfigKey<Integer> DEBUG_OPEN_DOORS =
       new ConfigKey<>(new String[] {"open", "open_doors"}, new ConfigIntValue(Input.Keys.C));
+
+  /**
+   * Keybinding to toggle the {@link contrib.systems.DebugDrawSystem Debug-HUD}, if the {@link
+   * contrib.utils.components.Debugger} and {@link contrib.systems.DebugDrawSystem} are active.
+   */
+  public static final ConfigKey<Integer> DEBUG_TOGGLE_HUD =
+      new ConfigKey<>(new String[] {"debug", "toggle_hud"}, new ConfigIntValue(Input.Keys.F3));
 }

--- a/dungeon/src/contrib/systems/DebugDrawSystem.java
+++ b/dungeon/src/contrib/systems/DebugDrawSystem.java
@@ -1,18 +1,27 @@
 package contrib.systems;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import contrib.components.AIComponent;
 import contrib.components.CollideComponent;
+import contrib.components.HealthComponent;
 import core.Entity;
 import core.System;
 import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.components.VelocityComponent;
 import core.systems.CameraSystem;
+import core.systems.DrawSystem;
 import core.utils.Point;
 import core.utils.Vector2;
 import core.utils.components.MissingComponentException;
 import core.utils.components.draw.animation.Animation;
+import java.util.List;
 
 /**
  * A debug system that visually overlays entity information on top of the game world.
@@ -36,9 +45,13 @@ import core.utils.components.draw.animation.Animation;
 public class DebugDrawSystem extends System {
 
   private final ShapeRenderer SHAPE_RENDERER = new ShapeRenderer();
+  private final BitmapFont FONT = new BitmapFont();
+  private boolean render = false;
 
   @Override
   public void execute() {
+    if (!render) return;
+
     SHAPE_RENDERER.setProjectionMatrix(CameraSystem.camera().combined);
     filteredEntityStream(PositionComponent.class).forEach(this::drawPosition);
   }
@@ -73,17 +86,17 @@ public class DebugDrawSystem extends System {
     SHAPE_RENDERER.end();
 
     if (entity.isPresent(DrawComponent.class)) drawTextureSize(entity, pc);
-    if (entity.isPresent(CollideComponent.class)) drawColideHitbox(entity, pc);
+    if (entity.isPresent(CollideComponent.class)) drawCollideHitbox(entity);
     if (entity.isPresent(VelocityComponent.class)) drawMoveHitbox(entity, pc);
+    if (CameraSystem.isEntityHovered(entity)) drawEntityInfo(entity, pc);
   }
 
   /**
    * Draw a red rectangle around the hitbox of the entity.
    *
    * @param entity Entity to draw the rectangle for.
-   * @param pc PositionComponent of the entity.
    */
-  private void drawColideHitbox(Entity entity, PositionComponent pc) {
+  private void drawCollideHitbox(Entity entity) {
     CollideComponent cc =
         entity
             .fetch(CollideComponent.class)
@@ -158,5 +171,191 @@ public class DebugDrawSystem extends System {
     SHAPE_RENDERER.setColor(Color.WHITE);
     SHAPE_RENDERER.rect(bottomLeft.x(), bottomLeft.y(), width, height);
     SHAPE_RENDERER.end();
+  }
+
+  /**
+   * Draw on entity hover relevant entity infos.
+   *
+   * <pre>
+   *   * Entity ID
+   *   * Position; View Direction
+   *   * Current Velocity (if VelocityComponent is present)
+   *   * curHealth/maxHealth (if HealthComponent is present)
+   *   * Current Animation state (if DrawComponent is present)
+   *   * List of all components attached to the entity
+   * </pre>
+   *
+   * @param entity The entity to draw info for.
+   * @param pc The PositionComponent of the entity.
+   */
+  private void drawEntityInfo(Entity entity, PositionComponent pc) {
+    // In headless mode (e.g., tests) Gdx.graphics may be null
+    if (Gdx.graphics == null) return;
+
+    // Compute layout and render a semi-transparent background + white text near the entity
+    drawInfoOverlay(buildInfoText(entity, pc), pc.position());
+  }
+
+  /**
+   * Builds the multiline info text shown near a hovered entity.
+   *
+   * <p>Includes:
+   *
+   * <ul>
+   *   <li>Entity name and ID
+   *   <li>Position and view direction
+   *   <li>Velocity (if present)
+   *   <li>Health (if present)
+   *   <li>Animation state (if present)
+   *   <li>List of all components when holding Shift
+   * </ul>
+   *
+   * @param entity The entity to build info for.
+   * @param pc The PositionComponent of the entity.
+   * @return The formatted info text.
+   */
+  private String buildInfoText(Entity entity, PositionComponent pc) {
+    Point position = pc.position();
+
+    // TODO: we should use a interface for components that want to add debug info lines e.g.
+    // "implements DebugInfoProvider { String debugInfoLine(); }"
+    StringBuilder info = new StringBuilder();
+    info.append(entity.name()).append(" (").append(entity.id()).append(")\n");
+    info.append("Position: (")
+        .append(String.format("%.2f", position.x()))
+        .append(", ")
+        .append(String.format("%.2f", position.y()))
+        .append("); ")
+        .append(pc.viewDirection())
+        .append("\n");
+
+    entity
+        .fetch(VelocityComponent.class)
+        .ifPresent(
+            vc -> {
+              String velStr =
+                  String.format("(%.2f, %.2f)", vc.currentVelocity().x(), vc.currentVelocity().y());
+              info.append("Velocity: ").append(velStr).append("\n");
+            });
+
+    entity
+        .fetch(HealthComponent.class)
+        .ifPresent(
+            hc ->
+                info.append("Health: ")
+                    .append(hc.currentHealthpoints())
+                    .append("/")
+                    .append(hc.maximalHealthpoints())
+                    .append(hc.isDead() ? " (DEAD)" : "")
+                    .append(hc.godMode() ? " (GOD)" : "")
+                    .append("\n"));
+
+    entity
+        .fetch(DrawComponent.class)
+        .ifPresent(
+            dc -> info.append("Animation State: ").append(dc.currentStateName()).append("\n"));
+
+    // We should try to render the path for the current ai; this probably needs a PathAI to check
+    // the instance here
+    entity
+        .fetch(AIComponent.class)
+        .ifPresent(
+            ai ->
+                info.append("AI State: ").append(ai.active() ? "Active" : "Inactive").append("\n"));
+
+    List<String> componentNames =
+        entity
+            .componentStream()
+            .map(comp -> comp.getClass().getSimpleName())
+            .sorted(String::compareToIgnoreCase)
+            .toList();
+
+    // If holding Shift, show all components; otherwise hint how to show them
+    if (Gdx.input.isKeyPressed(Input.Keys.SHIFT_LEFT)
+        || Gdx.input.isKeyPressed(Input.Keys.SHIFT_RIGHT)) {
+      info.append(componentNames.size())
+          .append(" component")
+          .append(componentNames.size() == 1 ? "" : "s")
+          .append("\n");
+      componentNames.forEach(name -> info.append(" - ").append(name).append("\n"));
+    } else {
+      info.append("(Hold Shift to show all ")
+          .append(componentNames.size())
+          .append(" component")
+          .append(componentNames.size() == 1 ? "" : "s")
+          .append("\n");
+    }
+
+    // remove last newline for a cleaner box bottom
+    info.setLength(info.length() - 1);
+    return info.toString();
+  }
+
+  /**
+   * Renders the info overlay near the given world position.
+   *
+   * <p>Text is drawn in world space using DrawSystem's batch, but the font is scaled so that it
+   * appears at a consistent pixel size regardless of camera zoom. A semi-transparent black
+   * background is drawn behind the text using ShapeRenderer.
+   *
+   * @param text The multiline text to render.
+   * @param worldPos The world position near which to render the text.
+   */
+  private void drawInfoOverlay(String text, Point worldPos) {
+    // Ensure crisp text at sub-pixel world positions
+    FONT.setUseIntegerPositions(false);
+
+    // Compute pixels-per-world-unit to counteract camera scaling so the font renders at
+    // consistent pixel size regardless of zoom.
+    float zoom = CameraSystem.camera().zoom;
+    float vpw = CameraSystem.camera().viewportWidth;
+    float vph = CameraSystem.camera().viewportHeight;
+    float pxPerWU_X = Gdx.graphics.getWidth() / (vpw * zoom);
+    float pxPerWU_Y = Gdx.graphics.getHeight() / (vph * zoom);
+
+    // Scale the font to cancel out world->screen scaling applied by the batch/camera.
+    float scaleX = 1f / pxPerWU_X;
+    float scaleY = 1f / pxPerWU_Y;
+    FONT.getData().setScale(scaleX, scaleY);
+
+    GlyphLayout layout = new GlyphLayout(FONT, text);
+
+    // Layout dimensions are now in world units due to font scaling above.
+    // Convert desired pixel paddings/offsets into world units using the scale.
+    float padding = 4f * scaleX; // ~4px padding (using X as baseline for a uniform box)
+    float offsetX = 8f * scaleX; // ~8px to the right of the entity
+    float offsetY = 12f * scaleY; // ~12px above the entity
+
+    float textX = worldPos.x() + offsetX;
+    float textY = worldPos.y() + offsetY; // y is baseline for BitmapFont
+    float bgX = textX - padding;
+    float bgY = textY - layout.height - padding; // background below baseline
+    float bgW = layout.width + 2f * padding;
+    float bgH = layout.height + 2f * padding;
+
+    // semi-transparent black box
+    SHAPE_RENDERER.begin(ShapeRenderer.ShapeType.Filled);
+    SHAPE_RENDERER.setColor(new Color(0f, 0f, 0f, 0.6f));
+    SHAPE_RENDERER.rect(bgX, bgY, bgW, bgH);
+    SHAPE_RENDERER.end();
+
+    // Draw text on top using the shared batch
+    Batch batch = DrawSystem.batch();
+    boolean started = false;
+    if (!batch.isDrawing()) {
+      batch.setProjectionMatrix(CameraSystem.camera().combined);
+      batch.begin();
+      started = true;
+    }
+    FONT.setColor(Color.WHITE);
+    FONT.draw(batch, layout, textX, textY);
+    if (started) {
+      batch.end();
+    }
+  }
+
+  /** Whether this debug system is currently active and drawing the overlays. */
+  public void toggleHUD() {
+    this.render = !this.render;
   }
 }

--- a/dungeon/src/contrib/systems/DebugDrawSystem.java
+++ b/dungeon/src/contrib/systems/DebugDrawSystem.java
@@ -195,9 +195,6 @@ public class DebugDrawSystem extends System {
     // In headless mode (e.g., tests) Gdx.gl may be null
     if (Gdx.gl == null) return;
 
-    Gdx.gl.glEnable(GL20.GL_BLEND);
-    Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
-
     // Compute layout and render a semi-transparent background + white text near the entity
     drawInfoOverlay(buildInfoText(entity, pc), pc.position());
   }
@@ -294,7 +291,7 @@ public class DebugDrawSystem extends System {
           .append(componentNames.size())
           .append(" component")
           .append(componentNames.size() == 1 ? "" : "s")
-          .append("\n");
+          .append(")\n");
     }
 
     // remove last newline for a cleaner box bottom
@@ -345,6 +342,8 @@ public class DebugDrawSystem extends System {
     float bgH = layout.height + 2f * padding;
 
     // semi-transparent black box
+    Gdx.gl.glEnable(GL20.GL_BLEND);
+    Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
     SHAPE_RENDERER.begin(ShapeRenderer.ShapeType.Filled);
     SHAPE_RENDERER.setColor(BACKGROUND_COLOR);
     SHAPE_RENDERER.rect(bgX, bgY, bgW, bgH);

--- a/dungeon/src/contrib/utils/CollisionUtils.java
+++ b/dungeon/src/contrib/utils/CollisionUtils.java
@@ -42,6 +42,30 @@ public class CollisionUtils {
   }
 
   /**
+   * Checks if an entity at a given position with a specified size and offset is colliding with the
+   * given {@link Point}.
+   *
+   * @param pos the bottom-left position of the entity
+   * @param offset the offset of the hitbox
+   * @param size the size of the entity
+   * @param point the point to check for collision
+   * @return true if any corner of the hitbox is colliding with the point, false otherwise
+   */
+  public static boolean isCollidingWithPoint(Point pos, Vector2 offset, Vector2 size, Point point) {
+    float minX = pos.x() + offset.x();
+    float minY = pos.y() + offset.y();
+    float maxX = minX + size.x();
+    float maxY = minY + size.y();
+
+    // Use half-open interval \[min, max) with a small TOP_OFFSET to avoid floating-point/corner
+    // issues
+    return point.x() >= minX
+        && point.x() < maxX - TOP_OFFSET
+        && point.y() >= minY
+        && point.y() < maxY - TOP_OFFSET;
+  }
+
+  /**
    * Helper method to determine if a tile can be entered by the entity.
    *
    * <p>Considers both whether the tile is accessible and whether the entity is allowed to enter pit

--- a/dungeon/src/core/game/GameLoop.java
+++ b/dungeon/src/core/game/GameLoop.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.Scaling;
 import com.badlogic.gdx.utils.SharedLibraryLoader;
 import com.badlogic.gdx.utils.viewport.ScalingViewport;
+import contrib.systems.DebugDrawSystem;
 import contrib.utils.CheckPatternPainter;
 import core.Entity;
 import core.Game;
@@ -272,5 +273,6 @@ public final class GameLoop extends ScreenAdapter {
     ECSManagment.add(new FrictionSystem());
     ECSManagment.add(new MoveSystem());
     ECSManagment.add(new InputSystem());
+    ECSManagment.add(new DebugDrawSystem());
   }
 }

--- a/escapeRoom/src/starter/CoopDungeon.java
+++ b/escapeRoom/src/starter/CoopDungeon.java
@@ -42,10 +42,6 @@ public class CoopDungeon {
     configGame();
     onSetup();
 
-    if (DEBUG_MODE) {
-      Debugger debugger = new Debugger();
-      Game.userOnFrame(() -> debugger.execute());
-    }
     Game.windowTitle("Coop-Dungeon");
     Game.run();
   }
@@ -102,6 +98,7 @@ public class CoopDungeon {
     Game.add(new StaminaRestoreSystem());
     Game.add(new ManaBarSystem());
     Game.add(new StaminaBarSystem());
+    if (DEBUG_MODE) Game.add(new Debugger());
   }
 
   private static void setupMusic() {

--- a/escapeRoom/src/starter/DemoRoom.java
+++ b/escapeRoom/src/starter/DemoRoom.java
@@ -38,10 +38,6 @@ public class DemoRoom {
     configGame();
     onSetup();
 
-    if (DEBUG_MODE) {
-      Debugger debugger = new Debugger();
-      Game.userOnFrame(() -> debugger.execute());
-    }
     Game.windowTitle("Demo-Room");
     Game.run();
   }
@@ -98,7 +94,7 @@ public class DemoRoom {
     Game.add(new LeverSystem());
     Game.add(new PressurePlateSystem());
     Game.add(new IdleSoundSystem());
-    if (DEBUG_MODE) Game.add(new DebugDrawSystem());
+    if (DEBUG_MODE) Game.add(new Debugger());
   }
 
   private static void setupMusic() {


### PR DESCRIPTION
Das `DebugDrawSystem` ist jetzt per Default im Spiel, jedoch ausgeblendet. Mit `F3` kann man das HUD ein und ausblenden.
Dafür braucht man den Debugger, der jetzt auch ein System ist, um den Keystroke aufzufragen.

Zusätzlich kann das `DebugDrawSystem` Entity-Informationen anzeigen, wenn man über ein Entity mit der Maus hovert (siehe Bild). Diese Version ist erstmal nur ein Mini-Prototype zum debuggen, später sollte man evtl. ein Interface ergänzen, was dann von Components implementiert werden kann um eine `Debug-Line` zu ergänzen. So könnte dann auch Blockly oder DevDungeon Komponente angezeigt werden.

<img width="247" height="435" alt="image" src="https://github.com/user-attachments/assets/b520b3ab-1cbe-4e77-9b13-dc5a99ad3e39" />
