### PR TITLE
Dungeon: Fix tile lookup for entity center

### DIFF
--- a/dungeon/src/core/Game.java
+++ b/dungeon/src/core/Game.java
@@ -5,7 +5,6 @@ import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.ai.pfa.GraphPath;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import contrib.systems.HudSystem;
-import contrib.utils.EntityUtils;
 import core.components.PlayerComponent;
 import core.components.PositionComponent;
 import core.game.ECSManagement;
@@ -695,11 +694,7 @@ public final class Game {
             target ->
                 ECSManagement.entities()
                     .filter(e -> e.isPresent(PositionComponent.class))
-                    .filter(
-                        e ->
-                            Game.tileAt(EntityUtils.getPosition(e))
-                                .map(target::equals)
-                                .orElse(false)))
+                    .filter(e -> Game.tileAtEntity(e).map(target::equals).orElse(false)))
         .orElseGet(Stream::empty);
   }
 

--- a/dungeon/src/core/level/elements/ILevel.java
+++ b/dungeon/src/core/level/elements/ILevel.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.ai.pfa.indexed.IndexedAStarPathFinder;
 import com.badlogic.gdx.ai.pfa.indexed.IndexedGraph;
 import com.badlogic.gdx.utils.Array;
 import contrib.entities.deco.Deco;
+import contrib.utils.EntityUtils;
 import core.Entity;
 import core.components.PositionComponent;
 import core.level.DungeonLevel;
@@ -316,7 +317,8 @@ public interface ILevel extends IndexedGraph<Tile> {
    * Retrieves the tile on which the given entity is standing.
    *
    * <p>The method fetches the position component of the entity using {@link Entity#fetch(Class)}
-   * and looks up the tile at that position. If the entity has no {@link PositionComponent} or the
+   * and looks up the tile at the entity's center position as determined by {@link
+   * EntityUtils#getPosition(Entity)}. If the entity has no {@link PositionComponent} or the center
    * position is out of bounds / has no tile, an empty {@link Optional} is returned.
    *
    * @param entity The entity for which to retrieve the tile.
@@ -324,10 +326,10 @@ public interface ILevel extends IndexedGraph<Tile> {
    *     unavailable.
    */
   default Optional<Tile> tileAtEntity(final Entity entity) {
-    return entity
-        .fetch(PositionComponent.class)
-        .map(PositionComponent::position)
-        .flatMap(this::tileAt);
+    if (!entity.isPresent(PositionComponent.class)) {
+      return Optional.empty();
+    }
+    return tileAt(EntityUtils.getPosition(entity));
   }
 
   /**

--- a/dungeon/src/core/systems/LevelSystem.java
+++ b/dungeon/src/core/systems/LevelSystem.java
@@ -1,6 +1,5 @@
 package core.systems;
 
-import contrib.utils.EntityUtils;
 import core.Entity;
 import core.Game;
 import core.System;
@@ -95,7 +94,7 @@ public final class LevelSystem extends System {
    * @return True if the entity is on the end tile, else false.
    */
   private boolean isOnOpenEndTile(final Entity entity) {
-    Tile currentTile = Game.tileAt(EntityUtils.getPosition(entity)).orElse(null);
+    Tile currentTile = Game.tileAtEntity(entity).orElse(null);
     if (currentTile == null) {
       return false;
     }

--- a/dungeon/test/core/systems/LevelSystemTest.java
+++ b/dungeon/test/core/systems/LevelSystemTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.badlogic.gdx.graphics.Texture;
+import contrib.components.CollideComponent;
+import contrib.systems.PositionSync;
 import core.Entity;
 import core.Game;
 import core.components.PlayerComponent;
@@ -118,18 +120,24 @@ public class LevelSystemTest {
     api.loadLevel(level);
     api.onEndTile(() -> api.loadLevel(level));
     Entity hero = new Entity();
-    hero.add(new PositionComponent());
+    hero.add(new PositionComponent(new Point(2.6f, 3)));
+    hero.add(new CollideComponent());
     hero.add(new PlayerComponent());
+    PositionSync.syncPosition(hero);
     Game.add(hero);
 
     ExitTile end = Mockito.mock(ExitTile.class);
     Point p = new Point(3, 3);
     when(end.position()).thenReturn(p);
     when(end.isOpen()).thenReturn(true);
-    when(level.tileAt((Point) any())).thenReturn(Optional.of(end));
+    when(level.tileAtEntity(hero)).thenCallRealMethod();
+    when(level.tileAt((Point) any()))
+        .thenAnswer(
+            invocation ->
+                invocation.<Point>getArgument(0).toCoordinate().equals(p.toCoordinate())
+                    ? Optional.of(end)
+                    : Optional.empty());
     Mockito.when(level.endTile()).thenReturn(Optional.of(end));
-
-    hero.fetch(PositionComponent.class).get().position(end);
 
     Tile[][] layout = new Tile[0][0];
     when(level.layout()).thenReturn(layout);


### PR DESCRIPTION
Die Tile-Ermittlung für Entities verwendete bisher den Ursprung der `PositionComponent`. Bei Entities mit Hitbox oder Sprite konnte dadurch ein benachbartes Tile erkannt werden, obwohl sich der Mittelpunkt bereits auf dem Ziel-Tile befand.

* Tile-Ermittlung:
  * `ILevel.tileAtEntity(...)` verwendet zentral den Hitbox- beziehungsweise Sprite-Mittelpunkt aus `EntityUtils.getPosition(...)`.
  * `LevelSystem` und `Game.entityAtTile(...)` verwenden wieder die zentrale `tileAtEntity(...)`-API statt eigener Mittelpunktberechnungen.
  * Entities ohne `PositionComponent` liefern weiterhin kein Tile.

* Tests:
  * Der bestehende `LevelSystemTest` bildet den Randfall ab, bei dem Ursprung und Hitbox-Mittelpunkt auf unterschiedlichen Tiles liegen.
