### PR TITLE
Game: Add energy fill shader

### DIFF
--- a/game/assets/shaders/energy_fill.frag
+++ b/game/assets/shaders/energy_fill.frag
@@ -29,7 +29,7 @@ void main() {
   }
 
   float y = uv.y;
-  y += sin(uv.x * 5.0 + u_time * TAU * 0.28) * 0.028;
+  y += sin(u_fillPercentage + uv.x * 5.0 + u_time * TAU * 0.28) * 0.028;
   float influence = 1.0 - smoothstep(u_fillPercentage-0.05, u_fillPercentage+0.05, y);
 
   // Only apply shader to non-black pixels to avoid darkening outlines and such

--- a/game/assets/shaders/energy_fill.frag
+++ b/game/assets/shaders/energy_fill.frag
@@ -1,0 +1,42 @@
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+// *****IMPORT: util.glsl*****
+
+// ----- From vertex shader -----
+varying vec2 uv;
+
+// ----- From LibGDX -----
+uniform sampler2D u_texture;
+
+// ----- Common uniforms set by DrawSystem -----
+uniform vec2 u_resolution;
+uniform float u_time;
+uniform vec2 u_mouse;
+uniform vec2 u_texelSize;
+uniform vec2 u_aspect;
+
+// ----- Custom uniforms -----
+uniform float u_fillPercentage;
+uniform vec4 u_color;
+
+// ----- Main -----
+void main() {
+  vec4 textureColor = unPma(texture2D(u_texture, uv));
+  if(textureColor.a < 0.1) {
+    discard;
+  }
+
+  float y = uv.y;
+  y += sin(uv.x * 5.0 + u_time * TAU * 0.28) * 0.028;
+  float influence = 1.0 - smoothstep(u_fillPercentage-0.05, u_fillPercentage+0.05, y);
+
+  // Only apply shader to non-black pixels to avoid darkening outlines and such
+  if (textureColor.r + textureColor.g + textureColor.b > 0.5) {
+    textureColor.rgb *= 1.0 + influence;
+    textureColor.rgb = mix(textureColor.rgb, u_color.rgb, 0.7 * influence);
+  }
+
+  gl_FragColor = pma(textureColor);
+}

--- a/game/src/engine/utils/components/draw/shader/EnergyFillShader.java
+++ b/game/src/engine/utils/components/draw/shader/EnergyFillShader.java
@@ -1,0 +1,95 @@
+package engine.utils.components.draw.shader;
+
+import com.badlogic.gdx.graphics.Color;
+import engine.utils.Rectangle;
+import java.util.List;
+
+/** A shader that overlays a color over the bottom percentage of an entity's texture. */
+public class EnergyFillShader extends AbstractShader {
+
+  private static final String VERT_PATH = "shaders/passthrough.vert";
+  private static final String FRAG_PATH = "shaders/energy_fill.frag";
+
+  private float fillPercentage;
+  private Color color;
+
+  /** Creates an EnergyFillShader with no fill and a bright red overlay. */
+  public EnergyFillShader() {
+    this(0.0f, Color.RED);
+  }
+
+  /**
+   * Creates an EnergyFillShader with the specified fill percentage and overlay color.
+   *
+   * @param fillPercentage the filled percentage, from {@code 0.0} to {@code 1.0}
+   * @param color the overlay color
+   */
+  public EnergyFillShader(float fillPercentage, Color color) {
+    super(VERT_PATH, FRAG_PATH);
+    this.fillPercentage = validateFillPercentage(fillPercentage);
+    this.color = color;
+  }
+
+  @Override
+  protected List<UniformBinding> getUniforms(int actualUpscale) {
+    return List.of(
+        new FloatUniform("u_fillPercentage", fillPercentage), new ColorUniform("u_color", color));
+  }
+
+  @Override
+  public int padding() {
+    return 0;
+  }
+
+  @Override
+  public Rectangle worldBounds() {
+    return null;
+  }
+
+  /**
+   * Gets the fill percentage.
+   *
+   * @return the fill percentage, from {@code 0.0} to {@code 1.0}
+   */
+  public float fillPercentage() {
+    return fillPercentage;
+  }
+
+  /**
+   * Sets the fill percentage.
+   *
+   * @param fillPercentage the filled percentage, from {@code 0.0} to {@code 1.0}
+   * @return this shader for chaining
+   */
+  public EnergyFillShader fillPercentage(float fillPercentage) {
+    this.fillPercentage = validateFillPercentage(fillPercentage);
+    return this;
+  }
+
+  /**
+   * Gets the overlay color.
+   *
+   * @return the overlay color
+   */
+  public Color color() {
+    return color;
+  }
+
+  /**
+   * Sets the overlay color.
+   *
+   * @param color the overlay color
+   * @return this shader for chaining
+   */
+  public EnergyFillShader color(Color color) {
+    this.color = color;
+    return this;
+  }
+
+  private static float validateFillPercentage(float fillPercentage) {
+    if (fillPercentage < 0.0f || fillPercentage > 1.0f) {
+      throw new IllegalArgumentException("Fill percentage must be between 0.0 and 1.0.");
+    }
+    return fillPercentage;
+  }
+}


### PR DESCRIPTION
Kleiner, einfacher shader um einen Füllstand auf der Textur eines Entities anzuzeigen.

[output.webm](https://github.com/user-attachments/assets/362b3419-eba9-4dff-b1fb-86c2fb9256e9)
