### PR TITLE
Dungeon: Fix stale HUD state blocking player input

### DIFF
--- a/advancedDungeon/src/starter/PortalStarter.java
+++ b/advancedDungeon/src/starter/PortalStarter.java
@@ -15,7 +15,6 @@ import contrib.systems.CollisionSystem;
 import contrib.systems.EventScheduler;
 import contrib.systems.FallingSystem;
 import contrib.systems.HealthSystem;
-import contrib.systems.HudSystem;
 import contrib.systems.LevelEditorSystem;
 import contrib.systems.LevelTickSystem;
 import contrib.systems.LeverSystem;
@@ -379,7 +378,6 @@ public class PortalStarter {
     Game.add(new AISystem());
     Game.add(new ProjectileSystem());
     Game.add(new HealthSystem());
-    Game.add(new HudSystem());
     Game.add(new SpikeSystem());
     Game.add(new LevelTickSystem());
     Game.add(new PitSystem());

--- a/dungeon/src/contrib/entities/HeroBuilder.java
+++ b/dungeon/src/contrib/entities/HeroBuilder.java
@@ -17,7 +17,6 @@ import contrib.hud.dialogs.DialogCallbackResolver;
 import contrib.hud.dialogs.DialogContextKeys;
 import contrib.hud.dialogs.PauseDialog;
 import contrib.systems.HealthSystem;
-import contrib.systems.HudSystem;
 import contrib.systems.PositionSync;
 import contrib.utils.components.health.Damage;
 import contrib.utils.components.skill.Skill;
@@ -401,26 +400,23 @@ public final class HeroBuilder {
     inputComp.registerCallback(
         KeyboardConfig.CLOSE_UI.value(),
         (caller) ->
-            Game.system(
-                HudSystem.class,
-                (hudSystem ->
-                    hudSystem
-                        .topmostCloseableUI()
-                        .ifPresent(
-                            firstUI -> {
-                              UIComponent uiComp = firstUI.b();
+            Game.hud()
+                .topmostCloseableUI()
+                .ifPresent(
+                    firstUI -> {
+                      UIComponent uiComp = firstUI.b();
 
-                              String dialogId = uiComp.dialogContext().dialogId();
-                              DialogCallbackResolver.createButtonCallback(
-                                      dialogId, DialogContextKeys.ON_CLOSE)
-                                  .accept(null);
+                      String dialogId = uiComp.dialogContext().dialogId();
+                      DialogCallbackResolver.createButtonCallback(
+                              dialogId, DialogContextKeys.ON_CLOSE)
+                          .accept(null);
 
-                              // UI is not networked, just close locally
-                              Entity uiEntity = firstUI.a();
-                              if (uiEntity.isLocal()) {
-                                UIUtils.closeDialog(uiComp);
-                              }
-                            }))),
+                      // UI is not networked, just close locally
+                      Entity uiEntity = firstUI.a();
+                      if (uiEntity.isLocal()) {
+                        UIUtils.closeDialog(uiComp);
+                      }
+                    }),
         false,
         true);
     inputComp.registerCallback(

--- a/dungeon/src/contrib/entities/HeroController.java
+++ b/dungeon/src/contrib/entities/HeroController.java
@@ -11,7 +11,6 @@ import contrib.hud.dialogs.DialogFactory;
 import contrib.hud.dialogs.DialogType;
 import contrib.item.Item;
 import contrib.modules.interaction.InteractionComponent;
-import contrib.systems.HudSystem;
 import contrib.utils.EntityUtils;
 import contrib.utils.components.skill.cursorSkill.CursorSkill;
 import contrib.utils.components.skill.projectileSkill.ProjectileSkill;
@@ -314,9 +313,8 @@ public class HeroController {
       LOGGER.error("Trying to open inventory for non-player entity or entity without inventory.");
       return;
     }
-    var pc = playerComp.get();
-
-    if (pc.openDialogs() && !isInventoryOpen(hero)) {
+    boolean hasOpenUi = Game.hud().hasOpenUI(hero);
+    if (hasOpenUi && !isInventoryOpen(hero)) {
       LOGGER.debug("Player {} has other dialogs open, cannot toggle inventory.", hero.id());
       return;
     }
@@ -693,9 +691,7 @@ public class HeroController {
         continue;
       }
 
-      var hudSys = Game.systems().get(HudSystem.class);
-      boolean paused =
-          hudSys instanceof HudSystem hudSystem && hudSystem.hasOpenPausingUI(playerEntity);
+      boolean paused = Game.hud().hasOpenPausingUI(playerEntity);
       if (!clientState.advanceProcessedSeq(msg.sequence())) {
         LOGGER.debug(
             "Ignoring stale or duplicate input sequence {} for client {}",

--- a/dungeon/src/contrib/hud/UIUtils.java
+++ b/dungeon/src/contrib/hud/UIUtils.java
@@ -4,7 +4,6 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Group;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
-import com.badlogic.gdx.utils.Disposable;
 import contrib.components.InventoryComponent;
 import contrib.components.UIComponent;
 import contrib.hud.dialogs.DialogCreationException;
@@ -12,9 +11,6 @@ import contrib.hud.elements.GUICombination;
 import contrib.hud.inventory.InventoryGUI;
 import core.Entity;
 import core.Game;
-import core.components.PlayerComponent;
-import core.game.PreRunConfiguration;
-import core.network.server.DialogTracker;
 import core.utils.components.path.IPath;
 import core.utils.components.path.SimpleIPath;
 import core.utils.logging.DungeonLogger;
@@ -261,9 +257,8 @@ public final class UIUtils {
    * Closes the dialog associated with the given UIComponent and optionally deletes its owner.
    *
    * <p>This method removes the UIComponent from its owner entity and removes the owner entity from
-   * the game if the owner has no more Components after the UIComponent is removed. If the owner of
-   * the UIComponent has a PlayerComponent, the number of open dialogs is decremented. All target
-   * entities are notified of the dialog closure.
+   * the game if the owner has no more Components after the UIComponent is removed. The HUD system
+   * observes the component removal and handles visual cleanup and network notification.
    *
    * @param uiComponent the UIComponent whose dialog is to be closed
    */
@@ -287,26 +282,16 @@ public final class UIUtils {
 
     try {
       Entity ownerEntity = uiComponent.dialogContext().ownerEntity();
-      ownerEntity.remove(UIComponent.class);
-      // decrease open dialog count for all target entities
-      for (Integer targetId : uiComponent.targetEntityIds()) {
-        Optional<Entity> target = Game.findEntityById(targetId);
-        target
-            .flatMap(t -> t.fetch(PlayerComponent.class))
-            .ifPresent(PlayerComponent::decrementOpenDialogs);
+      Optional<UIComponent> currentComponent = ownerEntity.fetch(UIComponent.class);
+      if (currentComponent.isEmpty() || currentComponent.get() != uiComponent) {
+        LOGGER.debug("Ignored close request for stale dialog on entity {}", ownerEntity.id());
+        return;
       }
+      ownerEntity.remove(UIComponent.class);
       LOGGER.debug("Closed dialog on entity {}", ownerEntity.id());
 
       if (ownerEntity.componentStream().toList().isEmpty()) {
         Game.remove(ownerEntity);
-      }
-
-      if (PreRunConfiguration.isNetworkServer()) {
-        DialogTracker.instance().closeDialog(uiComponent.dialogContext().dialogId(), true);
-      }
-
-      if (uiComponent.dialog() instanceof Disposable disposable) {
-        disposable.dispose();
       }
     } catch (DialogCreationException e) {
       LOGGER.warn("Could not close dialog: {}", e.getMessage());

--- a/dungeon/src/contrib/hud/elements/GUICombination.java
+++ b/dungeon/src/contrib/hud/elements/GUICombination.java
@@ -1,5 +1,6 @@
 package contrib.hud.elements;
 
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.scenes.scene2d.Group;
@@ -102,6 +103,8 @@ public final class GUICombination extends Group implements Disposable {
 
   @Override
   public void draw(final Batch batch, float parentAlpha) {
+    Color color = getColor();
+    batch.setColor(color.r, color.g, color.b, color.a * parentAlpha);
     this.combinableGuis.forEach(combinableGUI -> combinableGUI.draw(batch));
     this.combinableGuis.forEach(combinableGUI -> combinableGUI.drawTopLayer(batch));
   }

--- a/dungeon/src/contrib/systems/HudSystem.java
+++ b/dungeon/src/contrib/systems/HudSystem.java
@@ -2,12 +2,11 @@ package contrib.systems;
 
 import com.badlogic.gdx.scenes.scene2d.Group;
 import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.utils.Disposable;
 import contrib.components.UIComponent;
-import contrib.hud.UIUtils;
 import core.Entity;
 import core.Game;
 import core.System;
-import core.components.PlayerComponent;
 import core.game.PreRunConfiguration;
 import core.network.NetworkUtils;
 import core.network.messages.s2c.DialogShowMessage;
@@ -30,18 +29,23 @@ import java.util.Set;
  */
 public final class HudSystem extends System {
   private static final DungeonLogger LOGGER = DungeonLogger.getLogger(HudSystem.class);
+  private static final HudSystem INSTANCE = new HudSystem();
   private boolean ipaused = false;
 
-  /**
-   * The removeListener only gets the Entity after its Component is removed. Which means no longer
-   * any access to the Group. This is why we need the last group an entity had as a mapping.
-   */
-  private final Map<Entity, Group> entityGroupMap = new HashMap<>();
-
+  /** Stores the component because it is no longer available on the entity during removal. */
   private final Map<Entity, UIComponent> entityUIComponentMap = new HashMap<>();
 
-  /** Create a new HudSystem. */
-  public HudSystem() {
+  /**
+   * Returns the singleton HUD system.
+   *
+   * @return the HUD system instance
+   */
+  public static HudSystem getInstance() {
+    return INSTANCE;
+  }
+
+  /** Create the singleton HudSystem. */
+  private HudSystem() {
     super(AuthoritativeSide.BOTH, UIComponent.class);
     onEntityAdd = this::addListener;
     onEntityRemove = this::removeListener;
@@ -67,12 +71,24 @@ public final class HudSystem extends System {
    */
   public boolean hasOpenPausingUI(Entity entity) {
     return entityUIComponentMap.values().stream()
-        .anyMatch(
-            component ->
-                component.willPauseGame()
-                    && component.isVisible()
-                    && Arrays.stream(component.targetEntityIds())
-                        .anyMatch(id -> id == entity.id()));
+        .anyMatch(component -> component.willPauseGame() && isVisibleFor(component, entity));
+  }
+
+  /**
+   * Returns whether the entity is affected by any visible UI.
+   *
+   * @param entity the entity to check
+   * @return true if a visible UI targets the entity or all entities
+   */
+  public boolean hasOpenUI(Entity entity) {
+    return entityUIComponentMap.values().stream()
+        .anyMatch(component -> isVisibleFor(component, entity));
+  }
+
+  private boolean isVisibleFor(UIComponent component, Entity entity) {
+    int[] targets = component.targetEntityIds();
+    return component.isVisible()
+        && (targets.length == 0 || Arrays.stream(targets).anyMatch(id -> id == entity.id()));
   }
 
   /**
@@ -81,30 +97,23 @@ public final class HudSystem extends System {
    * @param entity Entity which no longer has a UIComponent.
    */
   private void removeListener(final Entity entity) {
-    Group remove = entityGroupMap.remove(entity);
-    if (remove != null) {
-      remove.remove();
+    UIComponent removedComponent = entityUIComponentMap.remove(entity);
+    if (removedComponent == null) {
+      return;
     }
-    entityUIComponentMap.remove(entity);
-    int[] targets =
-        entity.fetch(UIComponent.class).map(UIComponent::targetEntityIds).orElse(new int[0]);
+    removedComponent.dialog().remove();
+    boolean terminalRemoval =
+        !entity.isPresent(UIComponent.class) || Game.systems().get(HudSystem.class) == this;
+    if (PreRunConfiguration.isNetworkServer()) {
+      DialogTracker.instance()
+          .closeDialog(removedComponent.dialogContext().dialogId(), terminalRemoval);
+    }
 
-    if (targets.length == 0) {
-      // if no specific targets, decrease for all players
-      Game.allPlayers()
-          .forEach(
-              playerEntity -> {
-                playerEntity
-                    .fetch(PlayerComponent.class)
-                    .ifPresent(PlayerComponent::decrementOpenDialogs);
-              });
-    } else {
-      for (Integer targetId : targets) {
-        Optional<Entity> target = Game.findEntityById(targetId);
-        target
-            .flatMap(t -> t.fetch(PlayerComponent.class))
-            .ifPresent(PlayerComponent::decrementOpenDialogs);
-      }
+    // Removing a system temporarily detaches its entities too. Only dispose the dialog when the
+    // component or its entity was removed; otherwise the same component is re-added with the
+    // system.
+    if (terminalRemoval && removedComponent.dialog() instanceof Disposable disposable) {
+      disposable.dispose();
     }
   }
 
@@ -120,8 +129,6 @@ public final class HudSystem extends System {
             .fetch(UIComponent.class)
             .orElseThrow(() -> MissingComponentException.build(entity, UIComponent.class));
 
-    Group dialog = component.dialog();
-
     // check if we should draw it
     int[] myIds = Game.allPlayers().mapToInt(Entity::id).toArray();
     int[] targetIds = component.targetEntityIds();
@@ -135,20 +142,14 @@ public final class HudSystem extends System {
       return;
     }
 
-    // increase open dialog count for all target entities
-    for (Integer targetId : targetIds) {
-      Optional<Entity> target = Game.findEntityById(targetId);
-      target
-          .flatMap(t -> t.fetch(PlayerComponent.class))
-          .ifPresent(PlayerComponent::incrementOpenDialogs);
-    }
+    Group dialog = component.dialog();
 
     Game.stage()
         .ifPresentOrElse(
             stage -> addDialogToStage(dialog, stage),
             () -> sendDialogToClients(entity, component, affectedIds));
 
-    addMapping(entity, dialog, component);
+    entityUIComponentMap.put(entity, component);
     // Multiplayer clients only render dialogs. The server keeps callback ownership and
     // response authorization in DialogTracker.
     if (!Game.isMultiplayerClient()) {
@@ -185,17 +186,6 @@ public final class HudSystem extends System {
     }
   }
 
-  private void addMapping(final Entity entity, final Group dialog, final UIComponent component) {
-    Group previous = entityGroupMap.put(entity, dialog);
-    if (previous != null) {
-      previous.remove();
-    }
-    UIComponent previousUiComponent = entityUIComponentMap.put(entity, component);
-    if (previousUiComponent != null) {
-      UIUtils.closeDialog(previousUiComponent);
-    }
-  }
-
   private void addDialogToStage(final Group group, final Stage stage) {
     if (!stage.getActors().contains(group, true)) {
       stage.addActor(group);
@@ -216,7 +206,6 @@ public final class HudSystem extends System {
     } // only a hotfix for reconnecting clients
 
     // clean up any entities that no longer have a UIComponent
-    entityGroupMap.keySet().removeIf(entity -> !entity.isPresent(UIComponent.class));
     entityUIComponentMap.keySet().removeIf(entity -> !entity.isPresent(UIComponent.class));
   }
 

--- a/dungeon/src/contrib/systems/LevelEditorSystem.java
+++ b/dungeon/src/contrib/systems/LevelEditorSystem.java
@@ -18,7 +18,6 @@ import core.Entity;
 import core.Game;
 import core.System;
 import core.components.InputComponent;
-import core.components.PlayerComponent;
 import core.level.DungeonLevel;
 import core.level.Tile;
 import core.systems.DrawSystem;
@@ -30,7 +29,6 @@ import core.utils.components.draw.shader.OutlineShader;
 import core.utils.components.draw.shader.PassthroughShader;
 import core.utils.logging.DungeonLogger;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * The LevelEditorSystem is responsible for handling the level editor. It allows the user to change
@@ -201,8 +199,7 @@ public class LevelEditorSystem extends System {
 
     if (!active) return;
 
-    Optional<PlayerComponent> pc = Game.player().flatMap(e -> e.fetch(PlayerComponent.class));
-    if (pc.isPresent() && pc.get().openDialogs()) {
+    if (Game.player().map(Game.hud()::hasOpenUI).orElse(false)) {
       return;
     }
 

--- a/dungeon/src/core/Entity.java
+++ b/dungeon/src/core/Entity.java
@@ -143,9 +143,18 @@ public final class Entity implements Comparable<Entity> {
    * @param component The component to add
    */
   public void add(final Component component) {
-    components.put(component.getClass(), component);
+    Class<? extends Component> componentClass = component.getClass();
+    Component previousComponent = components.get(componentClass);
+    if (previousComponent != null && previousComponent != component) {
+      components.remove(componentClass);
+      // Replacing a component must run the old component's removal lifecycle first. Otherwise the
+      // entity still matches the same systems and their on-remove/on-add listeners never observe
+      // the new component instance.
+      ECSManagement.informAboutChanges(this);
+    }
+    components.put(componentClass, component);
     ECSManagement.informAboutChanges(this);
-    LOGGER.debug(component.getClass().getName() + " Components from " + this + " was added.");
+    LOGGER.debug(componentClass.getName() + " Components from " + this + " was added.");
   }
 
   /**

--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.ai.pfa.GraphPath;
 import com.badlogic.gdx.scenes.scene2d.Stage;
+import contrib.systems.HudSystem;
 import contrib.utils.EntityUtils;
 import core.components.PlayerComponent;
 import core.components.PositionComponent;
@@ -391,6 +392,15 @@ public final class Game {
    */
   public static Map<Class<? extends System>, System> systems() {
     return ECSManagement.systems();
+  }
+
+  /**
+   * Returns the singleton HUD system, which is registered as an essential ECS system.
+   *
+   * @return the HUD system
+   */
+  public static HudSystem hud() {
+    return HudSystem.getInstance();
   }
 
   /**

--- a/dungeon/src/core/components/PlayerComponent.java
+++ b/dungeon/src/core/components/PlayerComponent.java
@@ -1,25 +1,15 @@
 package core.components;
 
-import com.badlogic.gdx.Input;
 import core.Component;
-import core.systems.input.InputSystem;
 
 /**
  * Marks an entity as playable by the player.
  *
- * <p>This component keeps track of the number of open dialogs in the game. It provides methods to
- * increment and decrement the dialog counter, as well as a method to check if any dialogs are
- * currently open.
- *
- * <p>This component is used to identify the player entity in the game. It contains information
- * about whether the player is the local player and manages the count of open dialogs.
- *
- * @see Input.Keys
- * @see InputSystem
+ * <p>This component identifies player entities and stores whether the player is local together with
+ * its display name.
  */
 public final class PlayerComponent implements Component {
 
-  private int openDialogs = 0;
   private final boolean isLocalPlayer;
   private final String playerName;
 
@@ -61,25 +51,6 @@ public final class PlayerComponent implements Component {
    */
   public boolean isLocal() {
     return isLocalPlayer;
-  }
-
-  /** Increases the dialogue counter by 1. */
-  public void incrementOpenDialogs() {
-    openDialogs++;
-  }
-
-  /** Decreases the dialogue counter by 1. */
-  public void decrementOpenDialogs() {
-    openDialogs--;
-  }
-
-  /**
-   * Indicates whether dialogs are currently open.
-   *
-   * @return true if dialogs are currently open, otherwise false
-   */
-  public boolean openDialogs() {
-    return openDialogs > 0;
   }
 
   /**

--- a/dungeon/src/core/game/ECSManagement.java
+++ b/dungeon/src/core/game/ECSManagement.java
@@ -65,7 +65,7 @@ public final class ECSManagement {
     DrawSystem.getInstance(),
     new EventScheduler(),
     new LevelTickSystem(),
-    new HudSystem()
+    HudSystem.getInstance()
   };
 
   /**

--- a/dungeon/test/contrib/systems/HudSystemTest.java
+++ b/dungeon/test/contrib/systems/HudSystemTest.java
@@ -1,0 +1,218 @@
+package contrib.systems;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.badlogic.gdx.scenes.scene2d.Group;
+import com.badlogic.gdx.utils.Disposable;
+import contrib.components.UIComponent;
+import contrib.hud.UIUtils;
+import contrib.hud.dialogs.DialogContext;
+import contrib.hud.dialogs.DialogFactory;
+import contrib.hud.dialogs.DialogType;
+import core.Entity;
+import core.Game;
+import core.components.PlayerComponent;
+import core.game.PreRunConfiguration;
+import core.network.handler.NettyNetworkHandler;
+import core.network.server.DialogTracker;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import testingUtils.MockNetworkHandler;
+
+/** Tests for {@link HudSystem}. */
+public class HudSystemTest {
+
+  private HudSystem hudSystem;
+
+  @BeforeAll
+  static void registerDialogType() {
+    DialogFactory.register(TestDialogType.TEST, ignored -> new Group());
+    DialogFactory.register(TestDialogType.DISPOSABLE, ignored -> new TestDisposableGroup());
+    DialogFactory.register(
+        TestDialogType.REJECTED,
+        ignored -> {
+          throw new AssertionError("A dialog without a present target must not be created");
+        });
+  }
+
+  @BeforeEach
+  void setUp() {
+    Game.removeAllEntities();
+    Game.removeAllSystems();
+    MockNetworkHandler.useLocalNetworkHandler();
+    PreRunConfiguration.multiplayerEnabled(false);
+    PreRunConfiguration.isNetworkServer(true);
+    hudSystem = Game.hud();
+    Game.add(hudSystem);
+  }
+
+  @AfterEach
+  void tearDown() {
+    Game.removeAllEntities();
+    Game.removeAllSystems();
+    DialogTracker.instance().clear();
+    PreRunConfiguration.multiplayerEnabled(false);
+    PreRunConfiguration.isNetworkServer(true);
+  }
+
+  /** Replacing a player's UI keeps the HUD query synchronized with the current component. */
+  @Test
+  public void replacingUiComponentRunsFullLifecycle() {
+    Entity player = player();
+    UIComponent first = ui(player, player.id());
+    player.add(first);
+
+    assertTrue(hudSystem.hasOpenUI(player));
+    assertSame(first, hudSystem.topmostCloseableUI().orElseThrow().b());
+
+    UIComponent second = ui(player, false, player.id());
+    player.add(second);
+
+    assertTrue(hudSystem.hasOpenUI(player));
+    assertFalse(hudSystem.hasOpenPausingUI(player));
+    assertSame(second, player.fetch(UIComponent.class).orElseThrow());
+    assertSame(second, hudSystem.topmostCloseableUI().orElseThrow().b());
+
+    UIUtils.closeDialog(first);
+    assertSame(second, player.fetch(UIComponent.class).orElseThrow());
+    assertTrue(hudSystem.hasOpenUI(player));
+
+    UIUtils.closeDialog(second);
+    assertFalse(hudSystem.hasOpenUI(player));
+  }
+
+  /** Temporarily detaching the HUD keeps a dialog reusable until its component is removed. */
+  @Test
+  public void readdingHudSystemDoesNotDisposeDialog() {
+    Entity player = player();
+    UIComponent component = ui(TestDialogType.DISPOSABLE, player, true, player.id());
+    player.add(component);
+    TestDisposableGroup dialog = (TestDisposableGroup) component.dialog();
+
+    Game.remove(HudSystem.class);
+
+    assertFalse(dialog.disposed);
+    assertEquals(-1, DialogTracker.instance().getEntityId(component.dialogContext().dialogId()));
+
+    Game.add(hudSystem);
+
+    assertFalse(dialog.disposed);
+    assertTrue(hudSystem.hasOpenUI(player));
+    assertEquals(
+        player.id(), DialogTracker.instance().getEntityId(component.dialogContext().dialogId()));
+
+    UIUtils.closeDialog(component);
+    assertTrue(dialog.disposed);
+  }
+
+  /** Removing a UI-owning entity performs terminal dialog cleanup. */
+  @Test
+  public void removingUiOwnerDisposesDialog() {
+    Entity player = player();
+    UIComponent component = ui(TestDialogType.DISPOSABLE, player, true, player.id());
+    player.add(component);
+    TestDisposableGroup dialog = (TestDisposableGroup) component.dialog();
+
+    Game.remove(player);
+
+    assertTrue(dialog.disposed);
+    assertFalse(hudSystem.hasOpenUI(player));
+    assertEquals(-1, DialogTracker.instance().getEntityId(component.dialogContext().dialogId()));
+  }
+
+  /** Empty targets affect every player while explicit targets only affect matching players. */
+  @Test
+  public void uiTargetsDetermineWhoIsAffected() {
+    Entity player = player();
+    Entity otherPlayer = player();
+    NettyNetworkHandler networkHandler = Mockito.mock(NettyNetworkHandler.class);
+    Mockito.when(networkHandler.isServer()).thenReturn(true);
+    Mockito.when(networkHandler.serverRuntime()).thenReturn(Optional.empty());
+    MockNetworkHandler.useNetworkHandler(networkHandler);
+
+    UIComponent global = show(player);
+    assertTrue(hudSystem.hasOpenUI(player));
+    assertTrue(hudSystem.hasOpenUI(otherPlayer));
+
+    UIUtils.closeDialog(global);
+    assertFalse(hudSystem.hasOpenUI(player));
+
+    UIComponent targeted = show(player, player.id());
+    assertTrue(hudSystem.hasOpenUI(player));
+    assertFalse(hudSystem.hasOpenUI(otherPlayer));
+
+    UIUtils.closeDialog(targeted);
+    assertFalse(hudSystem.hasOpenUI(player));
+  }
+
+  /** A targeted UI is not created when none of its target players are present. */
+  @Test
+  public void uiWithoutPresentTargetIsNotCreated() {
+    Entity player = player();
+    UIComponent component = ui(TestDialogType.REJECTED, player, true, Integer.MAX_VALUE);
+
+    player.add(component);
+
+    assertFalse(hudSystem.hasOpenUI(player));
+    player.remove(UIComponent.class);
+  }
+
+  private static Entity player() {
+    Entity player = new Entity("player");
+    player.add(new PlayerComponent());
+    Game.add(player);
+    return player;
+  }
+
+  private static UIComponent show(Entity owner, int... targetEntityIds) {
+    UIComponent component = ui(owner, targetEntityIds);
+    owner.add(component);
+    return component;
+  }
+
+  private static UIComponent ui(Entity owner, int... targetEntityIds) {
+    return ui(owner, true, targetEntityIds);
+  }
+
+  private static UIComponent ui(Entity owner, boolean willPauseGame, int... targetEntityIds) {
+    return ui(TestDialogType.TEST, owner, willPauseGame, targetEntityIds);
+  }
+
+  private static UIComponent ui(
+      DialogType dialogType, Entity owner, boolean willPauseGame, int... targetEntityIds) {
+    DialogContext context =
+        new DialogContext(
+            dialogType,
+            true,
+            Map.of(contrib.hud.dialogs.DialogContextKeys.OWNER_ENTITY, owner.id()));
+    return new UIComponent(context, willPauseGame, true, targetEntityIds);
+  }
+
+  private enum TestDialogType implements DialogType {
+    TEST,
+    DISPOSABLE,
+    REJECTED;
+
+    @Override
+    public String type() {
+      return "HUD_SYSTEM_TEST";
+    }
+  }
+
+  private static final class TestDisposableGroup extends Group implements Disposable {
+    private boolean disposed;
+
+    @Override
+    public void dispose() {
+      disposed = true;
+    }
+  }
+}

--- a/dungeon/test/core/EntityTest.java
+++ b/dungeon/test/core/EntityTest.java
@@ -3,6 +3,7 @@ package core;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,27 @@ public class EntityTest {
     Component newComponent = Mockito.mock(Component.class);
     entity.add(newComponent);
     assertEquals(newComponent, entity.fetch(testComponent.getClass()).get());
+  }
+
+  /** Replacing a component must run system removal and addition lifecycle callbacks. */
+  @Test
+  public void replaceComponentNotifiesSystems() {
+    Entity trackedEntity = new Entity();
+    trackedEntity.add(new TestComponent());
+    Game.add(trackedEntity);
+    TrackingSystem system = new TrackingSystem();
+    Game.add(system);
+
+    TestComponent replacement = new TestComponent();
+    trackedEntity.add(replacement);
+
+    assertEquals(2, system.addCount.get());
+    assertEquals(1, system.removeCount.get());
+
+    trackedEntity.add(replacement);
+
+    assertEquals(2, system.addCount.get());
+    assertEquals(1, system.removeCount.get());
   }
 
   /** WTF? . */
@@ -72,5 +94,22 @@ public class EntityTest {
   @AfterEach
   public void tearDown() {
     Game.removeAllEntities();
+    Game.removeAllSystems();
+  }
+
+  private static final class TestComponent implements Component {}
+
+  private static final class TrackingSystem extends System {
+    private final AtomicInteger addCount = new AtomicInteger();
+    private final AtomicInteger removeCount = new AtomicInteger();
+
+    private TrackingSystem() {
+      super(TestComponent.class);
+      onEntityAdd = ignored -> addCount.incrementAndGet();
+      onEntityRemove = ignored -> removeCount.incrementAndGet();
+    }
+
+    @Override
+    public void execute() {}
   }
 }

--- a/escapeRoom/src/starter/MushRoom.java
+++ b/escapeRoom/src/starter/MushRoom.java
@@ -9,7 +9,6 @@ import contrib.entities.EntityFactory;
 import contrib.modules.levelHide.LevelHideSystem;
 import contrib.systems.CollisionSystem;
 import contrib.systems.HealthSystem;
-import contrib.systems.HudSystem;
 import contrib.systems.IdleSoundSystem;
 import contrib.systems.LevelEditorSystem;
 import contrib.systems.LevelTickSystem;
@@ -118,7 +117,6 @@ public class MushRoom {
     Game.add(new CollisionSystem());
     Game.add(new ProjectileSystem());
     Game.add(new HealthSystem());
-    Game.add(new HudSystem());
     Game.add(new LevelTickSystem());
     Game.add(new LeverSystem());
     Game.add(new PressurePlateSystem());


### PR DESCRIPTION
closes #3101

Der Dialog-Zustand wurde bisher zusätzlich im `PlayerComponent` gezählt. Dieser Counter konnte vom tatsächlichen Zustand im `HudSystem` abweichen und dadurch Player-Input blockieren. Bei der Untersuchung ist außerdem aufgefallen, dass `GUICombination` einen transparenten Batch-State übernehmen konnte. Das Inventar war dann geöffnet und hat Input blockiert, wurde aber nicht gezeichnet.

* Fehlerbehebung:
  * Beim Ersetzen einer Component wird die alte Component zuerst aus den betroffenen ECS-Systemen entfernt.
  * Veraltete Close-Aufrufe können eine inzwischen ersetzte UI nicht mehr schließen.
  * Dialoge werden beim Entfernen der `UIComponent` über den `HudSystem` aufgeräumt.
  * `GUICombination` setzt vor dem Zeichnen die eigene Farbe und `parentAlpha`, damit kein transparenter Batch-State von anderen Actors übernommen wird.

* HudSystem / API:
  * Dialog-Counter und die zugehörigen Methoden aus dem `PlayerComponent` entfernt.
  * Offene Dialoge werden direkt aus den registrierten `UIComponent`s bestimmt.
  * `HudSystem` als Singleton in den Essential Systems registriert.
  * `Game.hud()` als direkter Zugriff auf das `HudSystem` ergänzt.
  * `hasOpenUI(Entity)` ergänzt und die Target-/Visibility-Prüfung mit `hasOpenPausingUI(Entity)` zusammengeführt.
  * Bestehende Aufrufer auf die neue API umgestellt.
  * Internes Dialog-Tracking auf die benötigten `UIComponent`s reduziert.
