### PR TITLE
Wizard: Add frontend CI

### DIFF
--- a/.github/workflows/wizard_frontend_ci.yml
+++ b/.github/workflows/wizard_frontend_ci.yml
@@ -1,0 +1,31 @@
+name: Wizard Frontend CI
+
+on:
+  pull_request:
+    paths:
+      - 'wizard/spec-generator/**'
+      - '.github/workflows/wizard_frontend_ci.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: wizard/spec-generator
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: wizard/spec-generator/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Lint
+        run: npm run lint


### PR DESCRIPTION
Änderungen unter `wizard/spec-generator/**` und an diesem Workflow starten die Wizard-Frontend-CI mit `npm ci`, Build und Lint.