### PR TITLE
Dungeon: Debug-HUD Render Interaction Range

### DIFF
--- a/dungeon/src/contrib/systems/DebugDrawSystem.java
+++ b/dungeon/src/contrib/systems/DebugDrawSystem.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import contrib.components.AIComponent;
 import contrib.components.CollideComponent;
 import contrib.components.HealthComponent;
+import contrib.components.InteractionComponent;
 import core.Entity;
 import core.System;
 import core.components.DrawComponent;
@@ -91,6 +92,7 @@ public class DebugDrawSystem extends System {
     if (entity.isPresent(DrawComponent.class)) drawTextureSize(entity, pc);
     if (entity.isPresent(CollideComponent.class)) drawCollideHitbox(entity);
     if (entity.isPresent(VelocityComponent.class)) drawMoveHitbox(entity, pc);
+    if (entity.isPresent(InteractionComponent.class)) drawInteractionRange(entity, pc);
     if (CameraSystem.isEntityHovered(entity)) drawEntityInfo(entity, pc);
   }
 
@@ -114,6 +116,26 @@ public class DebugDrawSystem extends System {
     SHAPE_RENDERER.begin(ShapeRenderer.ShapeType.Line);
     SHAPE_RENDERER.setColor(Color.RED);
     SHAPE_RENDERER.rect(bottomLeft.x(), bottomLeft.y(), width, height);
+    SHAPE_RENDERER.end();
+  }
+
+  /**
+   * Draw a blue circle around the interaction range of the entity.
+   *
+   * @param entity Entity to draw the interaction range for.
+   * @param pc PositionComponent of the entity.
+   */
+  private void drawInteractionRange(Entity entity, PositionComponent pc) {
+    InteractionComponent ic =
+        entity
+            .fetch(InteractionComponent.class)
+            .orElseThrow(() -> MissingComponentException.build(entity, InteractionComponent.class));
+
+    float radius = ic.radius();
+
+    SHAPE_RENDERER.begin(ShapeRenderer.ShapeType.Line);
+    SHAPE_RENDERER.setColor(Color.CYAN);
+    SHAPE_RENDERER.circle(pc.position().x(), pc.position().y(), radius, 60);
     SHAPE_RENDERER.end();
   }
 

--- a/dungeon/src/contrib/systems/DebugDrawSystem.java
+++ b/dungeon/src/contrib/systems/DebugDrawSystem.java
@@ -49,6 +49,8 @@ public class DebugDrawSystem extends System {
   private static final ShapeRenderer SHAPE_RENDERER = new ShapeRenderer();
   private static final Color BACKGROUND_COLOR =
       new Color(0f, 0f, 0f, 0.75f); // semi-transparent black
+
+  private static final int CIRCLE_SEGMENTS = 60; // resolution of circles (higher = smoother)
   private final BitmapFont FONT = new BitmapFont();
   private boolean render = false;
 
@@ -71,7 +73,7 @@ public class DebugDrawSystem extends System {
     // --- filled dot for position ---
     SHAPE_RENDERER.begin(ShapeRenderer.ShapeType.Filled);
     SHAPE_RENDERER.setColor(Color.ORANGE);
-    SHAPE_RENDERER.circle(position.x(), position.y(), 0.3f);
+    SHAPE_RENDERER.circle(position.x(), position.y(), 0.2f, CIRCLE_SEGMENTS);
     SHAPE_RENDERER.end();
 
     // --- arrow for view direction ---
@@ -135,7 +137,7 @@ public class DebugDrawSystem extends System {
 
     SHAPE_RENDERER.begin(ShapeRenderer.ShapeType.Line);
     SHAPE_RENDERER.setColor(Color.CYAN);
-    SHAPE_RENDERER.circle(pc.position().x(), pc.position().y(), radius, 60);
+    SHAPE_RENDERER.circle(pc.position().x(), pc.position().y(), radius, CIRCLE_SEGMENTS);
     SHAPE_RENDERER.end();
   }
 

--- a/dungeon/src/core/systems/CameraSystem.java
+++ b/dungeon/src/core/systems/CameraSystem.java
@@ -4,12 +4,11 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.math.collision.BoundingBox;
-import contrib.components.CollideComponent;
-import contrib.utils.CollisionUtils;
 import core.Entity;
 import core.Game;
 import core.System;
 import core.components.CameraComponent;
+import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.game.PreRunConfiguration;
 import core.level.Tile;
@@ -86,11 +85,11 @@ public final class CameraSystem extends System {
   /**
    * Checks if the given entity is hovered by the mouse cursor.
    *
-   * <p>It uses the Hitbox inside the {@link CollideComponent} if available, otherwise it uses a
+   * <p>It uses the Texture inside the {@link DrawComponent} if available, otherwise it uses a
    * default radius of 0.5f around the entity's position.
    *
    * <p>Returns false if the entity does not have a {@link PositionComponent PositionComponent} or
-   * if if the input or graphics context is not available (e.g., in headless mode).
+   * if the input or graphics context is not available (e.g., in headless mode).
    *
    * @param entity The entity to check.
    * @return True if the entity is hovered, false otherwise.
@@ -110,12 +109,19 @@ public final class CameraSystem extends System {
         .map(
             positionComponent ->
                 entity
-                    .fetch(CollideComponent.class)
+                    .fetch(DrawComponent.class)
                     .map(
-                        cc ->
-                            CollisionUtils.isCollidingWithPoint(
-                                positionComponent.position(), cc.offset(), cc.size(), mousePoint))
-                    // Fallback: if no CollideComponent, use a default radius of 0.5f around the
+                        dc -> {
+                          float width = dc.getWidth();
+                          float height = dc.getHeight();
+                          Point bottomLeft = positionComponent.position();
+
+                          return bottomLeft.x() <= mousePoint.x()
+                              && mousePoint.x() <= bottomLeft.x() + width
+                              && bottomLeft.y() <= mousePoint.y()
+                              && mousePoint.y() <= bottomLeft.y() + height;
+                        })
+                    // Fallback: if no DrawComponent, use a default radius of 0.5f around the
                     // position
                     .orElseGet(
                         () -> positionComponent.position().distance(mousePoint) < HOVER_RADIUS))


### PR DESCRIPTION
Das Debug-HUD rendert jetzt Kreise mit mehr Segments und zeichnet (falls vorhanden) den Interaktions-Radius ein.

<img width="167" height="131" alt="image" src="https://github.com/user-attachments/assets/62e75855-e907-473b-ba1b-261d18edc926" />

Zusätzlich verwendet jetzt die Hover-Logik die Sprite Dimensionen statt die Kollision-Hitbox