### PR TITLE
Blockly: save level progression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 .externalToolBuilders/
 .classpath
 
-
 # Temporary files #
 ###################
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,9 @@ logs/
 ########################
 dungeon_config.json
 currentPortalLevel.json
+currentBlocklyLevel.json
 last_session.dat
+
 
 # JAVA, Scala #
 ###############

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -33,6 +33,7 @@ import core.components.VelocityComponent;
 import core.level.loader.DungeonLoader;
 import core.network.server.DialogTracker;
 import core.systems.PositionSystem;
+import core.utils.JsonHandler;
 import core.utils.Point;
 import core.utils.Tuple;
 import core.utils.Vector2;
@@ -40,8 +41,11 @@ import core.utils.components.draw.state.StateMachine;
 import core.utils.components.path.SimpleIPath;
 import entities.HeroTankControlledFactory;
 import java.awt.Desktop;
-import java.io.IOException;
+import java.io.*;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -89,6 +93,9 @@ import systems.TintTilesSystem;
  * <p>For the Web-Ui you have to start the frontend yourself.
  */
 public class Client {
+
+  private static final String SAVE_LEVEL_KEY = "LEVEL";
+  private static final String SAVE_FILE = "currentBlocklyLevel.json";
 
   /** The name of the blockly player. */
   public static final String WIZARD_NAME = "Algorim";
@@ -214,6 +221,8 @@ public class Client {
           PortalRegistry.registerPelletCatcherBehavior(
               () -> new BlocklyEnergyPelletCatcherBehavior());
 
+          DungeonLoader.loadLevel(loadLevelIndex());
+
           // Disbaled beacuse of bugs: see
           // https://github.com/Dungeon-CampusMinden/Dungeon/issues/3070
           // StageConfig.setupStage();
@@ -224,6 +233,7 @@ public class Client {
   private static void onLevelLoad() {
     Game.userOnLevelLoad(
         (firstLoad) -> {
+          writeLevelIndex(DungeonLoader.currentLevelIndex());
           BlocklyCodeRunner.instance().stopCode();
           Game.system(
               BlocklyCommandExecuteSystem.class,
@@ -413,6 +423,46 @@ public class Client {
       } catch (Exception e) {
         e.printStackTrace();
       }
+    }
+  }
+
+  private static int loadLevelIndex() {
+    File file = new File(SAVE_FILE);
+
+    if (!file.exists()) {
+      return 0;
+    }
+    try {
+      String json = readFileContent(file);
+      Map<String, Object> map = JsonHandler.readJson(json);
+      return ((Long) map.getOrDefault(SAVE_LEVEL_KEY, 0)).intValue();
+    } catch (IOException e) {
+      return 0;
+    }
+  }
+
+  private static String readFileContent(File file) throws IOException {
+    try (InputStream fis = new FileInputStream(file)) {
+      return new String(fis.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new IOException("Failed to read game configuration file: " + file.getPath(), e);
+    }
+  }
+
+  private static void writeLevelIndex(int index) {
+    if (loadLevelIndex() >= index) return;
+
+    HashMap<String, Object> map = new HashMap<>();
+    map.put(SAVE_LEVEL_KEY, index);
+    String content = JsonHandler.writeJson(map, true);
+    try {
+      File file = new File(SAVE_FILE);
+      // Ensure parent directory exists
+      try (OutputStreamWriter osw =
+          new OutputStreamWriter(new FileOutputStream(file, false), StandardCharsets.UTF_8)) {
+        osw.write(content);
+      }
+    } catch (Exception ignored) {
     }
   }
 }

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -226,10 +226,8 @@ public class Client {
           PortalRegistry.registerPelletCatcherBehavior(
               () -> new BlocklyEnergyPelletCatcherBehavior());
 
-          int index = loadLevelIndex();
-          if (index < 0 || index >= DungeonLoader.levelCount()) index = 0;
-
-          DungeonLoader.loadLevel(loadLevelIndex());
+          int index = Math.clamp(loadLevelIndex(), 0, DungeonLoader.levelCount() - 1);
+          DungeonLoader.loadLevel(index);
 
           // Disbaled beacuse of bugs: see
           // https://github.com/Dungeon-CampusMinden/Dungeon/issues/3070

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -40,6 +40,20 @@ import core.utils.Vector2;
 import core.utils.components.draw.state.StateMachine;
 import core.utils.components.path.SimpleIPath;
 import entities.HeroTankControlledFactory;
+import java.awt.Desktop;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Supplier;
 import level.produs.Level001;
 import level.produs.Level002;
 import level.produs.Level003;
@@ -74,21 +88,6 @@ import server.FrontendServer;
 import server.Server;
 import systems.BlocklyCommandExecuteSystem;
 import systems.TintTilesSystem;
-
-import java.awt.*;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStreamWriter;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.function.Supplier;
 
 /**
  * This Class must be run to start the dungeon application. Otherwise, the blockly frontend won't
@@ -226,6 +225,9 @@ public class Client {
           PortalRegistry.registerCalculations(() -> new BlocklyPortalCalculations());
           PortalRegistry.registerPelletCatcherBehavior(
               () -> new BlocklyEnergyPelletCatcherBehavior());
+
+          int index = loadLevelIndex();
+          if (index < 0 || index >= DungeonLoader.levelCount()) index = 0;
 
           DungeonLoader.loadLevel(loadLevelIndex());
 
@@ -441,7 +443,8 @@ public class Client {
     try {
       String json = readFileContent(file);
       Map<String, Object> map = JsonHandler.readJson(json);
-      return ((Long) map.getOrDefault(SAVE_LEVEL_KEY, 0)).intValue();
+      Object value = map.get(SAVE_LEVEL_KEY);
+      return value instanceof Number number ? number.intValue() : 0;
     } catch (IOException e) {
       return 0;
     }

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -40,15 +40,6 @@ import core.utils.Vector2;
 import core.utils.components.draw.state.StateMachine;
 import core.utils.components.path.SimpleIPath;
 import entities.HeroTankControlledFactory;
-import java.awt.Desktop;
-import java.io.*;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.function.Supplier;
 import level.produs.Level001;
 import level.produs.Level002;
 import level.produs.Level003;
@@ -83,6 +74,21 @@ import server.FrontendServer;
 import server.Server;
 import systems.BlocklyCommandExecuteSystem;
 import systems.TintTilesSystem;
+
+import java.awt.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * This Class must be run to start the dungeon application. Otherwise, the blockly frontend won't

--- a/blockly/src/client/Client.java
+++ b/blockly/src/client/Client.java
@@ -443,7 +443,7 @@ public class Client {
       Map<String, Object> map = JsonHandler.readJson(json);
       Object value = map.get(SAVE_LEVEL_KEY);
       return value instanceof Number number ? number.intValue() : 0;
-    } catch (IOException e) {
+    } catch (IOException | IllegalArgumentException e) {
       return 0;
     }
   }

--- a/dungeon/src/core/level/loader/DungeonLoader.java
+++ b/dungeon/src/core/level/loader/DungeonLoader.java
@@ -319,6 +319,15 @@ public class DungeonLoader {
   }
 
   /**
+   * Get the number of registered levels.
+   *
+   * @return Number of registered levels.
+   */
+  public static int levelCount() {
+    return levelOrder.size();
+  }
+
+  /**
    * Loads a DungeonLevel from the given path.
    *
    * @param path The path to the level file.


### PR DESCRIPTION
Ab jetzt wird der Fortschritt in Blockly über die Session hinweg gespeichert. 
Für Blockly-Web gab es dieses Feature schon über die Web-UI, jetzt kann aber auch die Java-Dungeon Varianten lückenlos weitergeführt werden.

Dafür speichere ich den Index des aktuellen Levels in einer json (analog zum Advanced Dungeon) 