### PR TITLE
Wizard: Add spec generator CI

### DIFF
--- a/.github/workflows/spec_generator_ci.yml
+++ b/.github/workflows/spec_generator_ci.yml
@@ -1,0 +1,31 @@
+name: Spec Generator CI
+
+on:
+  pull_request:
+    paths:
+      - 'wizard/spec-generator/**'
+      - '.github/workflows/spec_generator_ci.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: wizard/spec-generator
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: wizard/spec-generator/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Lint
+        run: npm run lint


### PR DESCRIPTION
Der Spec Generator wurde bei reinen Frontend-Änderungen bisher nur durch die Java-CI geprüft.

* Änderungen unter `wizard/spec-generator/**` starten jetzt eine eigene Spec-Generator-CI.
* Die CI installiert reproduzierbar mit `npm ci` und führt Build sowie Lint aus.
* Der Workflow reagiert auch auf Änderungen an seiner eigenen Definition.