### PR TITLE
The Last Hour: Register cutscene dialog on server

### DIFF
--- a/game/src/engine/game/GameLoop.java
+++ b/game/src/engine/game/GameLoop.java
@@ -798,7 +798,7 @@ public final class GameLoop extends ScreenAdapter {
                           .orElse(false))
               .findFirst()
               .flatMap(e -> e.fetch(UIComponent.class))
-              .ifPresent(UIUtils::closeDialog);
+              .ifPresent(component -> UIUtils.closeDialog(component, true));
         });
   }
 

--- a/game/src/escaperoom/foundation/ui/BlackFadeCutscene.java
+++ b/game/src/escaperoom/foundation/ui/BlackFadeCutscene.java
@@ -93,6 +93,28 @@ public final class BlackFadeCutscene extends Table {
       boolean fadeOut,
       Runnable onComplete,
       int... targetIds) {
+    return show(messages, fadeIn, fadeOut, false, onComplete, targetIds);
+  }
+
+  /**
+   * Shows the BlackFadeCutscene with explicit control over whether the user may close it.
+   *
+   * @param messages The list of text messages to display
+   * @param fadeIn Whether to fade in when showing
+   * @param fadeOut Whether to fade out when hiding
+   * @param canBeClosed Whether the user may close the cutscene with the configured close key
+   * @param onComplete Callback to run when all messages have been shown or the cutscene is closed
+   * @param targetIds The target entity ids this UI should be shown for
+   * @return The created UIComponent
+   * @throws NullPointerException if onComplete is null
+   */
+  public static UIComponent show(
+      List<Tuple<String, Integer>> messages,
+      boolean fadeIn,
+      boolean fadeOut,
+      boolean canBeClosed,
+      Runnable onComplete,
+      int... targetIds) {
     Objects.requireNonNull(onComplete, "onComplete callback cannot be null");
     String[] messageTexts = messages.stream().map(Tuple::a).toArray(String[]::new);
     int[] fontSizes = messages.stream().mapToInt(message -> message.b()).toArray();
@@ -106,7 +128,7 @@ public final class BlackFadeCutscene extends Table {
             .put(FADE_OUT_KEY, fadeOut)
             .build();
 
-    UIComponent ui = DialogFactory.show(ctx, true, false, targetIds);
+    UIComponent ui = DialogFactory.show(ctx, true, canBeClosed, targetIds);
 
     ui.registerCallback(
         DialogContextKeys.ON_RESUME,
@@ -114,6 +136,9 @@ public final class BlackFadeCutscene extends Table {
           UIUtils.closeDialog(ui, true);
           onComplete.run();
         });
+    if (canBeClosed) {
+      ui.registerCallback(DialogContextKeys.ON_CLOSE, data -> onComplete.run());
+    }
 
     return ui;
   }

--- a/game/src/feature/hud/dialogs/DialogContextKeys.java
+++ b/game/src/feature/hud/dialogs/DialogContextKeys.java
@@ -101,6 +101,9 @@ public class DialogContextKeys {
   /** The key for the dialog script (String) used by {@link DialogDialog}. */
   public static final String DIALOG = "dialog";
 
+  /** The image path substituted for {@code {path}} in a translated dialog script. */
+  public static final String SPEAKER_IMAGE = "speakerImage";
+
   /** The key for the puzzle complete callback */
   public static final String ON_COMPLETE = "onComplete";
 

--- a/game/src/feature/hud/dialogs/DialogDialog.java
+++ b/game/src/feature/hud/dialogs/DialogDialog.java
@@ -37,6 +37,8 @@ import java.util.List;
  */
 final class DialogDialog {
 
+  private static final String SPEAKER_IMAGE_PLACEHOLDER = "{path}";
+
   /** Distance in pixels from the top edge of the stage to the top of the dialog. */
   private static final float TOP_OFFSET = 100;
 
@@ -53,7 +55,13 @@ final class DialogDialog {
    * @return A fully configured DialogDialog or HeadlessDialogGroup.
    */
   static Group build(DialogContext ctx) {
-    String script = ctx.require(DialogContextKeys.DIALOG, String.class);
+    String sourceScript = ctx.require(DialogContextKeys.DIALOG, String.class);
+    String script =
+        ctx.find(DialogContextKeys.SPEAKER_IMAGE, String.class)
+            .map(
+                speakerImagePath ->
+                    sourceScript.replace(SPEAKER_IMAGE_PLACEHOLDER, speakerImagePath))
+            .orElse(sourceScript);
     if (script.isBlank()) {
       throw new DialogCreationException("DialogDialog requires a non-blank dialog script");
     }

--- a/game/src/feature/hud/dialogs/DialogFactory.java
+++ b/game/src/feature/hud/dialogs/DialogFactory.java
@@ -18,12 +18,12 @@ import feature.presentation.ShowImageUI;
 import feature.puzzle.PuzzleDialog;
 import feature.utils.AttributeBarUtil;
 import feature.utils.Translator;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -167,10 +167,8 @@ public class DialogFactory {
 
     DialogContext translatedContext = context;
     if (Game.isMultiplayerClient()) {
-      if (context.attributes().containsKey(DialogContextKeys.MESSAGE))
-        translatedContext = translateText(DialogContextKeys.MESSAGE, context);
-      if (context.attributes().containsKey(DialogContextKeys.DIALOG))
-        translatedContext = translateText(DialogContextKeys.DIALOG, context);
+      translatedContext = translateText(DialogContextKeys.MESSAGE, translatedContext);
+      translatedContext = translateText(DialogContextKeys.DIALOG, translatedContext);
     }
 
     UIComponent ui = new UIComponent(translatedContext, willPause, canBeClosed, targetEntityIds);
@@ -511,20 +509,23 @@ public class DialogFactory {
   }
 
   private static DialogContext translateText(String type, DialogContext context) {
-    DialogContext translatedContext = context;
-    try {
-      // Try-catch block to ensure Game doesnt crash when the text is not a String.
-      Optional<String> text = context.find(type, String.class);
-      if (text.isPresent() && Translator.hasKey(text.get())) {
-        Map<String, Object> attributes = context.attributes();
-        attributes.put(
-            type, Localization.getInstance().getCurrentTranslator().translate(text.get()));
-        return translatedContext =
-            new DialogContext(
-                context.dialogType(), context.center(), attributes, context.dialogId());
-      }
-    } catch (DialogCreationException e) {
+    Object value = context.attributes().get(type);
+    if (value instanceof String text && Translator.hasKey(text)) {
+      return new DialogContext.Builder(context)
+          .put(type, Localization.getInstance().getCurrentTranslator().translate(text))
+          .build();
     }
-    return translatedContext;
+    if (value instanceof String[] texts) {
+      String[] translatedTexts =
+          Arrays.stream(texts)
+              .map(
+                  text ->
+                      Translator.hasKey(text)
+                          ? Localization.getInstance().getCurrentTranslator().translate(text)
+                          : text)
+              .toArray(String[]::new);
+      return new DialogContext.Builder(context).put(type, translatedTexts).build();
+    }
+    return context;
   }
 }

--- a/game/src/feature/hud/dialogs/DialogFactory.java
+++ b/game/src/feature/hud/dialogs/DialogFactory.java
@@ -469,19 +469,52 @@ public class DialogFactory {
    */
   public static UIComponent showDialogDialog(
       String dialog, IVoidFunction onFinished, int... targetEntityIds) {
+    return showDialogDialog(dialogDialogContext(dialog).build(), onFinished, targetEntityIds);
+  }
+
+  /**
+   * Shows a sequenced speaker dialogue with a dynamic speaker image.
+   *
+   * <p>The image path replaces {@code {path}} in the dialog script after client-side translation.
+   * This keeps localized scripts client-specific while allowing the server to provide dynamic
+   * speaker portraits.
+   *
+   * @param dialog The non-empty dialog script.
+   * @param speakerImagePath The image path to substitute for {@code {path}} in the translated
+   *     script.
+   * @param onFinished Callback executed after the last page has been confirmed.
+   * @param targetEntityIds The target entity IDs for which the dialog is displayed.
+   * @return The {@link UIComponent} containing the dialog.
+   */
+  public static UIComponent showDialogDialog(
+      String dialog, String speakerImagePath, IVoidFunction onFinished, int... targetEntityIds) {
+    Objects.requireNonNull(speakerImagePath, "speaker image path cannot be null");
+    if (speakerImagePath.isBlank()) {
+      throw new IllegalArgumentException("speaker image path cannot be blank");
+    }
+
+    return showDialogDialog(
+        dialogDialogContext(dialog).put(DialogContextKeys.SPEAKER_IMAGE, speakerImagePath).build(),
+        onFinished,
+        targetEntityIds);
+  }
+
+  private static DialogContext.Builder dialogDialogContext(String dialog) {
     Objects.requireNonNull(dialog, "dialog string cannot be null");
     if (dialog.isBlank()) {
       throw new IllegalArgumentException("dialog string cannot be blank");
     }
+
+    return DialogContext.builder()
+        .type(DialogType.DefaultTypes.DIALOG_DIALOG)
+        .put(DialogContextKeys.DIALOG, dialog);
+  }
+
+  private static UIComponent showDialogDialog(
+      DialogContext context, IVoidFunction onFinished, int... targetEntityIds) {
     Objects.requireNonNull(onFinished, "onFinished callback cannot be null");
 
-    DialogContext ctx =
-        DialogContext.builder()
-            .type(DialogType.DefaultTypes.DIALOG_DIALOG)
-            .put(DialogContextKeys.DIALOG, dialog)
-            .build();
-
-    UIComponent ui = show(ctx, targetEntityIds);
+    UIComponent ui = show(context, targetEntityIds);
 
     ui.registerCallback(
         DialogContextKeys.ON_CONFIRM,

--- a/game/src/rooms/lasthour/level/LastHourLevel.java
+++ b/game/src/rooms/lasthour/level/LastHourLevel.java
@@ -746,10 +746,11 @@ public class LastHourLevel extends DungeonLevel {
                 new Interaction(
                     (e, who) -> {
                       if (isPhoneRinging) {
-                        String genTexturePath = portraitPathFor(who);
-                        String callDialog = ringingPhoneDialog.replace("{path}", genTexturePath);
                         DialogFactory.showDialogDialog(
-                            callDialog, this::stopPhoneRinging, who.id());
+                            ringingPhoneDialog,
+                            portraitPathFor(who),
+                            this::stopPhoneRinging,
+                            who.id());
                         return;
                       }
 

--- a/game/src/rooms/lasthour/level/LastHourLevel.java
+++ b/game/src/rooms/lasthour/level/LastHourLevel.java
@@ -195,6 +195,7 @@ public class LastHourLevel extends DungeonLevel {
         Lore.IntroTexts,
         false,
         true,
+        true,
         () ->
             DialogFactory.showDialogDialog(
                 "[speaker img=logo/cat_logo_64x64.png name=\"[color=#aaaaaa][size=25]...\"]"
@@ -226,7 +227,7 @@ public class LastHourLevel extends DungeonLevel {
                                     ? LastHourAchievements.ESCAPED_TOO_LATE
                                     : LastHourAchievements.ESCAPED_IN_TIME);
                             BlackFadeCutscene.show(
-                                endingLoreTexts(), true, false, () -> Game.exit("Win"));
+                                endingLoreTexts(), true, false, true, () -> Game.exit("Win"));
                           });
                 },
                 null)

--- a/game/src/rooms/lasthour/starter/TheLastHour.java
+++ b/game/src/rooms/lasthour/starter/TheLastHour.java
@@ -21,6 +21,7 @@ import engine.utils.NetworkUtils;
 import engine.utils.Tuple;
 import engine.utils.components.path.SimpleIPath;
 import engine.utils.logging.DungeonLoggerConfig;
+import escaperoom.foundation.ui.BlackFadeCutscene;
 import feature.components.Debugger;
 import feature.emote.EmoteSystem;
 import feature.entities.CharacterClass;
@@ -104,6 +105,7 @@ public class TheLastHour {
             .onConfigure(
                 () -> {
                   LastHourAchievements.register();
+                  BlackFadeCutscene.register();
                   UsbStickItem.ensureRegistration();
                   initLocalization();
                 })


### PR DESCRIPTION
Beim Verschieben von `BlackFadeCutscene` in den wiederverwendbaren Foundation-Slice wurde die bisherige automatische Registrierung durch `register()` ersetzt. The Last Hour rief diese Registrierung nur im Client-Setup auf. Zusätzlich verarbeitete die clientseitige Dialogübersetzung nur einzelne Strings, während Cutscenes ihre Seiten als String-Arrays übertragen.

Beim Telefon-Dialog wurde das dynamische Spielerportrait außerdem ersetzt, bevor aus dem Übersetzungsschlüssel das eigentliche Dialogskript entstand. Dadurch blieb `{path}` im übersetzten Skript und verursachte beim Rendern einen Absturz.

* The Last Hour:
  * `BlackFadeCutscene` wird im serverseitigen `onConfigure` registriert.
  * Intro- und End-Cutscenes zeigen wieder die übersetzten Texte und lassen sich per ESC schließen.
  * Nach der letzten Seite wird die Cutscene zuverlässig beendet, ohne erneut von vorne zu beginnen.
  * Der übersetzte Telefon-Dialog setzt das dynamische Spielerportrait clientseitig ein und rendert ohne ungültigen `{path}`.
* Dialog-Infrastruktur:
  * Die Übersetzung unterstützt einzelne Texte und Text-Arrays, ohne den ursprünglichen Dialog-Kontext zu verändern.
  * Dynamische Sprecherbilder werden über den Dialog-Kontext übertragen und nach der clientseitigen Übersetzung eingesetzt.
  * Serverseitige Close-Nachrichten schließen den Dialog clientseitig auch dann, wenn er nicht durch den Benutzer geschlossen werden darf.
  * Foundation-Cutscenes bleiben standardmäßig nicht per ESC schließbar.