### PR TITLE
Blockly: allow different popups for web and code api; add CLI

### DIFF
--- a/blockly/build.gradle
+++ b/blockly/build.gradle
@@ -37,10 +37,13 @@ generateGrammarSource {
 
 
 tasks.register('runBlockly', JavaExec) {
-    group 'starter'
+    group = 'starter'
     mainClass = 'client.Client'
     classpath = sourceSets.main.runtimeClasspath
+    def webFlag = project.hasProperty('web') ? project.property('web') : 'false'
+    args "web=${webFlag}"
 }
+
 
 tasks.register('buildBlocklyJar', Jar) {
     group 'jar'

--- a/blockly/frontend/webserver/webserver.ts
+++ b/blockly/frontend/webserver/webserver.ts
@@ -35,7 +35,8 @@ const openJar = () => {
     const _blocklyClientProcess = new Deno.Command("java", {
         args: [
             "-jar",
-             jarPath
+             jarPath,
+             "web=true"
         ],
     });
     _blocklyClientProcess.output().then(({ code }) => {

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -51,6 +51,12 @@ public class Client {
   private static HttpServer httpServer;
 
   /**
+   * If true, the Web interface Blockly is used for interaction with the Dunogen. Otherwise, the
+   * Code API is used.
+   */
+  public static boolean runInWeb = false;
+
+  /**
    * Setup and run the game. Also start the server that is listening to the requests from blockly
    * frontend.
    *
@@ -59,6 +65,13 @@ public class Client {
    */
   public static void main(String[] args) throws IOException {
     Game.initBaseLogger(Level.WARNING);
+
+    for (String arg : args) {
+      if (arg.equalsIgnoreCase("web=true")) {
+        runInWeb = true;
+      }
+    }
+
     StateMachine.setResetFrame(false);
     Debugger debugger = new Debugger();
     // start the game

--- a/blockly/src/level/produs/Level001.java
+++ b/blockly/src/level/produs/Level001.java
@@ -44,61 +44,68 @@ public class Level001 extends BlocklyLevel {
         "Bedingungen",
         "Sonstige");
 
-    popups.add(
-        new TextPopUp(
+    addPopup(
+        new TextPopup(
             "Willkommen im Blockly Dungeon! Heute wirst du mir helfen, aus den Fängen des Bösen zu entkommen."
                 + " Drücke "
                 + Input.Keys.toString(KeyboardConfig.PAUSE.value())
                 + " wenn ich mich wiederholen soll.",
             "Blockly Dungeon"));
 
-    popups.add(
-        new TextPopUp(
+    addWebPopup(
+        new TextPopup(
             "Ich bin "
                 + Client.WIZARD_NAME
                 + ", der Codemagier! Mit deiner Hilfe kann ich Zauber wirken – aber nur, wenn du die richtigen Codeblöcke im Browser benutzt. Komm, ich zeige dir, wie das geht!",
             "Blockly Dungeon"));
 
-    popups.add(
-        new TextPopUp(
+    addCodePopup(
+        new TextPopup(
+            "Ich bin "
+                + Client.WIZARD_NAME
+                + ", der Codemagier! Mit deiner Hilfe kann ich Zauber wirken – aber nur, wenn du den richtigen Code im Editor benutzt. Komm, ich zeige dir, wie das geht!",
+            "Blockly Dungeon"));
+
+    addWebPopup(
+        new TextPopup(
             "Das hier ist der Code. Der Start-Block markiert den Anfang deines Algorithmus – also dort, wo dein Zauber beginnt."
                 + "Tipp: Nutze die Escape-Tate (ESC) oben Links auf deiner Tatatur um Bilder zu schließen.",
             "Blockly Dungeon"));
-    popups.add(new ImagePopUp("popups/level001/start_block.png"));
+    addWebPopup(new ImagePopup("popups/level001/start_block.png"));
 
-    popups.add(
-        new TextPopUp(
+    addWebPopup(
+        new TextPopup(
             "In der Seitenleiste findest du verschiedene Kategorien. Je weiter wir kommen, desto mehr magische Fähigkeiten werden freigeschaltet! Behalte diese Liste also gut im Auge. "
                 + "Klicke mit der linken Maustaste, um dir die Zauber einer Kategorie anzusehen.",
             "Blockly Dungeon"));
-    popups.add(new ImagePopUp("popups/level001/sidebar.png"));
+    addWebPopup(new ImagePopup("popups/level001/sidebar.png"));
 
-    popups.add(
-        new TextPopUp(
+    addWebPopup(
+        new TextPopup(
             "Hier siehst du meine Zauber – oder wie du sie nennen würdest: Code-Blöcke. Mit ihnen sagst du mir, was ich tun soll. "
                 + "Ziehe einfach einen Block mit gedrückter linker Maustaste unter den Start-Block, um deinen ersten Zauber zu wirken!",
             "Blockly Dungeon"));
-    popups.add(new ImagePopUp("popups/level001/first_move.png"));
-    popups.add(
-        new TextPopUp(
+    addWebPopup(new ImagePopup("popups/level001/first_move.png"));
+    addWebPopup(
+        new TextPopup(
             "Einige Zauber wirken nur in Kombination mit anderen. Das erkennst du an den kleinen Puzzle-Ausschnitten an der Seite.",
             "Blockly Dungeon"));
-    popups.add(new ImagePopUp("popups/level001/turn.png"));
+    addWebPopup(new ImagePopup("popups/level001/turn.png"));
 
-    popups.add(
-        new TextPopUp(
+    addWebPopup(
+        new TextPopup(
             "Kombiniere meine Zauber geschickt, um mich bis zum Ausgang zu führen. Gemeinsam können wir das Böse besiegen!",
             "Blockly Dungeon"));
-    popups.add(new ImagePopUp("popups/level001/turn_example.png"));
+    addWebPopup(new ImagePopup("popups/level001/turn_example.png"));
 
-    popups.add(
-        new TextPopUp(
+    addWebPopup(
+        new TextPopup(
             "Mit dem Start-Knopf kannst du mich auf meine Reise schicken. Hab keine Angst, Fehler zu machen – ich bin ein mächtiger Magier und lasse mich so leicht nicht unterkriegen! "
                 + "Wenn etwas schiefgeht, starten wir das Level einfach noch einmal. "
                 + "Und noch ein letzter Tipp: Mit der Taste 'P' kannst du dir das Tutorial jederzeit wieder anschauen.",
             "Blockly Dungeon"));
-    popups.add(new ImagePopUp("popups/level001/start.png"));
-    popups.add(new ImagePopUp("popups/level001/reset.png"));
+    addWebPopup(new ImagePopup("popups/level001/start.png"));
+    addWebPopup(new ImagePopup("popups/level001/reset.png"));
   }
 
   @Override


### PR DESCRIPTION
Follow up zu #2554 
Jetzt kann man speziell Popups für die Web oder Code Variante von Blockly erstellen.
Über das CLI Argument `web` kann der JVM mitgeteilt werden, ob man im web oder non-web (default) läuft

* Fügt CLI Arg `web` hinzu
* Teilt `BlocklyLevel#popups` in Code und Web Popups
* Add add function for the lists
* update gradle skript