### PR TITLE
Dungeon: Tweak projectile hitbox sizes

### DIFF
--- a/advancedDungeon/src/produsAdvanced/riddles/MyFireballSkill.java
+++ b/advancedDungeon/src/produsAdvanced/riddles/MyFireballSkill.java
@@ -25,9 +25,8 @@ public class MyFireballSkill extends DamageProjectileSkill {
   private static final int DAMAGE = 2;
   private static final float RANGE = 7f;
   private static final DamageType DAMAGE_TYPE = DamageType.FIRE;
-  private static final Vector2 HIT_BOX_SIZE = Vector2.of(1, 1);
   private static final long COOLDOWN = 500;
-  private static final boolean IS_PIRCING = false;
+  private static final boolean IS_PIERCING = false;
 
   /**
    * Erstellt einen Feuerball mit Standardwerten.
@@ -62,10 +61,9 @@ public class MyFireballSkill extends DamageProjectileSkill {
         null,
         speed,
         range,
-        IS_PIRCING,
+        IS_PIERCING,
         damageAmount,
         DAMAGE_TYPE,
-        HIT_BOX_SIZE,
         resourceCost);
   }
 

--- a/dungeon/src/contrib/components/CollideComponent.java
+++ b/dungeon/src/contrib/components/CollideComponent.java
@@ -42,10 +42,10 @@ import java.util.logging.Logger;
  */
 public final class CollideComponent implements Component {
   /** The default offset of the hit box. */
-  public static final Vector2 DEFAULT_OFFSET = Vector2.of(0.25f, 0.25f);
+  public static final Vector2 DEFAULT_OFFSET = Vector2.of(0.1f, 0.1f);
 
   /** The default size of the hit box. */
-  public static final Vector2 DEFAULT_SIZE = Vector2.of(0.5f, 0.5f);
+  public static final Vector2 DEFAULT_SIZE = Vector2.of(0.8f, 0.8f);
 
   /**
    * The default collision behavior for projectiles.

--- a/dungeon/src/contrib/utils/components/skill/projectileSkill/BowSkill.java
+++ b/dungeon/src/contrib/utils/components/skill/projectileSkill/BowSkill.java
@@ -8,7 +8,6 @@ import core.Game;
 import core.components.PositionComponent;
 import core.utils.Point;
 import core.utils.Tuple;
-import core.utils.Vector2;
 import core.utils.components.path.IPath;
 import core.utils.components.path.SimpleIPath;
 import java.util.function.Consumer;
@@ -37,7 +36,6 @@ public class BowSkill extends DamageProjectileSkill {
   private static final boolean IS_PIRCING = false;
   private static final float DEFAULT_PROJECTILE_RANGE = 7f;
   private static final DamageType DAMAGE_TYPE = DamageType.PHYSICAL;
-  private static final Vector2 HIT_BOX_SIZE = Vector2.ONE;
   private static final Tuple<Resource, Integer> COST = new Tuple<>(Resource.ARROW, 1);
   private static final long BOW_COOLDOWN = 500;
   private double stickInWallProbability = 0.1;
@@ -70,7 +68,6 @@ public class BowSkill extends DamageProjectileSkill {
         IS_PIRCING,
         damageAmount,
         DAMAGE_TYPE,
-        HIT_BOX_SIZE,
         resourceCost);
   }
 

--- a/dungeon/src/contrib/utils/components/skill/projectileSkill/DamageProjectileSkill.java
+++ b/dungeon/src/contrib/utils/components/skill/projectileSkill/DamageProjectileSkill.java
@@ -28,7 +28,7 @@ public abstract class DamageProjectileSkill extends ProjectileSkill {
   protected DamageType damageType;
 
   /** Whether the projectile pierces through multiple targets or is removed after hitting one. */
-  protected boolean pircing;
+  protected boolean piercing;
 
   /** A supplier that provides the target endpoint of the projectile. */
   private Supplier<Point> endPointSupplier;
@@ -42,11 +42,12 @@ public abstract class DamageProjectileSkill extends ProjectileSkill {
    * @param end A supplier providing the endpoint (target location) of the projectile.
    * @param speed The travel speed of the projectile.
    * @param range The maximum range the projectile can travel.
-   * @param pircing Whether the projectile pierces through targets (true) or is destroyed on impact
+   * @param piercing Whether the projectile pierces through targets (true) or is destroyed on impact
    *     (false).
    * @param damageAmount The base damage dealt by the projectile.
    * @param damageType The type of damage inflicted by the projectile.
    * @param hitBoxSize The hitbox size of the projectile used for collision detection.
+   * @param hitBoxOffset The hitbox offset of the projectile used for collision detection.
    * @param resourceCost The resource cost (e.g., mana, energy, arrows) required to use this skill.
    */
   @SafeVarargs
@@ -57,15 +58,50 @@ public abstract class DamageProjectileSkill extends ProjectileSkill {
       Supplier<Point> end,
       float speed,
       float range,
-      boolean pircing,
+      boolean piercing,
       int damageAmount,
       DamageType damageType,
       Vector2 hitBoxSize,
+      Vector2 hitBoxOffset,
       Tuple<Resource, Integer>... resourceCost) {
-    super(name, cooldown, texture, speed, range, hitBoxSize, resourceCost);
+    super(name, cooldown, texture, speed, range, hitBoxSize, hitBoxOffset, resourceCost);
     this.damageAmount = damageAmount;
     this.damageType = damageType;
-    this.pircing = pircing;
+    this.piercing = piercing;
+    this.endPointSupplier = end;
+  }
+
+  /**
+   * Create a new {@link DamageProjectileSkill}.
+   *
+   * @param name The name of the skill.
+   * @param cooldown The cooldown time (in ms) before the skill can be used again.
+   * @param texture The visual texture used for the projectile.
+   * @param end A supplier providing the endpoint (target location) of the projectile.
+   * @param speed The travel speed of the projectile.
+   * @param range The maximum range the projectile can travel.
+   * @param piercing Whether the projectile pierces through targets (true) or is destroyed on impact
+   *     (false).
+   * @param damageAmount The base damage dealt by the projectile.
+   * @param damageType The type of damage inflicted by the projectile.
+   * @param resourceCost The resource cost (e.g., mana, energy, arrows) required to use this skill.
+   */
+  @SafeVarargs
+  public DamageProjectileSkill(
+      String name,
+      long cooldown,
+      IPath texture,
+      Supplier<Point> end,
+      float speed,
+      float range,
+      boolean piercing,
+      int damageAmount,
+      DamageType damageType,
+      Tuple<Resource, Integer>... resourceCost) {
+    super(name, cooldown, texture, speed, range, resourceCost);
+    this.damageAmount = damageAmount;
+    this.damageType = damageType;
+    this.piercing = piercing;
     this.endPointSupplier = end;
   }
 
@@ -95,7 +131,7 @@ public abstract class DamageProjectileSkill extends ProjectileSkill {
             .ifPresent(hc -> hc.receiveHit(calculateDamage(caster, target, direction)));
         additionalEffectAfterDamage(caster, projectile, target, direction);
 
-        if (pircing) {
+        if (piercing) {
           ignoreEntities.add(target);
         } else {
           Game.remove(projectile);

--- a/dungeon/src/contrib/utils/components/skill/projectileSkill/FireballSkill.java
+++ b/dungeon/src/contrib/utils/components/skill/projectileSkill/FireballSkill.java
@@ -32,7 +32,6 @@ public class FireballSkill extends DamageProjectileSkill {
   private static final boolean IS_PIERCING = false;
 
   private static final DamageType DAMAGE_TYPE = DamageType.FIRE;
-  private static final Vector2 HIT_BOX_SIZE = Vector2.of(1, 1);
 
   /**
    * Creates a fully customized fireball skill with a custom name.
@@ -67,7 +66,6 @@ public class FireballSkill extends DamageProjectileSkill {
         IS_PIERCING,
         damageAmount,
         DAMAGE_TYPE,
-        HIT_BOX_SIZE,
         resourceCost);
   }
 

--- a/dungeon/src/contrib/utils/components/skill/projectileSkill/TPBallSkill.java
+++ b/dungeon/src/contrib/utils/components/skill/projectileSkill/TPBallSkill.java
@@ -25,10 +25,9 @@ public class TPBallSkill extends DamageProjectileSkill {
   private static final float PROJECTILE_SPEED = 6.0f;
   private static final int DAMAGE_AMOUNT = 1;
   private static final DamageType DAMAGE_TYPE = DamageType.MAGIC;
-  private static final Vector2 HIT_BOX_SIZE = Vector2.of(1, 1);
   private static final float PROJECTILE_RANGE = 7f;
   private static final long COOLDOWN = 2000;
-  private static final boolean IS_PIRCING = false;
+  private static final boolean IS_PIERCING = false;
 
   /** Name of the Skill. */
   public static final String SKILL_NAME = "TPBall";
@@ -62,10 +61,9 @@ public class TPBallSkill extends DamageProjectileSkill {
         target,
         speed,
         range,
-        IS_PIRCING,
+        IS_PIERCING,
         damageAmount,
         DAMAGE_TYPE,
-        HIT_BOX_SIZE,
         resourceCost);
     this.tpTarget = tpTarget;
     tintColor(0xFF00FFFF);

--- a/dungeon/src/core/components/VelocityComponent.java
+++ b/dungeon/src/core/components/VelocityComponent.java
@@ -1,5 +1,6 @@
 package core.components;
 
+import contrib.components.CollideComponent;
 import core.Component;
 import core.Entity;
 import core.utils.Vector2;
@@ -59,14 +60,14 @@ public final class VelocityComponent implements Component {
    *
    * <p>This hitbox is used for level collision checks.
    */
-  public static final Vector2 MOVEBOX_DEFAULT_OFFSET = Vector2.of(0.25f, 0.25f);
+  public static final Vector2 MOVEBOX_DEFAULT_OFFSET = CollideComponent.DEFAULT_OFFSET;
 
   /**
    * The default size of the hit box.
    *
    * <p>This hitbox is used for level collision checks.
    */
-  public static final Vector2 MOVEBOX_DEFAULT_SIZE = Vector2.of(0.5f, 0.5f);
+  public static final Vector2 MOVEBOX_DEFAULT_SIZE = CollideComponent.DEFAULT_SIZE;
 
   private Vector2 moveboxOffset;
   private Vector2 moveboxSize;


### PR DESCRIPTION
Vorher:
<img width="135" height="126" alt="image" src="https://github.com/user-attachments/assets/19cae6ea-8b4f-4cad-81dc-cfbc3150548a" />
Nacher:
<img width="148" height="123" alt="image" src="https://github.com/user-attachments/assets/0c9f4df0-86b0-4083-b3a6-dddde1cffa59" />
Die rote (im zweiten Bild die weiße) Box zeigt die Kollision-HitBox von einen Feuerball. Jetzt ist die schön zentriert und etwas kleiner.