### PR TITLE
Dungeon/LH: Fix small issue in Localization API / Usage in LH

### DIFF
--- a/dungeon/src/core/language/Localization.java
+++ b/dungeon/src/core/language/Localization.java
@@ -2,7 +2,6 @@ package core.language;
 
 import com.badlogic.gdx.Gdx;
 import core.utils.components.draw.TextureMap;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
@@ -127,9 +126,8 @@ public class Localization {
    *
    * @param jsonNodes Nodes of the JSON up to the desired value as single params.
    * @return value behind a JSON node path.
-   * @throws IOException if the language file cannot be read.
    */
-  public String text(String jsonNodes) throws IOException {
+  public String text(String jsonNodes) {
     return defaultTranslation.text(jsonNodes);
   }
 
@@ -143,9 +141,8 @@ public class Localization {
    * @param jsonNodes Nodes of the JSON up to the desired value as single params.
    * @param templateValues positional template values used for {@code $1}, {@code $2}, ...
    * @return value behind a JSON node path with templates resolved.
-   * @throws IOException if the language file cannot be read.
    */
-  public String text(String jsonNodes, Object... templateValues) throws IOException {
+  public String text(String jsonNodes, Object... templateValues) {
     return defaultTranslation.text(jsonNodes, templateValues);
   }
 

--- a/escapeRoom/src/starter/LanguageTester.java
+++ b/escapeRoom/src/starter/LanguageTester.java
@@ -66,12 +66,8 @@ public class LanguageTester {
             // Shows a text popup by pressing "M". ("text", "test", "fail") Shows the fallback case
             // in English.
             if (Gdx.input.isKeyJustPressed(Input.Keys.M)) {
-              try {
-                DialogUtils.showTextPopup(
-                    localization.text("text.test.message"), localization.text("text.test.title"));
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
+              DialogUtils.showTextPopup(
+                  localization.text("text.test.message"), localization.text("text.test.title"));
             }
 
             // Changes the language between English and German by pressing "N".

--- a/theLastHourEscapeRoom/src/starter/LastHourClient.java
+++ b/theLastHourEscapeRoom/src/starter/LastHourClient.java
@@ -20,8 +20,6 @@ import core.Game;
 import core.components.PlayerComponent;
 import core.components.PositionComponent;
 import core.game.PreRunConfiguration;
-import core.language.Language;
-import core.language.Localization;
 import core.network.ConnectionListener;
 import core.network.messages.s2c.EntitySpawnEvent;
 import core.utils.CursorUtil;
@@ -234,13 +232,6 @@ public final class LastHourClient {
       // Best-effort: if anything goes wrong, fall through to the default texture loading
       // and let it fail loudly (the resulting visible error is clearer than a partial spawn).
     }
-  }
-
-  /** Registers the translation files for the supported languages. */
-  static void initLocalization() {
-    Localization localization = Game.localization();
-    localization.registerTranslationFile(Language.DE, "language/de.json");
-    localization.registerTranslationFile(Language.EN, "language/en.json");
   }
 
   private static final String T_SETTINGS_CONTROLS_HEADER = "settings.controls_header";

--- a/theLastHourEscapeRoom/src/starter/TheLastHour.java
+++ b/theLastHourEscapeRoom/src/starter/TheLastHour.java
@@ -22,6 +22,7 @@ import core.game.PreRunConfiguration;
 import core.game.ServerProcess;
 import core.game.ServerStarter;
 import core.language.Language;
+import core.language.Localization;
 import core.network.messages.s2c.LevelChangeEvent;
 import core.systems.FrictionSystem;
 import core.systems.LevelSystem;
@@ -101,7 +102,11 @@ public class TheLastHour {
         ServerStarter.builder(TheLastHour::serverSetup)
             .characterClasses(MULTIPLAYER_CHARACTER_CLASSES)
             .levels(Tuple.of("lasthour", LastHourLevel.class))
-            .onConfigure(UsbStickItem::ensureRegistration)
+            .onConfigure(
+                () -> {
+                  UsbStickItem.ensureRegistration();
+                  initLocalization();
+                })
             .config(new SimpleIPath("dungeon_config.json"), KeyboardConfig.class)
             .snapshotTranslator(new LastHourSnapshotTranslator())
             .entitySpawnStrategy(new LastHourEntitySpawnStrategy())
@@ -112,7 +117,7 @@ public class TheLastHour {
         ClientStarter.builder(LastHourClient::clientSetup)
             .levels(Tuple.of("lasthour", LastHourLevelClient.class))
             .onConfigure(LastHourClient::registerClientContent)
-            .initLocalization(LastHourClient::initLocalization)
+            .initLocalization(TheLastHour::initLocalization)
             .registerSettings(LastHourClient::registerSettings)
             .config(new SimpleIPath("dungeon_config.json"), KeyboardConfig.class)
             .snapshotTranslator(new LastHourSnapshotTranslator())
@@ -120,6 +125,13 @@ public class TheLastHour {
             .build();
 
     MainMenu.run(args, game, client, server);
+  }
+
+  /** Registers the translation files for the supported languages. */
+  static void initLocalization() {
+    Localization localization = Game.localization();
+    localization.registerTranslationFile(Language.DE, "language/de.json");
+    localization.registerTranslationFile(Language.EN, "language/en.json");
   }
 
   /**


### PR DESCRIPTION
- Localization.text() soll keine IOException in der Signatur haben
- Localization init vom LH Client zum Starter bewegt, damit der Server den auch ausführen kann