### PR TITLE
Blockly: use FireballSchedular

### DIFF
--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import level.produs.*;
 import server.Server;
-import systems.ScheduleShootFireballSystem;
 import systems.TintTilesSystem;
 
 /**
@@ -169,9 +168,7 @@ public class Client {
     Game.add(new EventScheduler());
     Game.add(new FogSystem());
     Game.add(new PressurePlateSystem());
-    Game.add(new ScheduleShootFireballSystem());
     if (DEBUG_MODE) Game.add(new Debugger());
-
     Game.add(
         new System() {
           @Override

--- a/blockly/src/coderunner/BlocklyCommands.java
+++ b/blockly/src/coderunner/BlocklyCommands.java
@@ -134,6 +134,9 @@ public class BlocklyCommands {
    */
   public static void shootFireball() {
     FireballSchedular.shoot();
+    // Multiple waits allow to shoot a fireball for the next tile (hero stands infront of monster)
+    Server.waitDelta();
+    Server.waitDelta();
     Server.waitDelta();
   }
 

--- a/blockly/src/coderunner/BlocklyCommands.java
+++ b/blockly/src/coderunner/BlocklyCommands.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import server.Server;
-import systems.ScheduleShootFireballSystem;
+import systems.FireballSchedular;
 
 /** A utility class that contains all methods for Blockly Blocks. */
 public class BlocklyCommands {
@@ -133,11 +133,7 @@ public class BlocklyCommands {
    * <p>The hero needs at least one unit of ammunition to successfully shoot a fireball.
    */
   public static void shootFireball() {
-    Game.system(
-        ScheduleShootFireballSystem.class,
-        scheduleShootFireballSystem -> scheduleShootFireballSystem.scheduleShoot());
-    Server.waitDelta();
-    Server.waitDelta();
+    FireballSchedular.shoot();
     Server.waitDelta();
   }
 

--- a/blockly/src/systems/FireballSchedular.java
+++ b/blockly/src/systems/FireballSchedular.java
@@ -2,33 +2,29 @@ package systems;
 
 import components.AmmunitionComponent;
 import contrib.components.CollideComponent;
+import contrib.systems.EventScheduler;
 import contrib.utils.EntityUtils;
 import contrib.utils.components.skill.projectileSkill.FireballSkill;
 import core.Entity;
 import core.Game;
-import core.System;
 import core.utils.MissingHeroException;
 import core.utils.components.MissingComponentException;
-import server.Server;
 
 /**
- * System that allows the hero in Blockly to shoot a fireball.
+ * Utilty class that allows the hero in Blockly to shoot a fireball.
  *
  * <p>Since Blockly code is executed in a separate thread, the libGDX context does not exist in that
  * thread, and no textures can be loaded there.
  *
- * <p>This system makes it possible to schedule the shooting of a fireball, which will then be
+ * <p>This Class makes it possible to schedule the shooting of a fireball, which will then be
  * executed inside the ECS thread. This ensures that the textures for the fireball can be loaded.
- *
- * <p>Only one shot can be scheduled at a time. Make sure to call {@link server.Server#waitDelta()}
- * accordingly.
  */
-public class ScheduleShootFireballSystem extends System {
+public class FireballSchedular {
 
   private static final float FIREBALL_RANGE = Integer.MAX_VALUE;
   private static final float FIREBALL_SPEED = 15f;
   private static final int FIREBALL_DMG = 1;
-  private final FireballSkill fireballSkill =
+  private static final FireballSkill fireballSkill =
       new FireballSkill(
           () -> {
             Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
@@ -41,22 +37,16 @@ public class ScheduleShootFireballSystem extends System {
           FIREBALL_SPEED,
           FIREBALL_RANGE,
           FIREBALL_DMG);
-  private boolean shoot = false;
 
-  @Override
-  public void execute() {
-    if (shoot) {
-      Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
-      hero.fetch(AmmunitionComponent.class)
-          .filter(AmmunitionComponent::checkAmmunition)
-          .ifPresent(ac -> aimAndShoot(ac, hero));
-      shoot = false;
-    }
-  }
-
-  /** Schedule to shoot a fireball. */
-  public void scheduleShoot() {
-    shoot = true;
+  public static void shoot() {
+    EventScheduler.scheduleAction(
+        () -> {
+          Entity hero = Game.hero().orElseThrow(MissingHeroException::new);
+          hero.fetch(AmmunitionComponent.class)
+              .filter(AmmunitionComponent::checkAmmunition)
+              .ifPresent(ac -> aimAndShoot(ac, hero));
+        },
+        0);
   }
 
   /**
@@ -65,9 +55,8 @@ public class ScheduleShootFireballSystem extends System {
    * @param ac AmmunitionComponent of the hero, ammunition amount will be reduced by 1
    * @param hero Entity to be used as hero for positioning
    */
-  private void aimAndShoot(AmmunitionComponent ac, Entity hero) {
+  private static void aimAndShoot(AmmunitionComponent ac, Entity hero) {
     fireballSkill.execute(hero);
     ac.spendAmmo();
-    Server.waitDelta();
   }
 }

--- a/blockly/src/systems/FireballSchedular.java
+++ b/blockly/src/systems/FireballSchedular.java
@@ -38,6 +38,11 @@ public class FireballSchedular {
           FIREBALL_RANGE,
           FIREBALL_DMG);
 
+  /**
+   * Shoot a fireball in the viewdirection of the hero.
+   *
+   * <p>This uses the {@link EventScheduler}
+   */
   public static void shoot() {
     EventScheduler.scheduleAction(
         () -> {


### PR DESCRIPTION
Eigentlich sollte das hier schon in #2479 passiert sein.
Beim rebasen und co muss da was mächtig schief gelaufen sein.

Dieser PR baut den gewünschen EventSchedular zum schießen von Feuerbällen in Blocky ein