### PR TITLE
Escaperoom: Coop Dungeon update crate mass in level 02

### DIFF
--- a/escapeRoom/src/coopDungeon/level/Level02.java
+++ b/escapeRoom/src/coopDungeon/level/Level02.java
@@ -23,7 +23,7 @@ import java.util.List;
  */
 public class Level02 extends DungeonLevel {
   private static final int DELAY_MILLIS = 1000;
-  private static final float CRATE_MASS = 3f;
+  private static final float CRATE_MASS = 1f;
   private LeverComponent p, p2, l1, l2;
   private ExitTile exit;
   private DoorTile door1, door2;


### PR DESCRIPTION
Damit nach #2456 sich die Kiste im Coop Dungeon wieder schieben lässt, hab ich hier die Masse reduziert- 