### PR TITLE
Tracking: Keep backend Docker images on Java 25

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
     schedule:
       interval: "weekly"
     labels: []
+    ignore:
+      - dependency-name: "eclipse-temurin"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: "docker-compose"
     directory: "/tracking"
     schedule:


### PR DESCRIPTION
Das Tracking-Backend bleibt bei Java 25. Dependabot behandelt das Temurin-Docker-Image unabhängig von der Gradle-Toolchain und hat deshalb in #3203 ein Major-Update auf Java 26 vorgeschlagen.

* Major-Updates für `eclipse-temurin` im Backend-Dockerfile werden ignoriert.
* Aktualisierungen innerhalb von Java 25 bleiben weiterhin aktiv.

Ersetzt #3203.