### PR TITLE
Fix pipeline last hour

### DIFF
--- a/.github/workflows/buildLastHour.yml
+++ b/.github/workflows/buildLastHour.yml
@@ -23,7 +23,7 @@ jobs:
 
             # 4. Jar desktop and web
             - name: Build JARs with Gradle
-              run: ./gradlew buildTheLastHourJar buildTheLastHourServerJar
+              run: ./gradlew buildTheLastHourJar
 
             # 5. save both jar artefacts
             - name: Upload Build Artifacts
@@ -63,19 +63,6 @@ jobs:
                       7z a Last-Hour-${{ matrix.platform_name }}.zip  ./theLastHourEscapeRoom/build/jpackage/TheLastHour
                     else
                       tar -czf Last-Hour-${{ matrix.platform_name }}.tar.gz -C theLastHourEscapeRoom/build/jpackage TheLastHour
-                    fi
-                shell: bash
-
-            -   name: Build Last Hour Server
-                run: ./gradlew jpackageImageTheLastHourServer
-
-            -   name: Archive TheLastHourServer
-                # zip the folder
-                run: |
-                    if [ "${{ runner.os }}" == "Windows" ]; then
-                      7z a Last-Hour-Server-${{ matrix.platform_name }}.zip  ./theLastHourEscapeRoom/build/jpackage/TheLastHourServer
-                    else
-                      tar -czf Last-Hour-Server-${{ matrix.platform_name }}.tar.gz -C theLastHourEscapeRoom/build/jpackage TheLastHourServer
                     fi
                 shell: bash
 

--- a/.github/workflows/buildLastHour.yml
+++ b/.github/workflows/buildLastHour.yml
@@ -23,7 +23,7 @@ jobs:
 
             # 4. Jar desktop and web
             - name: Build JARs with Gradle
-              run: ./gradlew buildTheLastHourJar buildTheLastHourServerJar buildTheLastHourClientJar
+              run: ./gradlew buildTheLastHourJar buildTheLastHourServerJar
 
             # 5. save both jar artefacts
             - name: Upload Build Artifacts
@@ -76,19 +76,6 @@ jobs:
                       7z a Last-Hour-Server-${{ matrix.platform_name }}.zip  ./theLastHourEscapeRoom/build/jpackage/TheLastHourServer
                     else
                       tar -czf Last-Hour-Server-${{ matrix.platform_name }}.tar.gz -C theLastHourEscapeRoom/build/jpackage TheLastHourServer
-                    fi
-                shell: bash
-
-            -   name: Build Last Hour Client
-                run: ./gradlew jpackageImageTheLastHourClient
-
-            -   name: Archive TheLastHourClient
-                # zip the folder
-                run: |
-                    if [ "${{ runner.os }}" == "Windows" ]; then
-                      7z a Last-Hour-Client-${{ matrix.platform_name }}.zip  ./theLastHourEscapeRoom/build/jpackage/TheLastHourClient
-                    else
-                      tar -czf Last-Hour-Client-${{ matrix.platform_name }}.tar.gz -C theLastHourEscapeRoom/build/jpackage TheLastHourClient
                     fi
                 shell: bash
 

--- a/.github/workflows/releaseInstructionsLastHour.md
+++ b/.github/workflows/releaseInstructionsLastHour.md
@@ -32,18 +32,16 @@ Single-player can be played on one device. Multiplayer requires two separate dev
 
 #### If you have [Java 25 or newer](https://www.oracle.com/java/technologies/downloads/#java25) installed
 
-* Download `TheLastHourServer.jar` below.
-* Download `TheLastHourClient.jar` below.
 * Make sure both player devices are connected to the same local network.
-* On the host device, start `TheLastHourServer.jar`.
-* On client devices, start `TheLastHourClient.jar`.
-* Enter the IP address and port shown in the host server window.
+* Both players have to start the `TheLastHour.jar`
+* One player clicks on "Host Game" to create the session
+* The other player clicks on "Join Game" and enters the IP address displayed on the host's screen
 
 #### If you do not have Java installed
 
 * On Windows, download `TheLastHour-win-x86_64.zip` and extract it locally.
 * On Linux, download `TheLastHour-linux-x86_64.tar.gz` and extract it locally.
 * Make sure both player devices are connected to the same local network.
-* On the host device, start `TheLastHourServer/TheLastHourServer.exe` on Windows or `TheLastHourServer/bin/TheLastHourServer` on Linux from inside the extracted release folder.
-* On client devices, start `TheLastHourClient/TheLastHourClient.exe` on Windows or `TheLastHourClient/bin/TheLastHourClient` on Linux from inside the extracted release folder.
-* Enter the IP address and port shown in the host server window.
+* Both players have to start the `TheLastHour/TheLastHour.exe` on Windows or `TheLastHour/TheLastHour` from inside the extracted release folder.
+* One player clicks on `Host Game` to create the session
+* The other player clicks on `Join Game` and enters the IP address displayed on the host's screen


### PR DESCRIPTION
Entfernt die Server und Client Variante aus der Pipeline, da die verbleibende Variante nun die Funktionen von client und server vereint. Die Installationsanleitung wurde ebenfalls überarbeitet. 

closes #3083