### PR TITLE
Dungeon: Add breakables turning non-solid upon breaking

### DIFF
--- a/dungeon/src/contrib/entities/MiscFactory.java
+++ b/dungeon/src/contrib/entities/MiscFactory.java
@@ -19,6 +19,7 @@ import core.components.DrawComponent;
 import core.components.PositionComponent;
 import core.components.VelocityComponent;
 import core.level.elements.tile.DoorTile;
+import core.systems.DrawSystem;
 import core.utils.*;
 import core.utils.Direction;
 import core.utils.Point;
@@ -682,7 +683,8 @@ public final class MiscFactory {
             });
     destroyableObj.add(baseIC);
 
-    destroyableObj.add(new CollideComponent(Vector2.ZERO, Vector2.ONE));
+    CollideComponent cc = new CollideComponent(Vector2.ZERO, Vector2.ONE);
+    destroyableObj.add(cc);
 
     Map<String, Animation> animationMap = Animation.loadAnimationSpritesheet(texturePath);
     State stIdle = State.fromMap(animationMap, "idle");
@@ -692,7 +694,18 @@ public final class MiscFactory {
     sm.addTransition(stIdle, "break", stBreaking);
     sm.addEpsilonTransition(stBreaking, State::isAnimationFinished, stBroken);
     DrawComponent dc = new DrawComponent(sm);
+    dc.depth(DepthLayer.Player.depth());
     destroyableObj.add(dc);
+
+    stBreaking.setOnEnter(
+        (s) -> {
+          cc.isSolid(false);
+          Game.system(
+              DrawSystem.class,
+              ds -> {
+                ds.changeEntityDepth(destroyableObj, DepthLayer.BackgroundDeco.depth());
+              });
+        });
 
     // Wrapper-InteractionComponent
     destroyableObj

--- a/dungeon/src/core/utils/components/draw/state/State.java
+++ b/dungeon/src/core/utils/components/draw/state/State.java
@@ -7,6 +7,7 @@ import core.utils.components.draw.animation.SpritesheetConfig;
 import core.utils.components.path.IPath;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Represents a visual state in the game, associated with an animation.
@@ -27,6 +28,12 @@ public class State {
 
   /** Optional user-defined data associated with this state. */
   protected Object data;
+
+  /** Optional callback executed when entering this state. */
+  private Consumer<State> onEnter;
+
+  /** Optional callback executed when exiting this state. */
+  private Consumer<State> onExit;
 
   /**
    * Constructs a state with a name and an animation.
@@ -171,6 +178,34 @@ public class State {
    */
   public void setData(Object data) {
     this.data = data;
+  }
+
+  /**
+   * Sets a callback to be executed when entering this state.
+   *
+   * @param onEnter the callback function
+   */
+  public void setOnEnter(Consumer<State> onEnter) {
+    this.onEnter = onEnter;
+  }
+
+  /** Executes the onEnter callback if it is set. */
+  public void onEnter() {
+    if (onEnter != null) onEnter.accept(this);
+  }
+
+  /**
+   * Sets a callback to be executed when exiting this state.
+   *
+   * @param onExit the callback function
+   */
+  public void setOnExit(Consumer<State> onExit) {
+    this.onExit = onExit;
+  }
+
+  /** Executes the onExit callback if it is set. */
+  public void onExit() {
+    if (onExit != null) onExit.accept(this);
   }
 
   /**

--- a/dungeon/src/core/utils/components/draw/state/StateMachine.java
+++ b/dungeon/src/core/utils/components/draw/state/StateMachine.java
@@ -111,7 +111,8 @@ public class StateMachine {
    * @throws IllegalArgumentException if the list of states is empty
    */
   public StateMachine(List<State> states) {
-    if (states.size() == 0) throw new IllegalArgumentException("State list can't be empty");
+    if (states == null || states.isEmpty())
+      throw new IllegalArgumentException("State list can't be empty");
     this.states = states;
     setInitialState();
   }
@@ -366,7 +367,11 @@ public class StateMachine {
     newState.setData(data);
     if (newState != currentState) {
       if (resetFrame) newState.frameCount(0);
+      if (currentState != null) {
+        currentState.onExit();
+      }
       currentState = newState;
+      currentState.onEnter();
     }
   }
 


### PR DESCRIPTION
Fixes #2521

- Breakables werden non-solid, sobald die break-Animation startet. 
- `State.onEnter` und `State.onExit` können callbacks erhalten, um Sachen auszuführen, wenn eine Animation einen bestimmten Zustand erreicht.
- Fixed ebenfalls ein Problem im DrawSystem das gerade dazu führt, dass die DrawComponent.depth ignoriert wird.