### PR TITLE
Dungeon: Improve level editor camera and tools

### DIFF
--- a/game/src/engine/level/DungeonLevel.java
+++ b/game/src/engine/level/DungeonLevel.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -333,6 +334,27 @@ public class DungeonLevel implements ILevel, ITickable {
   @Override
   public List<Tile> startTiles() {
     return startTiles;
+  }
+
+  /**
+   * Changes the visual design of every tile and refreshes all resolved textures.
+   *
+   * @param designLabel the new level design
+   */
+  public void designLabel(DesignLabel designLabel) {
+    Objects.requireNonNull(designLabel);
+    for (Tile[] row : layout) {
+      for (Tile tile : row) {
+        tile.designLabel(designLabel);
+      }
+    }
+    LevelElement[][] elementLayout = TileTextureFactory.levelElementLayout(layout);
+    for (Tile[] row : layout) {
+      for (Tile tile : row) {
+        tile.texturePath(
+            TileTextureFactory.findTexturePath(tile, layout, elementLayout, tile.levelElement()));
+      }
+    }
   }
 
   @Override

--- a/game/src/engine/level/Tile.java
+++ b/game/src/engine/level/Tile.java
@@ -116,6 +116,15 @@ public abstract class Tile {
   }
 
   /**
+   * Changes the design used to resolve this tile's textures.
+   *
+   * @param designLabel the new design
+   */
+  public void designLabel(DesignLabel designLabel) {
+    this.designLabel = designLabel;
+  }
+
+  /**
    * Defines the element type of this tile.
    *
    * @return The LevelElement of this tile.

--- a/game/src/engine/level/elements/tile/PitTile.java
+++ b/game/src/engine/level/elements/tile/PitTile.java
@@ -14,7 +14,7 @@ import engine.utils.components.path.IPath;
  * closed. If it is open, the player can fall into it. If it is closed, the player can walk over it.
  */
 public class PitTile extends Tile {
-  private final IPath stillStableTexturePath;
+  private IPath stillStableTexturePath;
   private boolean open;
   private long timeToOpen;
 
@@ -101,6 +101,12 @@ public class PitTile extends Tile {
    */
   public long timeToOpen() {
     return this.timeToOpen;
+  }
+
+  @Override
+  public void designLabel(DesignLabel designLabel) {
+    super.designLabel(designLabel);
+    stillStableTexturePath = TileTextureFactory.findTexturePath(LevelElement.FLOOR, designLabel);
   }
 
   @Override

--- a/game/src/engine/level/utils/TileTextureFactory.java
+++ b/game/src/engine/level/utils/TileTextureFactory.java
@@ -122,25 +122,26 @@ public class TileTextureFactory {
    */
   private static IPath resolvePrimaryPath(LevelPart levelPart) {
     String prefixPath = "dungeon/" + levelPart.design().name().toLowerCase() + "/";
+    String sharedPortalPrefix = "dungeon/" + DesignLabel.DEFAULT.name().toLowerCase() + "/";
 
     if (levelPart.element == LevelElement.GITTER) {
       IPath path = findGitterElement(levelPart);
       if (path != null) {
-        return new SimpleIPath(prefixPath + path.pathString() + ".png");
+        return new SimpleIPath(sharedPortalPrefix + path.pathString() + ".png");
       }
     }
 
     if (levelPart.element == LevelElement.GLASSWALL) {
       IPath path = findGlasswallElement(levelPart);
       if (path != null) {
-        return new SimpleIPath(prefixPath + path.pathString() + ".png");
+        return new SimpleIPath(sharedPortalPrefix + path.pathString() + ".png");
       }
     }
 
     if (levelPart.element == LevelElement.PORTAL) {
       IPath path = findPortalElement(levelPart);
       if (path != null) {
-        return new SimpleIPath(prefixPath + path.pathString() + ".png");
+        return new SimpleIPath(sharedPortalPrefix + path.pathString() + ".png");
       }
     }
 
@@ -327,15 +328,39 @@ public class TileTextureFactory {
    * @return Path to texture
    */
   public static IPath findTexturePath(Tile element, Tile[][] layout, LevelElement elementType) {
+    return findTexturePath(element, layout, levelElementLayout(layout), elementType);
+  }
+
+  /**
+   * Converts a tile layout to the element layout used for neighborhood-based texture resolution.
+   *
+   * @param layout the tile layout
+   * @return the corresponding element layout
+   */
+  public static LevelElement[][] levelElementLayout(Tile[][] layout) {
     LevelElement[][] elementLayout = new LevelElement[layout.length][layout[0].length];
     for (int x = 0; x < layout[0].length; x++) {
       for (int y = 0; y < layout.length; y++) {
         elementLayout[y][x] = layout[y][x].levelElement();
       }
     }
+    return elementLayout;
+  }
+
+  /**
+   * Resolves a tile texture using a previously derived element layout.
+   *
+   * @param element tile to resolve
+   * @param layout the tile layout, used for pit state
+   * @param elementLayout the precomputed element layout
+   * @param elementType the element type to resolve at the tile's coordinate
+   * @return path to the texture
+   */
+  public static IPath findTexturePath(
+      Tile element, Tile[][] layout, LevelElement[][] elementLayout, LevelElement elementType) {
     elementLayout[element.coordinate().y()][element.coordinate().x()] = elementType;
 
-    IPath pitPath = findTexturePathPit(element, layout);
+    IPath pitPath = findTexturePathPit(element, layout, elementLayout);
     if (pitPath != null) {
       return pitPath;
     }
@@ -353,9 +378,11 @@ public class TileTextureFactory {
    *
    * @param element Tile to check for
    * @param layout The level
+   * @param elementLayout the precomputed element layout
    * @return a texture path for open pits, or {@code null} if no pit-specific rule applies
    */
-  private static IPath findTexturePathPit(Tile element, Tile[][] layout) {
+  private static IPath findTexturePathPit(
+      Tile element, Tile[][] layout, LevelElement[][] elementLayout) {
     if (!(element instanceof PitTile pit) || !pit.isOpen()) {
       return null;
     }
@@ -377,14 +404,14 @@ public class TileTextureFactory {
       return new SimpleIPath(wallEmptyPath);
     }
 
-    IPath abovePath = findTexturePath(aboveTile, layout, aboveTile.levelElement());
-    String abovePathString = abovePath != null ? abovePath.pathString() : null;
-
-    if (abovePathString != null && abovePathString.endsWith("/wall/empty.png")) {
+    if (aboveTile instanceof PitTile abovePit && abovePit.isOpen()) {
       return new SimpleIPath(wallEmptyPath);
     }
 
-    if (aboveTile instanceof PitTile abovePit && abovePit.isOpen()) {
+    IPath abovePath = findTexturePath(aboveTile, layout, elementLayout, aboveTile.levelElement());
+    String abovePathString = abovePath != null ? abovePath.pathString() : null;
+
+    if (abovePathString != null && abovePathString.endsWith("/wall/empty.png")) {
       return new SimpleIPath(wallEmptyPath);
     }
 

--- a/game/src/engine/systems/input/InputManager.java
+++ b/game/src/engine/systems/input/InputManager.java
@@ -46,6 +46,7 @@ public final class InputManager {
   private static final Map<Integer, Long> previousButtonTapTimesMs = new HashMap<>();
   private static final Map<Integer, Long> keyDownTimesMs = new HashMap<>();
   private static final Map<Integer, Long> buttonDownTimesMs = new HashMap<>();
+  private static float scrollAmountY;
 
   private InputManager() {} // static utility class
 
@@ -125,6 +126,7 @@ public final class InputManager {
 
           @Override
           public boolean scrolled(float amountX, float amountY) {
+            scrollAmountY += amountY;
             return oldProcessor != null && oldProcessor.scrolled(amountX, amountY);
           }
         });
@@ -264,6 +266,15 @@ public final class InputManager {
   }
 
   /**
+   * Gets the vertical mouse-wheel movement accumulated during the current frame.
+   *
+   * @return vertical scroll amount
+   */
+  public static float scrollAmountY() {
+    return scrollAmountY;
+  }
+
+  /**
    * Clears all tracked input states.
    *
    * <p>Useful when changing input processors or when focus is lost. This also clears tap history
@@ -282,6 +293,7 @@ public final class InputManager {
     previousButtonTapTimesMs.clear();
     keyDownTimesMs.clear();
     buttonDownTimesMs.clear();
+    scrollAmountY = 0f;
   }
 
   /**
@@ -293,6 +305,7 @@ public final class InputManager {
     // Move justPressed keys/buttons to pressed state and clear justPressed
     updateFrame(justPressedKeys, pressedKeys, justReleasedKeys);
     updateFrame(justPressedButtons, pressedButtons, justReleasedButtons);
+    scrollAmountY = 0f;
   }
 
   private static void registerPress(

--- a/game/src/feature/leveleditor/DecoMode.java
+++ b/game/src/feature/leveleditor/DecoMode.java
@@ -134,7 +134,8 @@ public class DecoMode extends LevelEditorMode {
                 syncPlacedDecos();
                 levelChanged();
               });
-    } else if (InputManager.isKeyJustPressed(QUARTERNARY)) {
+    } else if (InputManager.isKeyJustPressed(QUARTERNARY)
+        || InputManager.isButtonJustPressed(Input.Buttons.MIDDLE)) {
       rapidFireActive = false;
       // Pipette tool to pick deco type on cursor
       Optional<DecoEntityData> clickedDeco = getDecoOnPosition(cursorPos);
@@ -208,7 +209,13 @@ public class DecoMode extends LevelEditorMode {
   public void onExit() {
     flushRapidFireLevelChange();
     closeDecoSelector();
+    clearHoveredEntity();
     removePreviewEntity();
+  }
+
+  @Override
+  public void onCursorLeaveWorld() {
+    clearHoveredEntity();
   }
 
   @Override
@@ -240,6 +247,7 @@ public class DecoMode extends LevelEditorMode {
     controls.put(SECONDARY_UP, "Change Grid Snap");
     controls.put(TERTIARY, "Delete on Cursor");
     controls.put(QUARTERNARY, "Pick from Cursor");
+    controls.put(Input.Buttons.MIDDLE, "Pick from Cursor");
     return controls;
   }
 
@@ -425,13 +433,18 @@ public class DecoMode extends LevelEditorMode {
 
     // Not hovering, clear hovered
     if ((!isHovering && wasHovering) || (isHovering && wasHovering && !sameEntity)) {
-      setEntityColor(decoHoveredEntity.entity, Color.WHITE);
-      decoHoveredEntity = null;
+      clearHoveredEntity();
     }
     if (isHovering && !wasHovering || (isHovering && !sameEntity)) {
       decoHoveredEntity = hoveredDeco.get();
       setEntityColor(decoHoveredEntity.entity, Color.YELLOW);
     }
+  }
+
+  private void clearHoveredEntity() {
+    if (decoHoveredEntity == null) return;
+    setEntityColor(decoHoveredEntity.entity, Color.WHITE);
+    decoHoveredEntity = null;
   }
 
   private void setEntityColor(Entity entity, Color color) {

--- a/game/src/feature/leveleditor/LevelEditorMode.java
+++ b/game/src/feature/leveleditor/LevelEditorMode.java
@@ -20,8 +20,6 @@ import java.util.Objects;
 /** Abstract base class for different modes in the Level Editor. */
 public abstract class LevelEditorMode {
 
-  private static DungeonLevel level = null;
-
   /** Primary action button. Direction UP */
   public static final int PRIMARY_UP = Input.Keys.E;
 
@@ -68,12 +66,6 @@ public abstract class LevelEditorMode {
     return name;
   }
 
-  /** Decorator method to assign the level reference before executing the mode logic. */
-  public void doExecute() {
-    LevelSystem.level().ifPresent(level -> LevelEditorMode.level = (DungeonLevel) level);
-    execute();
-  }
-
   /** Executes the logic for this mode. Called every frame. */
   public abstract void execute();
 
@@ -87,6 +79,9 @@ public abstract class LevelEditorMode {
 
   /** Called when exiting this mode. */
   public abstract void onExit();
+
+  /** Called when editor UI prevents this mode from handling the world cursor. */
+  public void onCursorLeaveWorld() {}
 
   /**
    * Gets the header text shown at the top of the details panel of the level editor.
@@ -167,6 +162,8 @@ public abstract class LevelEditorMode {
       return "LMB";
     } else if (key == Input.Buttons.RIGHT) {
       return "RMB";
+    } else if (key == Input.Buttons.MIDDLE) {
+      return "MMB";
     } else if (key == Input.Keys.Y) {
       return "Z";
     } else if (key == Input.Keys.Z) {
@@ -176,13 +173,16 @@ public abstract class LevelEditorMode {
   }
 
   protected DungeonLevel getLevel() {
-    if (level == null) {
-      Game.currentLevel()
-          .filter(DungeonLevel.class::isInstance)
-          .map(DungeonLevel.class::cast)
-          .ifPresent(currentLevel -> level = currentLevel);
+    Object currentLevel =
+        Game.currentLevel()
+            .orElseThrow(() -> new IllegalStateException("No current level is loaded."));
+    if (currentLevel instanceof DungeonLevel dungeonLevel) {
+      return dungeonLevel;
     }
-    return level;
+    throw new IllegalStateException(
+        "Level editor requires a DungeonLevel, but the current level is "
+            + currentLevel.getClass().getName()
+            + ".");
   }
 
   protected LevelEditorSystem getSystem() {

--- a/game/src/feature/leveleditor/PointMode.java
+++ b/game/src/feature/leveleditor/PointMode.java
@@ -19,6 +19,7 @@ public class PointMode extends LevelEditorMode {
 
   private static SnapMode snapMode = SnapMode.OnGrid;
   private static String heldPointName = null;
+  private String hoveredPointName;
 
   /**
    * Constructs a new PointMode.
@@ -30,10 +31,19 @@ public class PointMode extends LevelEditorMode {
   }
 
   @Override
-  public void onEnter() {}
+  public void onEnter() {
+    hoveredPointName = null;
+  }
 
   @Override
-  public void onExit() {}
+  public void onExit() {
+    hoveredPointName = null;
+  }
+
+  @Override
+  public void onCursorLeaveWorld() {
+    hoveredPointName = null;
+  }
 
   @Override
   public void execute() {
@@ -45,7 +55,7 @@ public class PointMode extends LevelEditorMode {
     Point snapPos = snapMode.getPosition(cursorPos);
     if (InputManager.isButtonJustPressed(Input.Buttons.LEFT)) {
       if (heldPointName != null) {
-        // Place held deco
+        // Place held point
         getLevel().addNamedPoint(heldPointName, snapPos);
         heldPointName = null;
         levelChanged();
@@ -81,7 +91,7 @@ public class PointMode extends LevelEditorMode {
         levelChanged();
       }
     } else if (InputManager.isKeyPressed(TERTIARY)) {
-      // Delete deco on cursor
+      // Delete point on cursor
       getOnPosition(cursorPos)
           .ifPresent(
               point -> {
@@ -89,24 +99,40 @@ public class PointMode extends LevelEditorMode {
                 levelChanged();
               });
     }
+    hoveredPointName = getOnPosition(cursorPos).orElse(null);
   }
 
   @Override
   public void render() {
-    DebugDrawSystem.drawNamedPoints(heldPointName, true);
+    String highlightedPoint = hoveredPointName != null ? hoveredPointName : heldPointName;
+    DebugDrawSystem.drawNamedPoints(highlightedPoint, true);
   }
 
   @Override
   public String additionalInformation() {
-    String status =
-        "Snap Mode: "
-            + snapMode.name()
-            + "\nHeld Point: "
-            + Objects.requireNonNullElse(heldPointName, "<none>")
-            + "\nTotal Points: "
-            + getLevel().namedPoints().size();
+    StringBuilder status =
+        new StringBuilder("Snap Mode: ")
+            .append(snapMode.name())
+            .append("\nHeld Point: ")
+            .append(Objects.requireNonNullElse(heldPointName, "<none>"))
+            .append("\nTotal Points: ")
+            .append(getLevel().namedPoints().size());
 
-    return status;
+    if (hoveredPointName != null) {
+      Point position = getLevel().namedPoints().get(hoveredPointName);
+      if (position != null) {
+        status
+            .append("\nPoint under cursor: ")
+            .append(hoveredPointName)
+            .append("\nPosition: (")
+            .append(position.x())
+            .append(", ")
+            .append(position.y())
+            .append(")");
+      }
+    }
+
+    return status.toString();
   }
 
   @Override

--- a/game/src/feature/leveleditor/TilesMode.java
+++ b/game/src/feature/leveleditor/TilesMode.java
@@ -3,13 +3,17 @@ package feature.leveleditor;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import engine.level.DungeonLevel;
 import engine.level.utils.Coordinate;
+import engine.level.utils.DesignLabel;
 import engine.level.utils.LevelElement;
+import engine.level.utils.TileTextureFactory;
 import engine.systems.input.InputManager;
 import engine.utils.Point;
 import engine.utils.Vector2;
 import feature.leveleditor.ui.LevelElementGrid;
 import feature.leveleditor.ui.NumberSetting;
+import feature.leveleditor.ui.SelectSetting;
 import feature.systems.DebugDrawSystem;
 import feature.utils.CheckPatternPainter;
 import java.util.LinkedHashMap;
@@ -44,6 +48,8 @@ public class TilesMode extends LevelEditorMode {
 
   private LevelElementGrid grid = null;
   private NumberSetting brushSizeSetting = null;
+  private SelectSetting<DesignLabel> designSetting = null;
+  private DesignLabel previewDesign = null;
   private boolean mouseLevelChangePending = false;
 
   /**
@@ -54,6 +60,26 @@ public class TilesMode extends LevelEditorMode {
    */
   public static String texturePath(LevelElement element) {
     return TILE_TEXTURES.getOrDefault(element, FALLBACK_TEXTURE);
+  }
+
+  /**
+   * Gets the preview texture for an element in the selected level design.
+   *
+   * <p>Portal, glass-wall, and grate textures currently exist only in the shared default design.
+   *
+   * @param element the level element
+   * @param designLabel the selected level design
+   * @return the texture path used by the element button
+   */
+  public static String texturePath(LevelElement element, DesignLabel designLabel) {
+    String defaultPath = texturePath(element);
+    if (element == LevelElement.SKIP
+        || element == LevelElement.PORTAL
+        || element == LevelElement.GLASSWALL
+        || element == LevelElement.GITTER) {
+      return defaultPath;
+    }
+    return TileTextureFactory.findTexturePath(element, designLabel).pathString();
   }
 
   /**
@@ -73,24 +99,39 @@ public class TilesMode extends LevelEditorMode {
   @Override
   public void buildDetailsUI(Table content) {
     content.clearChildren();
+    previewDesign = designLabel();
     grid =
         new LevelElementGrid(
             GRID_COLUMNS,
-            TilesMode::texturePath,
+            element -> texturePath(element, designLabel()),
             () -> selectedTileIndexL,
             () -> selectedTileIndexR,
             ordinal -> selectedTileIndexL = ordinal,
             ordinal -> selectedTileIndexR = ordinal);
+    designSetting =
+        new SelectSetting<>(
+            "Level Design",
+            DesignLabel.values(),
+            this::designLabel,
+            this::designLabel,
+            DesignLabel::name);
     brushSizeSetting =
         new NumberSetting(
             "Brush Size", 1, MAX_BRUSH_SIZE, () -> brushSize, size -> brushSize = size);
 
+    content.add(designSetting).growX().padBottom(10f).row();
     content.add(grid).growX().row();
     content.add(brushSizeSetting).growX().padTop(10f).row();
   }
 
   @Override
   public void updateDetailsUI() {
+    if (designSetting != null) designSetting.refresh();
+    DesignLabel currentDesign = designLabel();
+    if (grid != null && currentDesign != previewDesign) {
+      grid.refreshTextures();
+      previewDesign = currentDesign;
+    }
     if (grid != null) grid.refresh();
     if (brushSizeSetting != null) brushSizeSetting.refresh();
   }
@@ -139,7 +180,8 @@ public class TilesMode extends LevelEditorMode {
       brushSize = Math.max(1, brushSize - 1);
     }
 
-    if (InputManager.isKeyJustPressed(QUARTERNARY)) {
+    if (InputManager.isKeyJustPressed(QUARTERNARY)
+        || InputManager.isButtonJustPressed(Input.Buttons.MIDDLE)) {
       // Pick tile under cursor to LMB
       Point cursorPos = getCursorPosition();
       getLevel()
@@ -266,6 +308,18 @@ public class TilesMode extends LevelEditorMode {
     controls.put(Input.Buttons.RIGHT, "Place Tile [R]");
     controls.put(TERTIARY, "Place SKIP Tile");
     controls.put(QUARTERNARY, "Pick tile from cursor");
+    controls.put(Input.Buttons.MIDDLE, "Pick tile from cursor");
     return controls;
+  }
+
+  private DesignLabel designLabel() {
+    return getLevel().designLabel().orElse(DesignLabel.DEFAULT);
+  }
+
+  private void designLabel(DesignLabel designLabel) {
+    DungeonLevel level = getLevel();
+    if (level.designLabel().filter(designLabel::equals).isPresent()) return;
+    level.designLabel(designLabel);
+    levelChanged();
   }
 }

--- a/game/src/feature/leveleditor/ui/LevelElementGrid.java
+++ b/game/src/feature/leveleditor/ui/LevelElementGrid.java
@@ -45,6 +45,7 @@ public class LevelElementGrid extends Table {
   private final Label[] markers = new Label[LevelElement.values().length];
   private final IntSupplier primary;
   private final IntSupplier secondary;
+  private final Function<LevelElement, String> texturePath;
 
   private int lastPrimary = Integer.MIN_VALUE;
   private int lastSecondary = Integer.MIN_VALUE;
@@ -68,6 +69,7 @@ public class LevelElementGrid extends Table {
       IntConsumer onSecondary) {
     this.primary = primary;
     this.secondary = secondary;
+    this.texturePath = texturePath;
     defaults().pad(3f).size(BUTTON_SIZE);
 
     Label.LabelStyle markerStyle =
@@ -127,6 +129,16 @@ public class LevelElementGrid extends Table {
     forceRefresh();
   }
 
+  /** Reloads the preview image of every button from the configured texture-path provider. */
+  public void refreshTextures() {
+    LevelElement[] elements = LevelElement.values();
+    for (int i = 0; i < elements.length; i++) {
+      ImageButton.ImageButtonStyle style = buttons[i].getStyle();
+      style.imageUp = texture(texturePath.apply(elements[i]));
+      buttons[i].setStyle(style);
+    }
+  }
+
   private void forceRefresh() {
     lastPrimary = primary.getAsInt();
     lastSecondary = secondary.getAsInt();
@@ -166,8 +178,12 @@ public class LevelElementGrid extends Table {
     style.up = base.up;
     style.down = base.down;
     style.over = base.over;
-    Texture texture = TextureMap.instance().textureAt(new SimpleIPath(texturePath));
-    style.imageUp = new TextureRegionDrawable(new TextureRegion(texture));
+    style.imageUp = texture(texturePath);
     return style;
+  }
+
+  private static TextureRegionDrawable texture(String texturePath) {
+    Texture texture = TextureMap.instance().textureAt(new SimpleIPath(texturePath));
+    return new TextureRegionDrawable(new TextureRegion(texture));
   }
 }

--- a/game/src/feature/leveleditor/ui/ModeDetailsPanel.java
+++ b/game/src/feature/leveleditor/ui/ModeDetailsPanel.java
@@ -11,6 +11,7 @@ import feature.hud.elements.RichLabel;
 import feature.leveleditor.LevelEditorMode;
 import feature.systems.LevelEditorSystem;
 import feature.systems.LevelEditorSystem.Mode;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -89,9 +90,13 @@ public class ModeDetailsPanel extends Table {
     if (modeControls == null || modeControls.isEmpty()) return;
 
     controlsContent.add(text("Controls:")).colspan(2).left().padBottom(4f).row();
+    Map<String, String> keysByAction = new LinkedHashMap<>();
     modeControls.forEach(
-        (key, action) -> {
-          controlsContent.add(text(keyTag(key))).left().padRight(10f).padBottom(2f);
+        (key, action) ->
+            keysByAction.merge(action, keyTag(key), (keys, nextKey) -> keys + " " + nextKey));
+    keysByAction.forEach(
+        (action, keys) -> {
+          controlsContent.add(text(keys)).left().padRight(10f).padBottom(2f);
           controlsContent.add(text(action)).left().growX().padBottom(2f).row();
         });
   }
@@ -175,7 +180,7 @@ public class ModeDetailsPanel extends Table {
    * @return the rich text markup rendering the input prompt graphic.
    */
   private static String keyTag(int key) {
-    if (key == Input.Buttons.LEFT || key == Input.Buttons.RIGHT) {
+    if (key == Input.Buttons.LEFT || key == Input.Buttons.RIGHT || key == Input.Buttons.MIDDLE) {
       return "[key code=" + key + " type=mouse]";
     }
     return "[key code=" + swapForLayout(key) + "]";

--- a/game/src/feature/systems/HudSystem.java
+++ b/game/src/feature/systems/HudSystem.java
@@ -17,6 +17,7 @@ import feature.components.UIComponent;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -34,6 +35,11 @@ public final class HudSystem extends System {
 
   /** Stores the component because it is no longer available on the entity during removal. */
   private final Map<Entity, UIComponent> entityUIComponentMap = new HashMap<>();
+
+  /** Visible dialogs that must be restored after temporary HUD suppression. */
+  private final Set<UIComponent> dialogsVisibleBeforeSuppression = new HashSet<>();
+
+  private boolean dialogsSuppressed = false;
 
   /**
    * Returns the singleton HUD system.
@@ -85,6 +91,35 @@ public final class HudSystem extends System {
         .anyMatch(component -> isVisibleFor(component, entity));
   }
 
+  /**
+   * Temporarily hides all managed dialogs without closing them.
+   *
+   * <p>Dialogs added during suppression are hidden as well. Restoring the dialogs only makes those
+   * visible that were visible before they were suppressed.
+   *
+   * @param suppressed true to hide managed dialogs, false to restore them
+   */
+  public void dialogsSuppressed(boolean suppressed) {
+    if (dialogsSuppressed == suppressed) return;
+
+    dialogsSuppressed = suppressed;
+    if (suppressed) {
+      entityUIComponentMap.values().forEach(this::suppressDialog);
+      return;
+    }
+
+    dialogsVisibleBeforeSuppression.stream()
+        .filter(entityUIComponentMap::containsValue)
+        .forEach(component -> component.dialog().setVisible(true));
+    dialogsVisibleBeforeSuppression.clear();
+  }
+
+  private void suppressDialog(UIComponent component) {
+    if (!component.isVisible()) return;
+    dialogsVisibleBeforeSuppression.add(component);
+    component.dialog().setVisible(false);
+  }
+
   private boolean isVisibleFor(UIComponent component, Entity entity) {
     int[] targets = component.targetEntityIds();
     return component.isVisible()
@@ -112,8 +147,11 @@ public final class HudSystem extends System {
     // Removing a system temporarily detaches its entities too. Only dispose the dialog when the
     // component or its entity was removed; otherwise the same component is re-added with the
     // system.
-    if (terminalRemoval && removedComponent.dialog() instanceof Disposable disposable) {
-      disposable.dispose();
+    if (terminalRemoval) {
+      dialogsVisibleBeforeSuppression.remove(removedComponent);
+      if (removedComponent.dialog() instanceof Disposable disposable) {
+        disposable.dispose();
+      }
     }
   }
 
@@ -150,6 +188,7 @@ public final class HudSystem extends System {
             () -> sendDialogToClients(entity, component, affectedIds));
 
     entityUIComponentMap.put(entity, component);
+    if (dialogsSuppressed) suppressDialog(component);
     // Multiplayer clients only render dialogs. The server keeps callback ownership and
     // response authorization in DialogTracker.
     if (!Game.isMultiplayerClient()) {

--- a/game/src/feature/systems/LevelEditorSystem.java
+++ b/game/src/feature/systems/LevelEditorSystem.java
@@ -201,6 +201,7 @@ public class LevelEditorSystem extends System {
               CameraSystem.camera().position.x, CameraSystem.camera().position.y));
       editorCamera.add(editorCameraComponent);
       LevelEditorSystem.active = true;
+      Game.hud().dialogsSuppressed(true);
       playerControlsDeactivatedBeforeEditor = null;
       player
           .fetch(InputComponent.class)
@@ -237,6 +238,7 @@ public class LevelEditorSystem extends System {
       }
       player.fetch(HealthComponent.class).ifPresent(hc -> hc.godMode(false));
       currentModeInstance.onExit();
+      Game.hud().dialogsSuppressed(false);
     }
     updateUI();
   }

--- a/game/src/feature/systems/LevelEditorSystem.java
+++ b/game/src/feature/systems/LevelEditorSystem.java
@@ -12,11 +12,14 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import engine.Entity;
 import engine.Game;
 import engine.System;
+import engine.components.CameraComponent;
 import engine.components.InputComponent;
+import engine.components.PositionComponent;
 import engine.level.DungeonLevel;
 import engine.level.Tile;
 import engine.level.loader.DungeonLoader;
 import engine.level.loader.DungeonSaver;
+import engine.systems.CameraSystem;
 import engine.systems.DrawSystem;
 import engine.systems.input.InputManager;
 import engine.utils.FontHelper;
@@ -35,7 +38,6 @@ import feature.leveleditor.StartTilesMode;
 import feature.leveleditor.TilesMode;
 import feature.leveleditor.ui.LevelEditorUI;
 import java.io.File;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -79,7 +81,14 @@ public class LevelEditorSystem extends System {
   private static float feedbackMessageTimer = 0.0f;
   private static final float FEEDBACK_MESSAGE_DURATION = 3.0f; // seconds
 
-  private static Map<Integer, InputComponent.InputData> playerClallbacks = null;
+  private static final float FREE_CAMERA_SPEED = 20f;
+  private static final float FREE_CAMERA_SHIFT_SPEED_MULTIPLIER = 2f;
+  private static final float FREE_CAMERA_ZOOM_STEP = 0.05f;
+  private static final float MIN_FREE_CAMERA_ZOOM = 0.1f;
+  private static Entity editorCameraEntity;
+  private static CameraComponent editorCameraComponent;
+  private static Float cameraZoomBeforeEditor;
+  private static Boolean playerControlsDeactivatedBeforeEditor;
 
   private static LevelEditorUI ui = null;
   private static boolean cursorCapturedByUI = false;
@@ -178,22 +187,27 @@ public class LevelEditorSystem extends System {
    * @param active The active status to set.
    */
   public static void active(boolean active) {
-    LevelEditorSystem.active = active;
+    if (LevelEditorSystem.active == active) return;
+
     Entity player = Game.player().orElseThrow();
     if (active) {
       loadSettingsForCurrentLevel();
+      cameraZoomBeforeEditor = CameraSystem.camera().zoom;
+      editorCameraComponent = player.fetch(CameraComponent.class).orElseThrow();
+      player.remove(CameraComponent.class);
+      Entity editorCamera = editorCameraEntity();
+      editorCamera.add(
+          new PositionComponent(
+              CameraSystem.camera().position.x, CameraSystem.camera().position.y));
+      editorCamera.add(editorCameraComponent);
+      LevelEditorSystem.active = true;
+      playerControlsDeactivatedBeforeEditor = null;
       player
           .fetch(InputComponent.class)
           .ifPresent(
               pc -> {
-                playerClallbacks = pc.callbacks();
-                pc.removeCallback(LevelEditorMode.PRIMARY_UP);
-                pc.removeCallback(LevelEditorMode.PRIMARY_DOWN);
-                pc.removeCallback(LevelEditorMode.SECONDARY_UP);
-                pc.removeCallback(LevelEditorMode.SECONDARY_DOWN);
-                pc.removeCallback(LevelEditorMode.TERTIARY);
-                pc.removeCallback(Input.Buttons.LEFT);
-                pc.removeCallback(Input.Buttons.RIGHT);
+                playerControlsDeactivatedBeforeEditor = pc.deactivateControls();
+                pc.deactivateControls(true);
               });
       player
           .fetch(HealthComponent.class)
@@ -205,24 +219,23 @@ public class LevelEditorSystem extends System {
         currentModeInstance.onEnter();
       }
     } else {
-      if (playerClallbacks != null) {
+      Entity editorCamera = editorCameraEntity();
+      editorCamera.remove(CameraComponent.class);
+      player.add(editorCameraComponent);
+      editorCamera.remove(PositionComponent.class);
+      editorCameraComponent = null;
+      LevelEditorSystem.active = false;
+      if (cameraZoomBeforeEditor != null) {
+        CameraSystem.camera().zoom = cameraZoomBeforeEditor;
+        cameraZoomBeforeEditor = null;
+      }
+      if (playerControlsDeactivatedBeforeEditor != null) {
         player
             .fetch(InputComponent.class)
-            .ifPresent(
-                pc -> {
-                  playerClallbacks.forEach(
-                      ((key, value) ->
-                          pc.registerCallback(
-                              key, value.callback(), value.repeat(), value.pauseable())));
-                });
-        playerClallbacks = null;
-        player
-            .fetch(HealthComponent.class)
-            .ifPresent(
-                hc -> {
-                  hc.godMode(false);
-                });
+            .ifPresent(pc -> pc.deactivateControls(playerControlsDeactivatedBeforeEditor));
+        playerControlsDeactivatedBeforeEditor = null;
       }
+      player.fetch(HealthComponent.class).ifPresent(hc -> hc.godMode(false));
       currentModeInstance.onExit();
     }
     updateUI();
@@ -388,21 +401,30 @@ public class LevelEditorSystem extends System {
     updateUI();
 
     if (!active) return;
+    Entity editorCamera = editorCameraEntity();
 
     clearTextFieldFocusOnOutsideClick();
 
     if (Game.player().map(Game.hud()::hasOpenUI).orElse(false)) {
+      currentModeInstance.onCursorLeaveWorld();
       return;
     }
 
     // Do not react to editor keys while the user types into a text field of the editor UI
     if (Game.stage().map(stage -> stage.getKeyboardFocus() instanceof TextField).orElse(false)) {
+      currentModeInstance.onCursorLeaveWorld();
       return;
     }
 
     if (InputManager.isKeyJustPressed(TOGGLE_DEBUG_SHADER)) {
       toggleDebugShader();
     }
+
+    boolean cursorCaptured = uiCapturesCursor();
+    if (cursorCaptured) {
+      currentModeInstance.onCursorLeaveWorld();
+    }
+    updateFreeCamera(editorCamera, !cursorCaptured);
 
     Mode previousMode = currentMode;
     if (InputManager.isKeyPressed(MODE_1)) {
@@ -418,10 +440,65 @@ public class LevelEditorSystem extends System {
     }
 
     if (!internalStopped || previousMode != currentMode) {
-      if (!uiCapturesCursor()) {
-        currentModeInstance.doExecute();
+      if (!cursorCaptured) {
+        currentModeInstance.execute();
       }
     }
+  }
+
+  private static void updateFreeCamera(Entity editorCamera, boolean allowZoom) {
+    PositionComponent positionComponent = editorCamera.fetch(PositionComponent.class).orElseThrow();
+
+    int horizontal =
+        (InputManager.isKeyPressed(Input.Keys.D) ? 1 : 0)
+            - (InputManager.isKeyPressed(Input.Keys.A) ? 1 : 0);
+    int vertical =
+        (InputManager.isKeyPressed(Input.Keys.W) ? 1 : 0)
+            - (InputManager.isKeyPressed(Input.Keys.S) ? 1 : 0);
+    engine.utils.Vector2 direction = engine.utils.Vector2.of(horizontal, vertical);
+    if (!direction.isZero()) {
+      float speedMultiplier =
+          InputManager.isKeyPressed(Input.Keys.SHIFT_LEFT)
+                  || InputManager.isKeyPressed(Input.Keys.SHIFT_RIGHT)
+              ? FREE_CAMERA_SHIFT_SPEED_MULTIPLIER
+              : 1f;
+      float distance =
+          FREE_CAMERA_SPEED
+              * speedMultiplier
+              * CameraSystem.camera().zoom
+              * Math.min(Gdx.graphics.getDeltaTime(), 0.1f);
+      positionComponent.position(
+          positionComponent.position().translate(direction.normalize().scale(distance)));
+    }
+
+    float scrollAmount = InputManager.scrollAmountY();
+    if (allowZoom && scrollAmount != 0f) {
+      CameraSystem.camera().zoom =
+          Math.max(
+              MIN_FREE_CAMERA_ZOOM,
+              CameraSystem.camera().zoom + scrollAmount * FREE_CAMERA_ZOOM_STEP);
+    }
+  }
+
+  private static Entity editorCameraEntity() {
+    if (editorCameraEntity == null
+        || Game.findEntityById(editorCameraEntity.id())
+            .filter(entity -> entity == editorCameraEntity)
+            .isEmpty()) {
+      if (editorCameraEntity != null) {
+        editorCameraEntity.remove(CameraComponent.class);
+        editorCameraEntity.remove(PositionComponent.class);
+      }
+      editorCameraEntity = Entity.createLocalEntity("Level Editor Camera");
+      Game.add(editorCameraEntity);
+      if (active) {
+        editorCameraEntity.add(
+            new PositionComponent(
+                CameraSystem.camera().position.x, CameraSystem.camera().position.y));
+        editorCameraEntity.add(editorCameraComponent);
+      }
+    }
+    return editorCameraEntity;
   }
 
   /**


### PR DESCRIPTION
Der Level-Editor entkoppelt die Kamera vom Spieler, blendet das Spiel-HUD während der Bearbeitung aus und ergänzt die Bearbeitung von Tiles, Dekorationen und benannten Punkten.

### Kamera und Eingabe

* Beim Aktivieren des Editors wechselt die vorhandene `CameraComponent` vom Spieler auf ein lokales Editor-Entity. Beim Verlassen wird sie wieder auf den Spieler übertragen.
* Die Freecam bewegt sich mit WASD, zoomt mit dem Mausrad und bewegt sich mit gehaltener Shift-Taste doppelt so schnell.
* Spielersteuerung und vorheriger Zoom werden nach dem Verlassen wiederhergestellt. Die Editor-Kamera wird nach einem Levelwechsel erneut im ECS registriert.
* Während der Editor aktiv ist, werden vorhandene und neu hinzukommende HUD-Dialoge ausgeblendet und können nicht bedient werden. Beim Verlassen erscheinen die zuvor sichtbaren Dialoge mit ihrem bisherigen Zustand wieder.

### Tiles und Leveldesign

* Im Tiles-Modus kann das Design des aktuellen Levels ausgewählt werden. Die Änderung aktualisiert die Texturen im Level und in der Tile-Auswahl.
* Die zentrale `TileTextureFactory` löst die Texturen für das gewählte Design auf. Portal-, Glaswand- und Gitter-Texturen verwenden die vorhandenen gemeinsamen Assets.
* Tiles können mit V oder der mittleren Maustaste vom Cursor übernommen werden. Gleiche Aktionen mit mehreren Tasten erscheinen gemeinsam in einer Zeile.

### Dekorationen und Punkte

* Im Deco-Modus übernimmt die mittlere Maustaste wie V die Dekoration unter dem Cursor.
* Hover-Markierungen werden beim Verlassen der Weltfläche und beim Wechsel des Modus entfernt.
* Im Point-Modus zeigt der Hover den Namen und die genaue Position eines benannten Punkts an und hebt ihn im Level hervor.
* Editor-Modi greifen immer auf das aktuell geladene Level zu, damit UI-Aktionen nach einem Levelwechsel kein altes Level verändern.