### PR TITLE
Add tests for ItemPotionHealth

### DIFF
--- a/dungeon/test/contrib/item/concreteItem/ItemPotionHealthTest.java
+++ b/dungeon/test/contrib/item/concreteItem/ItemPotionHealthTest.java
@@ -3,13 +3,26 @@ package contrib.item.concreteItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import contrib.components.HealthComponent;
+import contrib.components.InventoryComponent;
 import contrib.item.HealthPotionType;
+import contrib.utils.components.health.DamageType;
+import core.Entity;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ItemPotionHealthTest {
+
+  @Test
+  void defaultConstructor_ShouldCreateWeakPotion() {
+    ItemPotionHealth potion = new ItemPotionHealth();
+
+    assertEquals(HealthPotionType.WEAK, potion.type());
+    assertEquals(HealthPotionType.WEAK.getHealAmount(), potion.healAmount());
+  }
 
   @Test
   void type_ShouldReturnPotionType() {
@@ -85,6 +98,91 @@ class ItemPotionHealthTest {
     assertEquals(potion1.hashCode(), potion2.hashCode());
   }
 
+  @Test
+  void match_ShouldReturnTrueForSameHealAmount() {
+    ItemPotionHealth potion1 = new ItemPotionHealth(HealthPotionType.WEAK);
+    ItemPotionHealth potion2 = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    assertTrue(potion1.match(potion2));
+  }
+
+  @Test
+  void match_ShouldReturnFalseForDifferentHealAmount() {
+    ItemPotionHealth potion1 = new ItemPotionHealth(HealthPotionType.WEAK);
+    ItemPotionHealth potion2 = new ItemPotionHealth(typeWithDifferentHealAmount());
+
+    assertFalse(potion1.match(potion2));
+  }
+
+  @Test
+  void match_ShouldReturnFalseForDifferentItemClass() {
+    ItemPotionHealth potion = new ItemPotionHealth(HealthPotionType.WEAK);
+    ItemKey key = new ItemKey();
+
+    assertFalse(potion.match(key));
+  }
+
+  @Test
+  void match_ShouldReturnFalseForNull() {
+    ItemPotionHealth potion = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    assertFalse(potion.match(null));
+  }
+
+  @Test
+  void use_ShouldRemovePotionAndHealEntityWithInventoryAndHealthComponent() {
+    Entity entity = new Entity();
+    InventoryComponent inventory = new InventoryComponent();
+    HealthComponent health = new HealthComponent(50);
+    ItemPotionHealth potion = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    inventory.add(potion);
+    entity.add(inventory);
+    entity.add(health);
+
+    potion.use(entity);
+
+    assertEquals(0, inventory.count());
+    assertEquals(
+      -HealthPotionType.WEAK.getHealAmount(),
+      health.calculateDamageOf(DamageType.HEAL));
+  }
+
+  @Test
+  void use_ShouldRemovePotionWithoutHealingWhenHealthComponentIsMissing() {
+    Entity entity = new Entity();
+    InventoryComponent inventory = new InventoryComponent();
+    ItemPotionHealth potion = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    inventory.add(potion);
+    entity.add(inventory);
+
+    potion.use(entity);
+
+    assertEquals(0, inventory.count());
+  }
+
+  @Test
+  void use_ShouldNotConsumePotionOrHealWhenInventoryIsMissing() {
+    Entity entity = new Entity();
+    HealthComponent health = new HealthComponent(50);
+    ItemPotionHealth potion = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    entity.add(health);
+
+    potion.use(entity);
+
+    assertEquals(1, potion.stackSize());
+    assertEquals(0, health.calculateDamageOf(DamageType.HEAL));
+  }
+
+  @Test
+  void use_ShouldThrowNullPointerExceptionForNullEntity() {
+    ItemPotionHealth potion = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    assertThrows(NullPointerException.class, () -> potion.use(null));
+  }
+
   private static HealthPotionType typeWithDifferentHealAmount() {
     for (HealthPotionType type : HealthPotionType.values()) {
       if (type.getHealAmount() != HealthPotionType.WEAK.getHealAmount()) {
@@ -95,10 +193,6 @@ class ItemPotionHealthTest {
   }
 
   private static class TestableItemPotionHealth extends ItemPotionHealth {
-
-    private TestableItemPotionHealth(HealthPotionType type) {
-      super(type);
-    }
 
     private static String potionTypeKey() {
       return DATA_KEY_POTION_TYPE;

--- a/dungeon/test/contrib/item/concreteItem/ItemPotionHealthTest.java
+++ b/dungeon/test/contrib/item/concreteItem/ItemPotionHealthTest.java
@@ -1,0 +1,50 @@
+package contrib.item.concreteItem;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import contrib.item.HealthPotionType;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ItemPotionHealthTest {
+
+  @Test
+  void type_ShouldReturnPotionType() {
+    ItemPotionHealth potion = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    assertEquals(HealthPotionType.WEAK, potion.type());
+  }
+
+  @Test
+  void healAmount_ShouldReturnHealAmountOfPotionType() {
+    ItemPotionHealth potion = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    assertEquals(HealthPotionType.WEAK.getHealAmount(), potion.healAmount());
+  }
+
+  @Test
+  void itemData_ShouldContainPotionTypeAndHealAmount() {
+    ItemPotionHealth potion = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    Map<String, String> data = potion.itemData();
+
+    assertTrue(data.containsValue(HealthPotionType.WEAK.name()));
+    assertTrue(data.containsValue(Integer.toString(HealthPotionType.WEAK.getHealAmount())));
+  }
+
+  @Test
+  void equals_ShouldReturnTrueForSameHealAmount() {
+    ItemPotionHealth potion1 = new ItemPotionHealth(HealthPotionType.WEAK);
+    ItemPotionHealth potion2 = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    assertEquals(potion1, potion2);
+  }
+
+  @Test
+  void hashCode_ShouldBeSameForSameHealAmount() {
+    ItemPotionHealth potion1 = new ItemPotionHealth(HealthPotionType.WEAK);
+    ItemPotionHealth potion2 = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    assertEquals(potion1.hashCode(), potion2.hashCode());
+  }
+}

--- a/dungeon/test/contrib/item/concreteItem/ItemPotionHealthTest.java
+++ b/dungeon/test/contrib/item/concreteItem/ItemPotionHealthTest.java
@@ -1,8 +1,13 @@
 package contrib.item.concreteItem;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import contrib.item.HealthPotionType;
+import contrib.item.Item;
+import java.lang.reflect.Field;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -23,13 +28,25 @@ class ItemPotionHealthTest {
   }
 
   @Test
-  void itemData_ShouldContainPotionTypeAndHealAmount() {
+  void itemData_ShouldContainPotionTypeAndHealAmountWithCorrectKeys() {
     ItemPotionHealth potion = new ItemPotionHealth(HealthPotionType.WEAK);
 
     Map<String, String> data = potion.itemData();
 
-    assertTrue(data.containsValue(HealthPotionType.WEAK.name()));
-    assertTrue(data.containsValue(Integer.toString(HealthPotionType.WEAK.getHealAmount())));
+    assertEquals(2, data.size());
+    assertEquals(
+      HealthPotionType.WEAK.name(),
+      data.get(itemDataKey("DATA_KEY_POTION_TYPE")));
+    assertEquals(
+      Integer.toString(HealthPotionType.WEAK.getHealAmount()),
+      data.get(itemDataKey("DATA_KEY_HEAL_AMOUNT")));
+  }
+
+  @Test
+  void equals_ShouldReturnTrueForSameObject() {
+    ItemPotionHealth potion = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    assertTrue(potion.equals(potion));
   }
 
   @Test
@@ -41,10 +58,51 @@ class ItemPotionHealthTest {
   }
 
   @Test
+  void equals_ShouldReturnFalseForDifferentHealAmount() {
+    ItemPotionHealth potion1 = new ItemPotionHealth(HealthPotionType.WEAK);
+    ItemPotionHealth potion2 = new ItemPotionHealth(typeWithDifferentHealAmount());
+
+    assertNotEquals(potion1, potion2);
+  }
+
+  @Test
+  void equals_ShouldReturnFalseForDifferentClass() {
+    ItemPotionHealth potion = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    assertFalse(potion.equals("not a potion"));
+  }
+
+  @Test
+  void equals_ShouldReturnFalseForNull() {
+    ItemPotionHealth potion = new ItemPotionHealth(HealthPotionType.WEAK);
+
+    assertFalse(potion.equals(null));
+  }
+
+  @Test
   void hashCode_ShouldBeSameForSameHealAmount() {
     ItemPotionHealth potion1 = new ItemPotionHealth(HealthPotionType.WEAK);
     ItemPotionHealth potion2 = new ItemPotionHealth(HealthPotionType.WEAK);
 
     assertEquals(potion1.hashCode(), potion2.hashCode());
+  }
+
+  private static String itemDataKey(String fieldName) {
+    try {
+      Field field = Item.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (String) field.get(null);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Could not read item data key: " + fieldName, e);
+    }
+  }
+
+  private static HealthPotionType typeWithDifferentHealAmount() {
+    for (HealthPotionType type : HealthPotionType.values()) {
+      if (type.getHealAmount() != HealthPotionType.WEAK.getHealAmount()) {
+        return type;
+      }
+    }
+    throw new AssertionError("No HealthPotionType with different heal amount found.");
   }
 }

--- a/dungeon/test/contrib/item/concreteItem/ItemPotionHealthTest.java
+++ b/dungeon/test/contrib/item/concreteItem/ItemPotionHealthTest.java
@@ -6,8 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import contrib.item.HealthPotionType;
-import contrib.item.Item;
-import java.lang.reflect.Field;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -36,10 +34,10 @@ class ItemPotionHealthTest {
     assertEquals(2, data.size());
     assertEquals(
       HealthPotionType.WEAK.name(),
-      data.get(itemDataKey("DATA_KEY_POTION_TYPE")));
+      data.get(TestableItemPotionHealth.potionTypeKey()));
     assertEquals(
       Integer.toString(HealthPotionType.WEAK.getHealAmount()),
-      data.get(itemDataKey("DATA_KEY_HEAL_AMOUNT")));
+      data.get(TestableItemPotionHealth.healAmountKey()));
   }
 
   @Test
@@ -87,16 +85,6 @@ class ItemPotionHealthTest {
     assertEquals(potion1.hashCode(), potion2.hashCode());
   }
 
-  private static String itemDataKey(String fieldName) {
-    try {
-      Field field = Item.class.getDeclaredField(fieldName);
-      field.setAccessible(true);
-      return (String) field.get(null);
-    } catch (ReflectiveOperationException e) {
-      throw new AssertionError("Could not read item data key: " + fieldName, e);
-    }
-  }
-
   private static HealthPotionType typeWithDifferentHealAmount() {
     for (HealthPotionType type : HealthPotionType.values()) {
       if (type.getHealAmount() != HealthPotionType.WEAK.getHealAmount()) {
@@ -104,5 +92,20 @@ class ItemPotionHealthTest {
       }
     }
     throw new AssertionError("No HealthPotionType with different heal amount found.");
+  }
+
+  private static class TestableItemPotionHealth extends ItemPotionHealth {
+
+    private TestableItemPotionHealth(HealthPotionType type) {
+      super(type);
+    }
+
+    private static String potionTypeKey() {
+      return DATA_KEY_POTION_TYPE;
+    }
+
+    private static String healAmountKey() {
+      return DATA_KEY_HEAL_AMOUNT;
+    }
   }
 }


### PR DESCRIPTION
Tests für `ItemPotionHealth` ergänzt und erweitert.

Getestet wurden:
- `ItemPotionHealth()`
- `use(Entity e)`
- `match(Item input)`
- `type()`
- `healAmount()`
- `itemData()` mit den passenden Daten-Schlüsseln
- `equals()` mit gleichem Objekt, gleichem HealAmount, anderem HealAmount, fremder Klasse und null
- `hashCode()` bei gleichem HealAmount

Reflection wurde entfernt. Die ItemData-Keys werden jetzt ohne Reflection geprüft.

Die Tests wurden erfolgreich ausgeführt mit:

```bash
./gradlew :dungeon:test --tests contrib.item.concreteItem.ItemPotionHealthTest