### PR TITLE
add suppressible flag to UIComponent

### DIFF
--- a/game/src/feature/components/UIComponent.java
+++ b/game/src/feature/components/UIComponent.java
@@ -22,6 +22,7 @@ public final class UIComponent implements Component {
 
   private final boolean willPauseGame;
   private final boolean canBeClosed;
+  private final boolean suppressible;
   private final int[] targetEntityIds;
   private final DialogContext dialogContext;
 
@@ -44,9 +45,29 @@ public final class UIComponent implements Component {
       boolean willPauseGame,
       boolean canBeClosed,
       int... targetEntityIds) {
+    this(dialogContext, willPauseGame, canBeClosed, true, targetEntityIds);
+  }
+
+  /**
+   * Create a new UIComponent.
+   *
+   * @param dialogContext the context that defines the dialog to be shown
+   * @param willPauseGame if the UI should pause the Game or not
+   * @param canBeClosed if the UI can be closed (e.g. with the close key)
+   * @param suppressible if the dialog should be hidden by temporary HUD suppression
+   * @param targetEntityIds the target entity ids this UI should be shown for (e.g. for inventory
+   *     UIs). Empty array for all entities.
+   */
+  public UIComponent(
+      DialogContext dialogContext,
+      boolean willPauseGame,
+      boolean canBeClosed,
+      boolean suppressible,
+      int... targetEntityIds) {
     this.dialogContext = dialogContext;
     this.willPauseGame = willPauseGame;
     this.canBeClosed = canBeClosed;
+    this.suppressible = suppressible;
     this.targetEntityIds = targetEntityIds;
   }
 
@@ -130,6 +151,15 @@ public final class UIComponent implements Component {
    */
   public boolean canBeClosed() {
     return canBeClosed;
+  }
+
+  /**
+   * Check if the dialog may be hidden while HUD dialogs are temporarily suppressed.
+   *
+   * @return true when temporary HUD suppression should hide the dialog
+   */
+  public boolean suppressible() {
+    return suppressible;
   }
 
   /**

--- a/game/src/feature/hud/dialogs/DialogFactory.java
+++ b/game/src/feature/hud/dialogs/DialogFactory.java
@@ -138,6 +138,25 @@ public class DialogFactory {
    */
   public static UIComponent show(
       DialogContext context, boolean willPause, boolean canBeClosed, int... targetEntityIds) {
+    return show(context, willPause, canBeClosed, true, targetEntityIds);
+  }
+
+  /**
+   * Creates and displays a dialog of the specified type.
+   *
+   * @param context The context containing all necessary data for dialog creation
+   * @param willPause whether the dialog will pause the game when displayed
+   * @param canBeClosed whether the dialog can be closed by the user
+   * @param suppressible whether temporary HUD suppression may hide the dialog
+   * @param targetEntityIds array of entity IDs to notify when the dialog is closed
+   * @return The UIComponent containing the dialog (use to register callbacks)
+   */
+  public static UIComponent show(
+      DialogContext context,
+      boolean willPause,
+      boolean canBeClosed,
+      boolean suppressible,
+      int... targetEntityIds) {
     Objects.requireNonNull(context, "context");
 
     // Determine the owner entity (who holds the UIComponent)
@@ -171,7 +190,8 @@ public class DialogFactory {
       translatedContext = translateText(DialogContextKeys.DIALOG, translatedContext);
     }
 
-    UIComponent ui = new UIComponent(translatedContext, willPause, canBeClosed, targetEntityIds);
+    UIComponent ui =
+        new UIComponent(translatedContext, willPause, canBeClosed, suppressible, targetEntityIds);
     ownerEntity.add(ui);
 
     return ui;
@@ -352,6 +372,45 @@ public class DialogFactory {
       Consumer<DialogResponseMessage.Payload> onConfirm,
       IVoidFunction onCancel,
       int... targetEntityIds) {
+    return showInputDialog(
+        text,
+        title,
+        inputPrefill,
+        inputPlaceholder,
+        confirmLabel,
+        cancelLabel,
+        true,
+        onConfirm,
+        onCancel,
+        targetEntityIds);
+  }
+
+  /**
+   * Shows a dialog for text input with control over temporary HUD suppression.
+   *
+   * @param text The message to display in the dialog body
+   * @param title The dialog window title
+   * @param inputPrefill The pre-filled text in the input field
+   * @param inputPlaceholder The placeholder text for the input field
+   * @param confirmLabel Label for the confirm button
+   * @param cancelLabel Label for the cancel button
+   * @param suppressible whether temporary HUD suppression may hide the dialog
+   * @param onConfirm Callback executed when the confirm button is pressed
+   * @param onCancel Callback executed when the cancel button is pressed
+   * @param targetEntityIds The target entity IDs for which the dialog is displayed
+   * @return The {@link UIComponent} containing the dialog
+   */
+  public static UIComponent showInputDialog(
+      String text,
+      String title,
+      String inputPrefill,
+      String inputPlaceholder,
+      String confirmLabel,
+      String cancelLabel,
+      boolean suppressible,
+      Consumer<DialogResponseMessage.Payload> onConfirm,
+      IVoidFunction onCancel,
+      int... targetEntityIds) {
     Objects.requireNonNull(onConfirm, "onConfirm callback cannot be null");
     Objects.requireNonNull(onCancel, "onCancel callback cannot be null");
     DialogContext.Builder builder =
@@ -365,7 +424,7 @@ public class DialogFactory {
             .put(DialogContextKeys.CONFIRM_LABEL, confirmLabel)
             .put(DialogContextKeys.CANCEL_LABEL, cancelLabel);
 
-    UIComponent ui = show(builder.build(), targetEntityIds);
+    UIComponent ui = show(builder.build(), true, true, suppressible, targetEntityIds);
 
     // Register callbacks
     ui.registerCallback(

--- a/game/src/feature/leveleditor/PointMode.java
+++ b/game/src/feature/leveleditor/PointMode.java
@@ -68,6 +68,7 @@ public class PointMode extends LevelEditorMode {
             "Name of point",
             "Add",
             "Cancel",
+            false,
             payload -> {
               if (payload instanceof DialogResponseMessage.StringValue(String value)
                   && !value.isBlank()) {

--- a/game/src/feature/systems/HudSystem.java
+++ b/game/src/feature/systems/HudSystem.java
@@ -115,6 +115,7 @@ public final class HudSystem extends System {
   }
 
   private void suppressDialog(UIComponent component) {
+    if (!component.suppressible()) return;
     if (!component.isVisible()) return;
     dialogsVisibleBeforeSuppression.add(component);
     component.dialog().setVisible(false);

--- a/game/test/feature/systems/HudSystemTest.java
+++ b/game/test/feature/systems/HudSystemTest.java
@@ -165,6 +165,32 @@ public class HudSystemTest {
     player.remove(UIComponent.class);
   }
 
+  /** Non-suppressible dialogs stay visible while normal HUD dialogs are temporarily hidden. */
+  @Test
+  public void nonSuppressibleDialogStaysVisibleDuringSuppression() {
+    Entity player = player();
+    UIComponent normal = show(player, player.id());
+
+    hudSystem.dialogsSuppressed(true);
+
+    assertFalse(normal.isVisible());
+    assertFalse(hudSystem.hasOpenUI(player));
+
+    Entity editorDialogOwner = new Entity("editor-dialog");
+    Game.add(editorDialogOwner);
+    UIComponent editorDialog =
+        ui(TestDialogType.TEST, editorDialogOwner, true, true, false, player.id());
+    editorDialogOwner.add(editorDialog);
+
+    assertTrue(editorDialog.isVisible());
+    assertTrue(hudSystem.hasOpenUI(player));
+
+    hudSystem.dialogsSuppressed(false);
+
+    assertTrue(normal.isVisible());
+    assertTrue(editorDialog.isVisible());
+  }
+
   private static Entity player() {
     Entity player = new Entity("player");
     player.add(new PlayerComponent());
@@ -188,12 +214,22 @@ public class HudSystemTest {
 
   private static UIComponent ui(
       DialogType dialogType, Entity owner, boolean willPauseGame, int... targetEntityIds) {
+    return ui(dialogType, owner, willPauseGame, true, true, targetEntityIds);
+  }
+
+  private static UIComponent ui(
+      DialogType dialogType,
+      Entity owner,
+      boolean willPauseGame,
+      boolean canBeClosed,
+      boolean suppressible,
+      int... targetEntityIds) {
     DialogContext context =
         new DialogContext(
             dialogType,
             true,
             Map.of(feature.hud.dialogs.DialogContextKeys.OWNER_ENTITY, owner.id()));
-    return new UIComponent(context, willPauseGame, true, targetEntityIds);
+    return new UIComponent(context, willPauseGame, canBeClosed, suppressible, targetEntityIds);
   }
 
   private enum TestDialogType implements DialogType {


### PR DESCRIPTION
fixed einen Bug bei dem das CustomPoint-Erstellungs UI nicht im Editor Modus nicht geöffnet werden konnte.


Im Editor Modus werden Dialoge die neu erstellt werden automatisch supressed (#3204), das betraf auch den Dialog zum erstellen eines neuen Custom Points.


`UIComponent` wurde um eine `suppressible` Flag ergänzt (default ist true). 
