### PR TITLE
Wizard: Replace asset ID with SHA-256

### DIFF
--- a/wizard/spec-generator/src/components/AssetsTab.tsx
+++ b/wizard/spec-generator/src/components/AssetsTab.tsx
@@ -27,33 +27,38 @@ export function AssetsTab({
   const [storageRevision, setStorageRevision] = React.useState(0);
   const previews = useAssetPreviews(assetList, storageRevision);
 
-  /** Writes the selected content to the given asset id and returns the resulting path/mediaType. */
-  const applySelection = async (id: string, selection: AssetSelection) => {
+  /** Writes the selected content and returns its id, path, and media type. */
+  const applySelection = async (asset: Asset | null, selection: AssetSelection) => {
+    const previousId = asset?.id ?? Util.generateUniqueId("a");
+
     if (selection.kind === "custom") {
-      await AssetStorage.putAssetFile(id, selection.file);
+      const id = await AssetStorage.putAssetFile(selection.file);
+      if (asset && !isBundledAssetPath(asset.path) && asset.id !== id) {
+        await AssetStorage.deleteAssetFile(asset.id);
+      }
       const extensionIndex = selection.file.name.lastIndexOf(".");
       const fileNameWithId =
         extensionIndex > 0
           ? `${selection.file.name.slice(0, extensionIndex)}-${id}${selection.file.name.slice(extensionIndex)}`
           : `${selection.file.name}-${id}`;
       return {
+        id,
         path: `${CUSTOM_PATH_PREFIX}/${fileNameWithId}`,
         mediaType: getMediaTypeForPath(selection.file.name),
       };
     }
 
     // Bundled assets have no IndexedDB entry, so a previously stored file is removed.
-    await AssetStorage.deleteAssetFile(id);
+    await AssetStorage.deleteAssetFile(previousId);
     return {
+      id: previousId,
       path: selection.path,
       mediaType: getMediaTypeForPath(selection.path),
       sourceType: "bundled_asset" as const,
     };
   };
-
   const handleAddAsset = async (selection: AssetSelection) => {
-    const id = Util.generateUniqueId("a");
-    const { path, mediaType } = await applySelection(id, selection);
+    const { id, path, mediaType } = await applySelection(null, selection);
 
     const newAsset: Asset = {
       id,
@@ -70,8 +75,12 @@ export function AssetsTab({
   };
 
   const handleReplaceContent = async (asset: Asset, selection: AssetSelection) => {
-    // The id stays the same so that all references to this asset keep working.
-    const { path, mediaType } = await applySelection(asset.id, selection);
+    const previousId = asset.id;
+    const { id, path, mediaType } = await applySelection(asset, selection);
+    if (previousId !== id) {
+      replaceAssetReferences(deerSchema, previousId, id);
+      asset.id = id;
+    }
     asset.path = path;
     asset.mediaType = mediaType;
     updateDeerSchema(deerSchema);
@@ -130,4 +139,16 @@ export function AssetsTab({
       )}
     </div>
   );
+}
+
+function replaceAssetReferences(deerSchema: DeerSchema, previousId: string, nextId: string) {
+  for (const riddle of deerSchema.riddles) {
+    for (const informationSource of riddle.informationSources) {
+      for (const resource of informationSource.resources) {
+        if (resource.kind === "asset" && resource.assetId === previousId) {
+          resource.assetId = nextId;
+        }
+      }
+    }
+  }
 }

--- a/wizard/spec-generator/src/data/AssetStorage.ts
+++ b/wizard/spec-generator/src/data/AssetStorage.ts
@@ -41,11 +41,16 @@ async function runTransaction<T>(
 }
 
 export class AssetStorage {
-  /** Stores (or overwrites) the binary content of an asset under the given asset id. */
-  static async putAssetFile(id: string, file: File): Promise<void> {
-    const blob = new Blob([await file.arrayBuffer()], { type: file.type });
+  /** Stores (or overwrites) the binary content of an asset under its content hash id. */
+  static async putAssetFile(file: File): Promise<string> {
+    const contents = await file.arrayBuffer();
+    const digest = await crypto.subtle.digest("SHA-256", contents);
+    const hash = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+    const id = hash.slice(0, 12);
+    const blob = new Blob([contents], { type: file.type });
     const entry: StoredAssetFile = { id, name: file.name, mediaType: file.type, blob };
     await runTransaction("readwrite", (store) => store.put(entry));
+    return id;
   }
 
   /** Returns the stored file for an asset id, or null if it is not available. */

--- a/wizard/spec-generator/src/data/ErrorChecker.ts
+++ b/wizard/spec-generator/src/data/ErrorChecker.ts
@@ -102,6 +102,10 @@ export class ErrorChecker {
     this.add(tabId, field, { description, details, severity: "warning" });
   }
 
+  private info(tabId: ValidatedTabId, field: string, description: string, details?: string) {
+    this.add(tabId, field, { description, details, severity: "info" });
+  }
+
   /** Reports an error when the given text is empty or only whitespace. */
   private requireText(
     tabId: ValidatedTabId,
@@ -366,7 +370,7 @@ export class ErrorChecker {
 
     // bundled assets bring their own license, only uploaded files need one from the user.
     if (!isBundledAssetPath(asset.path) && isBlank(asset.source?.license)) {
-      this.warning(
+      this.info(
         "assets",
         field,
         `Für die Datei "${name}" ist keine Lizenz angegeben.`,


### PR DESCRIPTION
+ Lizenz ist nicht mehr blockierende Warning, sondern nur noch Info.

@AMatutat 