### PR TITLE
Dungeon: spiky damage now caused by onHold 

### DIFF
--- a/dungeon/src/contrib/entities/HeroFactory.java
+++ b/dungeon/src/contrib/entities/HeroFactory.java
@@ -197,23 +197,20 @@ public final class HeroFactory {
             });
     hc.currentHealthpoints(characterClass.hp());
     hero.add(hc);
-    CollideComponent col =
-        new CollideComponent(
-            (you, other, direction) ->
-                other
-                    .fetch(SpikyComponent.class)
-                    .ifPresent(
-                        spikyComponent -> {
-                          if (spikyComponent.isActive()) {
-                            hc.receiveHit(
-                                new Damage(
-                                    spikyComponent.damageAmount(),
-                                    spikyComponent.damageType(),
-                                    other));
-                            spikyComponent.activateCoolDown();
-                          }
-                        }),
-            CollideComponent.DEFAULT_COLLIDER);
+    CollideComponent col = new CollideComponent();
+    col.onHold(
+        (you, other, direction) ->
+            other
+                .fetch(SpikyComponent.class)
+                .ifPresent(
+                    spikyComponent -> {
+                      if (spikyComponent.isActive()) {
+                        hc.receiveHit(
+                            new Damage(
+                                spikyComponent.damageAmount(), spikyComponent.damageType(), other));
+                        spikyComponent.activateCoolDown();
+                      }
+                    }));
     hero.add(col);
 
     InputComponent inputComp = new InputComponent();


### PR DESCRIPTION
Eigentlich wurde es durch #2471 gefixt. Aber #2456 hat es ausersehen wieder in der onEnter verschoben