### PR TITLE
Dungeon: Fix multiplayer bootstrap race during level load

### DIFF
--- a/dungeon/src/core/game/GameLoop.java
+++ b/dungeon/src/core/game/GameLoop.java
@@ -432,6 +432,9 @@ public final class GameLoop extends ScreenAdapter {
       } else {
         LOGGER.warn("No levels found to load!");
       }
+      if (PreRunConfiguration.isNetworkServer()) {
+        Game.network().completeServerBootstrap();
+      }
     }
   }
 

--- a/dungeon/src/core/network/handler/INetworkHandler.java
+++ b/dungeon/src/core/network/handler/INetworkHandler.java
@@ -112,6 +112,14 @@ public interface INetworkHandler {
    */
   default void markInitialWorldReady() {}
 
+  /**
+   * Signals that the authoritative server finished constructing its initial world.
+   *
+   * <p>Server implementations may use this boundary to delay game ticks and connection bootstrap
+   * until the initial level is fully loaded. Client and local implementations may ignore it.
+   */
+  default void completeServerBootstrap() {}
+
   /** Starts the handler's processing loop. */
   void start();
 

--- a/dungeon/src/core/network/handler/NettyNetworkHandler.java
+++ b/dungeon/src/core/network/handler/NettyNetworkHandler.java
@@ -176,6 +176,11 @@ public class NettyNetworkHandler implements INetworkHandler {
   }
 
   @Override
+  public void completeServerBootstrap() {
+    if (serverMode && server != null) server.completeBootstrap();
+  }
+
+  @Override
   public void addConnectionListener(ConnectionListener listener) {
     if (!serverMode) client.addConnectionListener(listener);
   }

--- a/dungeon/src/core/network/server/AuthoritativeServerLoop.java
+++ b/dungeon/src/core/network/server/AuthoritativeServerLoop.java
@@ -62,6 +62,8 @@ public final class AuthoritativeServerLoop {
   private final ScheduledExecutorService executor;
   private final SnapshotHistory snapshotHistory = new SnapshotHistory(SERVER_DELTA_HISTORY_SIZE);
   private volatile int serverTick = 0;
+  private volatile boolean bootstrapComplete;
+  private boolean worldInitialized;
   private String snapshotLevelName;
   private Object snapshotLevelIdentity;
 
@@ -139,11 +141,26 @@ public final class AuthoritativeServerLoop {
     return !executor.isShutdown();
   }
 
+  /** Allows the server loop to initialize and start ticking the fully constructed initial world. */
+  public void completeBootstrap() {
+    bootstrapComplete = true;
+  }
+
   private void tick() {
+    if (!bootstrapComplete) {
+      return;
+    }
+
     try {
       long tickStartNanos = System.nanoTime();
       //noinspection NonAtomicOperationOnVolatileField only place where serverTick is modified
       serverTick++;
+      if (!worldInitialized) {
+        executeGameTick();
+        worldInitialized = true;
+        NetworkTelemetry.recordFrameTime(System.nanoTime() - tickStartNanos);
+        return;
+      }
       // Drain any inbound network messages on the game thread before running systems
       long networkDispatchStartNanos = System.nanoTime();
       try {
@@ -154,8 +171,7 @@ public final class AuthoritativeServerLoop {
         NetworkTelemetry.recordNetworkDispatchBatch(System.nanoTime() - networkDispatchStartNanos);
       }
       syncClientsToEntities();
-      PreRunConfiguration.userOnFrame().execute();
-      ECSManagement.executeOneTick(core.System.AuthoritativeSide.SERVER);
+      executeGameTick();
       NetworkTelemetry.recordFrameTime(System.nanoTime() - tickStartNanos);
     } catch (Exception e) {
       LOGGER.error("Tick error", e);
@@ -163,6 +179,11 @@ public final class AuthoritativeServerLoop {
       LOGGER.fatal("Unexpected error in server loop", t);
       stop();
     }
+  }
+
+  private void executeGameTick() {
+    PreRunConfiguration.userOnFrame().execute();
+    ECSManagement.executeOneTick(core.System.AuthoritativeSide.SERVER);
   }
 
   private void sendSnapshot() {

--- a/dungeon/src/core/network/server/ServerRuntime.java
+++ b/dungeon/src/core/network/server/ServerRuntime.java
@@ -80,6 +80,14 @@ public final class ServerRuntime {
     if (transport != null) transport.stop();
   }
 
+  /** Signals that the initial authoritative world has been fully constructed. */
+  public void completeBootstrap() {
+    if (loop == null) {
+      throw new IllegalStateException("Server is not running. Call `start()` first.");
+    }
+    loop.completeBootstrap();
+  }
+
   /**
    * Broadcasts a message to all connected clients.
    *

--- a/dungeon/src/core/network/server/ServerTransport.java
+++ b/dungeon/src/core/network/server/ServerTransport.java
@@ -324,7 +324,7 @@ public final class ServerTransport {
   }
 
   /**
-   * Broadcasts a {@link NetworkMessage} to all connected clients.
+   * Broadcasts a {@link NetworkMessage} to all established clients.
    *
    * @param msg The message to broadcast.
    * @param reliable True to send via a reliable channel (TCP), false for unreliable (UDP).
@@ -333,7 +333,10 @@ public final class ServerTransport {
    *     with true. For any errors during sending, the Future completes with false.
    */
   public CompletableFuture<Boolean> broadcast(NetworkMessage msg, boolean reliable) {
-    List<Session> activeSessions = sessions.values().stream().filter(s -> !s.isClosed()).toList();
+    List<Session> activeSessions =
+        sessions.values().stream()
+            .filter(session -> !session.isClosed() && session.clientState().isPresent())
+            .toList();
     if (activeSessions.isEmpty()) {
       return CompletableFuture.completedFuture(true);
     }
@@ -745,8 +748,6 @@ public final class ServerTransport {
     }
 
     short newClientId = (short) nextClientId.getAndIncrement();
-    clientIdToName.put(newClientId, playerName);
-
     byte[] sessionToken = SessionTokenUtil.generate(NetworkConfig.SESSION_TOKEN_LENGTH_BYTES);
     ClientState clientState =
         new ClientState(
@@ -756,10 +757,12 @@ public final class ServerTransport {
             sessionToken,
             selectedCharacterClass(req));
     session.udpReady(false);
-    session.attachClientState(clientState);
-    clientIdToSession.put(newClientId, session);
 
     session.sendMessage(new ConnectAck(newClientId, ServerRuntime.SESSION_ID, sessionToken), true);
+
+    session.attachClientState(clientState);
+    clientIdToSession.put(newClientId, session);
+    clientIdToName.put(newClientId, playerName);
 
     sendInitialLevel(session.tcpCtx(), newClientId);
     sendInitialEntitySpawns(session, newClientId);
@@ -824,10 +827,11 @@ public final class ServerTransport {
     session.udpReady(false);
 
     // remove old mappings
-    clientIdToName.put(clientId, playerName);
     oldSession.udpAddress().ifPresent(udpToClientId::remove);
     oldSession.udpReady(false);
     sessions.remove(oldSession.tcpCtx().channel().id());
+    clientIdToSession.remove(clientId, oldSession);
+    clientIdToName.remove(clientId);
     try {
       oldSession.close(); // should be already closed, but just in case
     } catch (Exception ignored) {
@@ -835,11 +839,13 @@ public final class ServerTransport {
 
     // Reuse the previous ClientState so reconnects keep the original character class selection.
     oldClientState.resetForReconnect(ServerRuntime.SESSION_ID, newSessionToken, true);
-    session.attachClientState(oldClientState);
-    clientIdToSession.put(clientId, session);
 
     // 4. Send ConnectAck
     session.sendMessage(new ConnectAck(clientId, ServerRuntime.SESSION_ID, newSessionToken), true);
+
+    session.attachClientState(oldClientState);
+    clientIdToSession.put(clientId, session);
+    clientIdToName.put(clientId, playerName);
 
     sendInitialLevel(session.tcpCtx(), clientId);
     sendInitialEntitySpawns(session, clientId);


### PR DESCRIPTION
Beim Start eines Multiplayer-Servers konnte der Server-Loop bereits Ticks ausführen, während die `GameLoop` das initiale Level noch aufgebaut hat. Dadurch konnten `onFirstTick()` und `setupPapers()` mit einem unvollständigen Entity-Bestand laufen. Einzelne Deco-Entities wie Sheets wurden dann nicht verarbeitet oder blieben solid.

* Server-Bootstrap:
  * Autoritative Server-Ticks warten, bis das initiale Level vollständig aufgebaut wurde.
  * Der erste freigegebene Tick initialisiert die ECS-Systeme, bevor Verbindungsanfragen und normale Server-Ticks verarbeitet werden.
  * Der Levelaufbau und die anschließenden ECS-Änderungen bleiben auf dem autoritativen Ausführungspfad.

* Connection-Ordering:
  * Broadcasts werden nur an bereits etablierte Sessions gesendet.
  * `ConnectAck` wird eingereiht, bevor eine Session für weitere Servernachrichten sichtbar wird.
